### PR TITLE
[add]フェス登録機能追加

### DIFF
--- a/app/helpers/stages_helper.rb
+++ b/app/helpers/stages_helper.rb
@@ -1,0 +1,10 @@
+module StagesHelper
+  def stage_text_color(hex)
+    h = hex.to_s.delete("#")
+    r, g, b = h.length == 3 ? h.chars.map { |c| (c*2).to_i(16) } : [h[0..1], h[2..3], h[4..5]].map { _1.to_i(16) }
+    luminance = (0.2126*r + 0.7152*g + 0.0722*b) / 255.0
+    luminance > 0.6 ? "#111111" : "#ffffff"
+  rescue
+    "#ffffff"
+  end
+end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -12,3 +12,6 @@ application.register("side-menu", SideMenuController)
 
 import SpotifyArtistSearchController from "./spotify_artist_search_controller"
 application.register("spotify-artist-search", SpotifyArtistSearchController)
+
+import NestedFormController from "./nested_form_controller"
+application.register("nested-form", NestedFormController)

--- a/app/javascript/controllers/nested_form_controller.js
+++ b/app/javascript/controllers/nested_form_controller.js
@@ -1,0 +1,22 @@
+import { Controller } from "@hotwired/stimulus"
+
+// <template>のHTMLを複製して NEW_RECORD をユニークIDに置換→挿入
+export default class extends Controller {
+  static targets = ["container", "template"]
+
+  add(e) {
+    e.preventDefault()
+    const html = this.templateTarget.innerHTML
+    const uid  = Date.now().toString()
+    const content = html.replaceAll("NEW_RECORD", uid)
+    this.containerTarget.insertAdjacentHTML("beforeend", content)
+  }
+
+  remove(e) {
+    e.preventDefault()
+    const wrapper = e.currentTarget.closest("[data-nested-form-wrapper]")
+    const destroyField = wrapper.querySelector("input[type='hidden'][name$='[_destroy]']")
+    if (destroyField) destroyField.value = "1"       // _destroy=1 で削除
+    wrapper.classList.add("hidden")                  // 見た目は即非表示
+  }
+}

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -3,5 +3,22 @@ class Stage < ApplicationRecord
   validates :name, presence: true
 
   # 任意: 屋内/屋外など（UIは後で）
-  enum :environment, { unspecified: 0, outdoor: 1, indoor: 2 }, prefix: true, _default: 0
+  enum :environment, { unspecified: 0, outdoor: 1, indoor: 2 }, 
+  prefix: true, 
+  default: 0
+
+  COLOR_PALETTE = {
+    "red"      => "#F95858",
+    "emerald"  => "#10B981",
+    "blue"     => "#3B82F6",
+    "amber"    => "#F59E0B",
+    "violet"   => "#8B5CF6",
+    "slate"    => "#64748B",
+  }.freeze
+
+  validates :color_key, inclusion: { in: COLOR_PALETTE.keys }, allow_nil: true
+
+  def color_hex
+    COLOR_PALETTE[color_key.presence || "slate"]
+  end
 end

--- a/app/views/admin/festivals/_festival_day_fields.html.erb
+++ b/app/views/admin/festivals/_festival_day_fields.html.erb
@@ -1,0 +1,29 @@
+<div class="space-y-3 rounded-lg border border-slate-200 bg-white p-4 shadow-sm" data-nested-form-wrapper>
+  <%= f.hidden_field :id %>
+  <div class="grid grid-cols-1 gap-4 md:grid-cols-4">
+    <div>
+      <%= f.label :date, "日付", class: "block text-sm font-semibold text-slate-700" %>
+      <%= f.date_field :date, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm" %>
+    </div>
+    <div>
+      <%= f.label :doors_at, "開場", class: "block text-sm font-semibold text-slate-700" %>
+      <%= f.time_field :doors_at, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm", step: 60 %>
+    </div>
+    <div>
+      <%= f.label :start_at, "開演", class: "block text-sm font-semibold text-slate-700" %>
+      <%= f.time_field :start_at, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm", step: 60 %>
+    </div>
+    <div>
+      <%= f.label :end_at, "終演", class: "block text-sm font-semibold text-slate-700" %>
+      <%= f.time_field :end_at, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm", step: 60 %>
+    </div>
+    <div class="md:col-span-4">
+      <%= f.label :note, "備考", class: "block text-sm font-semibold text-slate-700" %>
+      <%= f.text_field :note, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm", placeholder: "例）雨天決行 / 出演者情報など" %>
+    </div>
+  </div>
+  <div class="flex justify-end">
+    <%= f.hidden_field :_destroy, value: "0" %>
+    <button class="text-xs font-semibold text-red-600 transition hover:text-red-700" data-action="click->nested-form#remove" type="button">削除</button>
+  </div>
+</div>

--- a/app/views/admin/festivals/_form.html.erb
+++ b/app/views/admin/festivals/_form.html.erb
@@ -1,0 +1,55 @@
+<%= form_with model: [:admin, @festival], class: "space-y-6" do |f| %>
+  <div class="border rounded-md p-4 bg-white">
+    <p class="text-sm text-slate-700">
+      フェスの基本情報を入力してください。<br>
+      <span class="text-slate-500 text-xs">※ slug はURL用の識別子です（例: <code>rockin-2025</code>）。未入力でも保存時に整形する処理を入れていれば自動生成可能です。</span>
+    </p>
+  </div>
+
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-4 items-start">
+    <div>
+      <%= f.label :name, "名称", class: "block font-semibold" %>
+      <%= f.text_field :name, class: "w-full border rounded px-3 py-2" %>
+    </div>
+    <div>
+      <%= f.label :slug, "スラッグ（URL識別子）", class: "block font-semibold" %>
+      <%= f.text_field :slug, class: "w-full border rounded px-3 py-2", placeholder: "fes-ready-2026" %>
+    </div>
+  </div>
+
+  <div class="grid grid-cols-1 md:grid-cols-3 gap-4 items-start">
+    <div>
+      <%= f.label :venue_name, "会場名", class: "block font-semibold" %>
+      <%= f.text_field :venue_name, class: "w-full border rounded px-3 py-2" %>
+    </div>
+    <div>
+      <%= f.label :prefecture, "都道府県", class: "block font-semibold" %>
+      <%= f.text_field :prefecture, class: "w-full border rounded px-3 py-2", placeholder: "例）長野県" %>
+    </div>
+    <div>
+      <%= f.label :city, "市区町村", class: "block font-semibold" %>
+      <%= f.text_field :city, class: "w-full border rounded px-3 py-2", placeholder: "例）茅野市" %>
+    </div>
+  </div>
+
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-4 items-start">
+    <div>
+      <%= f.label :start_date, "開始日", class: "block font-semibold" %>
+      <%= f.date_field :start_date, class: "w-full border rounded px-3 py-2" %>
+    </div>
+    <div>
+      <%= f.label :end_date, "終了日", class: "block font-semibold" %>
+      <%= f.date_field :end_date, class: "w-full border rounded px-3 py-2" %>
+    </div>
+  </div>
+
+  <div>
+    <%= f.label :timezone, "タイムゾーン", class: "block font-semibold" %>
+    <%= f.text_field :timezone, class: "w-full border rounded px-3 py-2", placeholder: "Asia/Tokyo", value: @festival.timezone.presence || "Asia/Tokyo" %>
+    <p class="text-xs text-slate-500 mt-1">通常は <code>Asia/Tokyo</code> のままでOKです。</p>
+  </div>
+
+  <div class="pt-4">
+    <%= f.submit "登録する", class: "px-4 py-2 rounded bg-[#F95858] text-white hover:opacity-90" %>
+  </div>
+<% end %>

--- a/app/views/admin/festivals/_stage_fields.html.erb
+++ b/app/views/admin/festivals/_stage_fields.html.erb
@@ -1,0 +1,27 @@
+<div class="grid grid-cols-1 md:grid-cols-3 gap-2 mb-2 items-center" data-nested-form-wrapper>
+  <%= f.hidden_field :id %>
+
+  <%= f.text_field :name, placeholder: "メインステージ", class: "border rounded px-2 py-1" %>
+
+  <%= f.select :environment,
+               Stage.environments.keys.map { |k| [k, k] },
+               {},
+               class: "border rounded px-2 py-1" %>
+
+  <div class="flex items-center gap-2">
+    <%# color_key をセレクトで選ぶ %>
+    <%= f.select :color_key,
+                 Stage::COLOR_PALETTE.map { |k, hex| ["#{k} (#{hex})", k] },
+                 {},
+                 class: "border rounded px-2 py-1" %>
+
+    <%# 選択中のプレビュー（既存は f.object.color_hex を使う） %>
+    <% hex = f.object.respond_to?(:color_hex) ? f.object.color_hex : Stage::COLOR_PALETTE["slate"] %>
+    <span class="inline-block h-6 w-6 rounded border" style="background-color: <%= hex %>;"></span>
+  </div>
+
+  <%= f.hidden_field :_destroy, value: "0" %>
+  <div class="md:col-span-3">
+    <button class="text-xs px-2 py-1 rounded border" data-action="click->nested-form#remove" type="button">削除</button>
+  </div>
+</div>

--- a/app/views/admin/festivals/edit.html.erb
+++ b/app/views/admin/festivals/edit.html.erb
@@ -1,0 +1,2 @@
+<h1 class="text-xl font-bold mb-4">フェス編集</h1>
+<%= render "form" %>

--- a/app/views/admin/festivals/index.html.erb
+++ b/app/views/admin/festivals/index.html.erb
@@ -24,7 +24,9 @@
           <tr class="hover:bg-slate-50">
             <td class="px-4 py-3 font-mono text-xs text-slate-500"><%= festival.id %></td>
             <td class="px-4 py-3">
-              <div class="font-semibold"><%= festival.name %></div>
+              <div class="font-semibold text-slate-800">
+                <%= link_to festival.name, admin_festival_path(festival), class: "text-slate-800 transition hover:text-indigo-600" %>
+              </div>
               <div class="mt-1 text-xs font-mono text-slate-500"><%= festival.slug %></div>
             </td>
             <td class="px-4 py-3">

--- a/app/views/admin/festivals/new.html.erb
+++ b/app/views/admin/festivals/new.html.erb
@@ -1,0 +1,2 @@
+<h1 class="text-xl font-bold mb-4">フェス新規登録</h1>
+<%= render "form" %>

--- a/app/views/admin/festivals/setup.html.erb
+++ b/app/views/admin/festivals/setup.html.erb
@@ -1,0 +1,66 @@
+<h1 class="text-xl font-bold mb-4">日程・ステージの設定</h1>
+
+<%= form_with model: [:admin, @festival],
+              url: apply_admin_festival_path(@festival),
+              method: :patch,
+              class: "space-y-6" do |f| %>
+
+  <!-- 日程 -->
+  <div class="border rounded p-4 space-y-4" data-controller="nested-form">
+    <div>
+      <h2 class="font-semibold">日程</h2>
+      <p class="mt-1 text-sm text-slate-600">日付と開場・開演・終演時間を入力してください（24時間表記、タイムゾーンはフェス設定に準拠）。</p>
+    </div>
+
+    <div class="space-y-3" data-nested-form-target="container">
+      <%= f.fields_for :festival_days do |d| %>
+        <%= render "festival_day_fields", f: d %>
+      <% end %>
+    </div>
+
+    <!-- 追加ボタン -->
+    <div class="mt-2">
+      <button type="button"
+              class="text-sm text-[#F95858]"
+              data-action="click->nested-form#add">
+        日程を追加
+      </button>
+    </div>
+
+    <!-- 追加用テンプレート -->
+    <template data-nested-form-target="template">
+      <%= f.fields_for :festival_days, FestivalDay.new, child_index: "NEW_RECORD" do |d| %>
+        <%= render "festival_day_fields", f: d %>
+      <% end %>
+    </template>
+  </div>
+
+  <!-- ステージ -->
+  <div class="border rounded p-4 space-y-4" data-controller="nested-form">
+    <h2 class="font-semibold">ステージ</h2>
+
+    <div class="space-y-3" data-nested-form-target="container">
+      <%= f.fields_for :stages do |s| %>
+        <%= render "stage_fields", f: s %>
+      <% end %>
+    </div>
+
+    <!-- 追加ボタン -->
+    <div class="mt-2">
+      <button type="button"
+              class="text-sm text-[#F95858]"
+              data-action="click->nested-form#add">
+        ステージを追加
+      </button>
+    </div>
+
+    <!-- 追加用テンプレート -->
+    <template data-nested-form-target="template">
+      <%= f.fields_for :stages, Stage.new, child_index: "NEW_RECORD" do |s| %>
+        <%= render "stage_fields", f: s %>
+      <% end %>
+    </template>
+  </div>
+
+  <%= f.submit "適用する", class: "px-4 py-2 rounded bg-[#F95858] text-white" %>
+<% end %>

--- a/app/views/admin/festivals/show.html.erb
+++ b/app/views/admin/festivals/show.html.erb
@@ -1,0 +1,160 @@
+<% time_zone = ActiveSupport::TimeZone[@festival.timezone] || Time.zone %>
+<% festival_days = @festival.festival_days.order(:date) %>
+<% stages = @festival.stages.order(:sort_order, :id) %>
+
+<div class="mx-auto max-w-5xl px-4 py-10 min-h-[calc(100vh-var(--header-offset,4.5rem)-var(--footer-offset,6rem))]">
+  <div class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+    <div>
+      <h1 class="text-2xl font-bold"><%= @festival.name %></h1>
+      <p class="mt-2 text-slate-600">
+        フェスの基本情報・日程・ステージの詳細を確認できます。
+      </p>
+    </div>
+    <div class="flex flex-wrap gap-2">
+      <%= link_to "一覧に戻る", admin_festivals_path, class: "inline-flex items-center justify-center rounded-lg border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50" %>
+      <%= link_to "日程・ステージ設定", setup_admin_festival_path(@festival), class: "inline-flex items-center justify-center rounded-lg border border-indigo-200 bg-indigo-50 px-4 py-2 text-sm font-semibold text-indigo-700 transition hover:bg-indigo-100" %>
+      <%= link_to "編集", edit_admin_festival_path(@festival), class: "inline-flex items-center justify-center rounded-lg bg-[#F95858] px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-[#e04f4f]" %>
+    </div>
+  </div>
+
+  <div class="mt-10 space-y-12">
+    <section>
+      <h2 class="text-lg font-semibold text-slate-800">基本情報</h2>
+      <div class="mt-4 overflow-hidden rounded-xl border border-slate-200 bg-white">
+        <dl class="divide-y divide-slate-100 text-sm text-slate-700">
+          <div class="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-3">
+            <dt class="font-semibold text-slate-500">フェスID</dt>
+            <dd class="sm:col-span-2 font-mono text-xs text-slate-500"><%= @festival.id %></dd>
+          </div>
+          <div class="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-3">
+            <dt class="font-semibold text-slate-500">名称</dt>
+            <dd class="sm:col-span-2 font-semibold text-slate-800"><%= @festival.name %></dd>
+          </div>
+          <div class="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-3">
+            <dt class="font-semibold text-slate-500">スラッグ</dt>
+            <dd class="sm:col-span-2 font-mono text-xs text-slate-600"><%= @festival.slug %></dd>
+          </div>
+          <div class="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-3">
+            <dt class="font-semibold text-slate-500">開催期間</dt>
+            <dd class="sm:col-span-2">
+              <% start_label = @festival.start_date&.strftime("%Y/%m/%d") %>
+              <% end_label   = @festival.end_date&.strftime("%Y/%m/%d") %>
+              <%= if start_label && end_label
+                    @festival.start_date == @festival.end_date ? start_label : "#{start_label} 〜 #{end_label}"
+                  elsif start_label
+                    start_label
+                  elsif end_label
+                    end_label
+                  else
+                    "-"
+                  end %>
+            </dd>
+          </div>
+          <div class="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-3">
+            <dt class="font-semibold text-slate-500">会場</dt>
+            <dd class="sm:col-span-2">
+              <div><%= @festival.venue_name.presence || "-" %></div>
+              <% location = [@festival.prefecture, @festival.city].compact_blank %>
+              <% if location.any? %>
+                <div class="mt-1 text-xs text-slate-500"><%= location.join(" / ") %></div>
+              <% end %>
+            </dd>
+          </div>
+          <div class="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-3">
+            <dt class="font-semibold text-slate-500">タイムゾーン</dt>
+            <dd class="sm:col-span-2">
+              <span class="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-700">
+                <%= @festival.timezone %>
+              </span>
+            </dd>
+          </div>
+          <div class="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-3">
+            <dt class="font-semibold text-slate-500">登録日時</dt>
+            <dd class="sm:col-span-2 text-xs text-slate-500"><%= l(@festival.created_at, format: :long) %></dd>
+          </div>
+          <div class="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-3">
+            <dt class="font-semibold text-slate-500">更新日時</dt>
+            <dd class="sm:col-span-2 text-xs text-slate-500"><%= l(@festival.updated_at, format: :long) %></dd>
+          </div>
+        </dl>
+      </div>
+    </section>
+
+    <section>
+      <h2 class="text-lg font-semibold text-slate-800">日程</h2>
+      <% if festival_days.any? %>
+        <div class="mt-4 space-y-4">
+          <% festival_days.each do |day| %>
+            <div class="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <div class="flex flex-wrap items-center justify-between gap-2">
+                <div class="text-base font-semibold text-slate-800">
+                  <%= day.date.strftime("%Y/%m/%d (%a)") %>
+                </div>
+                <% if day.note.present? %>
+                  <div class="text-xs text-slate-500"><%= day.note %></div>
+                <% end %>
+              </div>
+              <dl class="mt-3 grid grid-cols-1 gap-3 text-sm text-slate-700 sm:grid-cols-3">
+                <div>
+                  <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">開場</dt>
+                  <dd class="mt-1"><%= day.doors_at ? day.doors_at.in_time_zone(time_zone).strftime("%H:%M") : "-" %></dd>
+                </div>
+                <div>
+                  <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">開演</dt>
+                  <dd class="mt-1"><%= day.start_at ? day.start_at.in_time_zone(time_zone).strftime("%H:%M") : "-" %></dd>
+                </div>
+                <div>
+                  <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">終演</dt>
+                  <dd class="mt-1"><%= day.end_at ? day.end_at.in_time_zone(time_zone).strftime("%H:%M") : "-" %></dd>
+                </div>
+              </dl>
+            </div>
+          <% end %>
+        </div>
+      <% else %>
+        <p class="mt-4 rounded-lg border border-dashed border-slate-300 bg-slate-50 px-4 py-6 text-sm text-slate-500">
+          登録された日程はまだありません。日程・ステージ設定から追加してください。
+        </p>
+      <% end %>
+    </section>
+
+    <section>
+      <h2 class="text-lg font-semibold text-slate-800">ステージ</h2>
+      <% if stages.any? %>
+        <div class="mt-4 grid gap-4 md:grid-cols-2">
+          <% stages.each do |stage| %>
+            <% hex = stage.color_hex %>
+            <% text_color = stage_text_color(hex) %>
+            <% environment_label = stage.environment.present? ? I18n.t("enums.stage.environment.#{stage.environment}", default: stage.environment.humanize) : "-" %>
+            <div class="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <div class="flex items-center justify-between gap-2">
+                <h3 class="text-base font-semibold text-slate-800"><%= stage.name %></h3>
+                <span class="inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold" style="background-color: <%= hex %>; color: <%= text_color %>;">
+                  <span><%= stage.color_key.presence || "slate" %></span>
+                </span>
+              </div>
+              <dl class="mt-3 space-y-2 text-sm text-slate-700">
+                <div class="flex justify-between gap-3">
+                  <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">表示順</dt>
+                  <dd class="font-mono text-xs text-slate-600"><%= stage.sort_order %></dd>
+                </div>
+                <div class="flex justify-between gap-3">
+                  <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">環境</dt>
+                  <dd><%= environment_label %></dd>
+                </div>
+                <div>
+                  <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">メモ</dt>
+                  <dd class="mt-1 text-sm text-slate-600"><%= stage.note.presence || "-" %></dd>
+                </div>
+              </dl>
+            </div>
+          <% end %>
+        </div>
+      <% else %>
+        <p class="mt-4 rounded-lg border border-dashed border-slate-300 bg-slate-50 px-4 py-6 text-sm text-slate-500">
+          登録されたステージはまだありません。日程・ステージ設定から追加してください。
+        </p>
+      <% end %>
+    </section>
+  </div>
+</div>

--- a/app/views/admin/home/top.html.erb
+++ b/app/views/admin/home/top.html.erb
@@ -4,7 +4,7 @@
 
   <nav class="mt-6 space-y-3">
     <%= render "shared/nav_stack_button", label: "ユーザー管理", url: admin_users_path %>
-    <%= render "shared/nav_stack_button", label: "フェス管理", url: "#" %>
+    <%= render "shared/nav_stack_button", label: "フェス管理", url: admin_festivals_path %>
     <%= render "shared/nav_stack_button", label: "アーティスト管理", url: admin_artists_path %>
     <%= render "shared/nav_stack_button", label: "タイムテーブル管理", url: "#" %>
     <%= render "shared/nav_stack_button", label: "セットリスト管理", url: "#" %>


### PR DESCRIPTION
## 概要
- フェス情報の登録機能を追加
- フェス登録画面を追加
- フェス詳細画面を追加
- フェス編集機能を追加
- フェス削除機能を追加

## 対応Issue
- close #33 
- close #34 
- close #35 
- close #36 

## 関連Issue
- #32 

## 特記事項
- festivalsテーブルの基本情報を入力後、festival_daysとstagesテーブルの情報を入力
- フェス詳細ページを追加実装
- adminトップページの「フェス管理」のパスを追加
