### PR TITLE
[fix]ヘッダー下にでメインビューが隠れる現象の修正

### DIFF
--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -1,12 +1,12 @@
-<main class="min-h-screen bg-gradient-to-b from-sky-200 via-sky-100 to-white pt-24 md:pt-28 pb-32 text-center">
+<main class="min-h-screen bg-gradient-to-b from-sky-200 via-sky-100 to-white pb-32 text-center">
   <!-- メインビジュアル -->
-  <div class="relative w-full min-h-[60vh] md:min-h-[50vh] lg:min-h-[75vh] -mt-20 lg:-mt-24">
+  <div class="relative w-full min-h-[60vh] md:min-h-[50vh] lg:min-h-[75vh] -mt-16 lg:-mt-28">
     <%= image_tag(
       "fes.png",
       alt: "FES READY ステージ",
       class: "absolute inset-0 h-full w-full object-cover"
     ) %>
-    <h1 class="absolute left-1/2 top-[30%] -translate-x-1/2 -translate-y-1/2 text-4xl md:text-6xl font-black tracking-tight text-black drop-shadow-[0_4px_12px_rgba(255,255,255,0.8)]">
+    <h1 class="absolute left-1/2 top-[35%] -translate-x-1/2 -translate-y-1/2 text-4xl md:text-6xl font-black tracking-tight text-black drop-shadow-[0_4px_12px_rgba(255,255,255,0.8)]">
       FES READY
     </h1>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,9 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
-  <body class="font-sans antialiased" data-controller="side-menu" data-action="keydown@window->side-menu#handleKeydown">
+  <body class="font-sans antialiased pt-16 md:pt-20" 
+        data-controller="side-menu" 
+        data-action="keydown@window->side-menu#handleKeydown">
     <%= render "shared/header" %>
     <%= render "shared/side_menu" %>
     <%= render "shared/flash" %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,5 +1,5 @@
-<header class="fixed inset-x-0 top-0 z-50 bg-[#F95858] text-white">
-  <div class="mx-auto flex w-full max-w-screen-xl items-center gap-4 px-4 py-3">
+<header class="fixed inset-x-0 top-0 z-50 bg-[#F95858] text-white h-16 md:h-20">
+  <div class="h-full items-center mx-auto flex w-full max-w-screen-xl items-center gap-4 px-4">
     <% if current_page?(root_path) %>
       <span
         class="flex h-10 w-10 items-center justify-center rounded-full opacity-50"


### PR DESCRIPTION
## 概要
ヘッダーによりメインビューの要素が見えなくなる現象を修正

## 対応Issue
なし

## 関連Issue
なし

## 特記事項
- application.html.erbのbody部分にヘッダーの高さ分のマージンを追加し、要素が被らないように修正