### PR TITLE
[add]ステージパフォーマンス登録機能追加

### DIFF
--- a/app/controllers/admin/stage_performances_controller.rb
+++ b/app/controllers/admin/stage_performances_controller.rb
@@ -1,0 +1,67 @@
+class Admin::StagePerformancesController < Admin::BaseController
+  before_action :set_sp, only: %i[show edit update destroy]
+
+  def index
+    @pagy, @stage_performances =
+      pagy(StagePerformance
+        .includes(:festival_day, :stage, :artist)
+        .order(:starts_at))
+  end
+
+  def show; end
+
+  def new
+    @stage_performance = StagePerformance.new(status: :draft)
+    @stage_performance.festival_day_id = params[:festival_day_id] if params[:festival_day_id].present?
+  end
+
+  def create
+    @stage_performance = StagePerformance.new(sp_params)
+    if @stage_performance.save
+      redirect_to admin_stage_performance_path(@stage_performance), notice: "出演枠を作成しました。"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  rescue ActiveRecord::StatementInvalid => e
+    flash.now[:alert] = friendly_pg_error(e)
+    render :new, status: :unprocessable_entity
+  end
+
+  def edit; end
+
+  def update
+    if @stage_performance.update(sp_params)
+      redirect_to admin_stage_performance_path(@stage_performance), notice: "出演枠を更新しました。"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  rescue ActiveRecord::StatementInvalid => e
+    flash.now[:alert] = friendly_pg_error(e)
+    render :edit, status: :unprocessable_entity
+  end
+
+  def destroy
+    @stage_performance.destroy!
+    redirect_to admin_stage_performances_path, notice: "削除しました。"
+  end
+
+  private
+
+  def set_sp
+    @stage_performance = StagePerformance.includes(:artist, :stage, festival_day: :festival).find(params[:id])
+  end
+
+  def sp_params
+    params.require(:stage_performance).permit(
+      :festival_day_id, :stage_id, :artist_id,
+      :starts_at, :ends_at, :status
+    )
+  end
+
+  def friendly_pg_error(err)
+    msg = err.message
+    return "同一ステージで時間帯が重複しています（確定枠）。時間を見直してください。" if msg.include?("no_overlap_on_same_stage_when_scheduled")
+    return "同一スロットの二重登録です（確定枠）。開始時刻・ステージ・アーティストの組み合わせを見直してください。" if msg.include?("uniq_sp_slot_when_scheduled")
+    "保存に失敗しました（DB制約）。入力内容を確認してください。"
+  end
+end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -1,6 +1,10 @@
 class Artist < ApplicationRecord
   validates :name, presence: true
 
+  has_many :stage_performances, dependent: :destroy
+  has_many :festival_days, through: :stage_performances
+  has_many :festivals, -> { distinct }, through: :festival_days
+
   # SpotifyのIDは Base62 22文字（例: 0OdUWJ0sBjDrqHygGUXeCF）
   validates :spotify_artist_id,
            format: { with: /\A[0-9A-Za-z]{22}\z/, message: "is invalid (22-char base62)" },

--- a/app/models/festival_day.rb
+++ b/app/models/festival_day.rb
@@ -1,5 +1,7 @@
 class FestivalDay < ApplicationRecord
   belongs_to :festival
+  has_many :stage_performances, dependent: :destroy
+
   validates :date, presence: true
   validates :date, uniqueness: { scope: :festival_id }
 end

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -1,5 +1,6 @@
 class Stage < ApplicationRecord
   belongs_to :festival
+  has_many :stage_performances, dependent: :destroy
   validates :name, presence: true
 
   # 任意: 屋内/屋外など（UIは後で）

--- a/app/models/stage_performance.rb
+++ b/app/models/stage_performance.rb
@@ -1,0 +1,27 @@
+class StagePerformance < ApplicationRecord
+  enum :status, { draft: 0, scheduled: 1 }
+
+  belongs_to :festival_day
+  belongs_to :stage, optional: true
+  belongs_to :artist
+
+  # scheduledのときだけ必須＆妥当性チェック
+  with_options if: :scheduled? do
+    validates :stage,     presence: true
+    validates :starts_at, presence: true
+    validates :ends_at,   presence: true
+    validate  :ends_after_starts
+  end
+
+  scope :chronological, -> { order(:starts_at) }
+  scope :for_day,       ->(day_id)    { where(festival_day_id: day_id) }
+  scope :for_stage,     ->(stage_id)  { where(stage_id: stage_id) }
+  scope :for_artist,    ->(artist_id) { where(artist_id: artist_id) }
+
+  private
+
+  def ends_after_starts
+    return if starts_at.blank? || ends_at.blank?
+    errors.add(:ends_at, "は開始より後にしてください") if ends_at <= starts_at
+  end
+end

--- a/app/views/admin/home/top.html.erb
+++ b/app/views/admin/home/top.html.erb
@@ -6,7 +6,7 @@
     <%= render "shared/nav_stack_button", label: "ユーザー管理", url: admin_users_path %>
     <%= render "shared/nav_stack_button", label: "フェス管理", url: admin_festivals_path %>
     <%= render "shared/nav_stack_button", label: "アーティスト管理", url: admin_artists_path %>
-    <%= render "shared/nav_stack_button", label: "タイムテーブル管理", url: "#" %>
+    <%= render "shared/nav_stack_button", label: "ステージパフォーマンス管理", url: admin_stage_performances_path %>
     <%= render "shared/nav_stack_button", label: "セットリスト管理", url: "#" %>
   </nav>
 </div>

--- a/app/views/admin/stage_performances/_form.html.erb
+++ b/app/views/admin/stage_performances/_form.html.erb
@@ -1,0 +1,65 @@
+<% stage_performance = local_assigns.fetch(:stage_performance, @stage_performance) %>
+
+<%= form_with model: [:admin, stage_performance], class: "space-y-6" do |f| %>
+  <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm space-y-6">
+    <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
+      <div>
+        <%= f.label :festival_day_id, "日程", class: "block text-sm font-semibold text-slate-700" %>
+        <%= f.collection_select :festival_day_id,
+              FestivalDay.includes(:festival).order(:date),
+              :id,
+              ->(d) { "#{d.festival.name} / #{d.date.strftime('%Y/%m/%d')}" },
+              {},
+              class: "mt-2 w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200" %>
+      </div>
+      <div>
+        <%= f.label :artist_id, "アーティスト", class: "block text-sm font-semibold text-slate-700" %>
+        <%= f.collection_select :artist_id,
+              Artist.order(:name),
+              :id,
+              :name,
+              {},
+              class: "mt-2 w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200" %>
+      </div>
+    </div>
+
+    <div>
+      <%= f.label :stage_id, "ステージ（確定時）", class: "block text-sm font-semibold text-slate-700" %>
+      <%= f.collection_select :stage_id,
+            Stage.order(:sort_order, :id),
+            :id,
+            :name,
+            { include_blank: "(未定)" },
+            class: "mt-2 w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200" %>
+      <p class="mt-2 text-xs text-slate-500">status が scheduled の場合は必須です。</p>
+    </div>
+
+    <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
+      <div>
+        <%= f.label :starts_at, "開始", class: "block text-sm font-semibold text-slate-700" %>
+        <%= f.datetime_local_field :starts_at,
+              class: "mt-2 w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200" %>
+      </div>
+      <div>
+        <%= f.label :ends_at, "終了", class: "block text-sm font-semibold text-slate-700" %>
+        <%= f.datetime_local_field :ends_at,
+              class: "mt-2 w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200" %>
+      </div>
+    </div>
+
+    <div>
+      <%= f.label :status, "状態", class: "block text-sm font-semibold text-slate-700" %>
+      <%= f.select :status,
+            StagePerformance.statuses.keys.map { |k| [k, k] },
+            {},
+            class: "mt-2 w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200" %>
+      <p class="mt-2 text-xs text-slate-500">
+        draft=出演者のみ登録 / scheduled=タイムテーブル確定（時間・ステージ必須）
+      </p>
+    </div>
+  </div>
+
+  <div class="pt-2">
+    <%= f.submit class: "inline-flex items-center rounded bg-[#F95858] px-5 py-2 text-sm font-semibold text-white shadow transition hover:bg-[#e04f4f]" %>
+  </div>
+<% end %>

--- a/app/views/admin/stage_performances/edit.html.erb
+++ b/app/views/admin/stage_performances/edit.html.erb
@@ -1,0 +1,22 @@
+<div class="mx-auto max-w-4xl px-4 py-10 min-h-[calc(100vh-var(--header-offset,4.5rem)-var(--footer-offset,6rem))]">
+  <div class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+    <div>
+      <h1 class="text-2xl font-bold text-slate-900">出演枠を編集</h1>
+      <p class="mt-1 text-sm text-slate-600">
+        タイムテーブルが確定したら status を <code>scheduled</code> に変更し、ステージと時間を入力してください。
+      </p>
+    </div>
+    <div class="flex flex-wrap gap-2">
+      <%= link_to "詳細に戻る",
+            admin_stage_performance_path(@stage_performance),
+            class: "inline-flex items-center justify-center rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50" %>
+      <%= link_to "一覧に戻る",
+            admin_stage_performances_path,
+            class: "inline-flex items-center justify-center rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50" %>
+    </div>
+  </div>
+
+  <div class="mt-8">
+    <%= render "form", stage_performance: @stage_performance %>
+  </div>
+</div>

--- a/app/views/admin/stage_performances/index.html.erb
+++ b/app/views/admin/stage_performances/index.html.erb
@@ -1,0 +1,74 @@
+<div class="mx-auto max-w-5xl px-4 py-10 min-h-[calc(100vh-var(--header-offset,4.5rem)-var(--footer-offset,6rem))]">
+  <div class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+    <div>
+      <h1 class="text-2xl font-bold text-slate-900">出演枠一覧</h1>
+      <p class="mt-2 text-sm text-slate-600">draft = 出演者のみ登録 / scheduled = 確定</p>
+    </div>
+    <%= link_to "新規作成",
+        new_admin_stage_performance_path,
+        class: "inline-flex items-center justify-center rounded-lg bg-[#F95858] px-5 py-2 text-sm font-semibold text-white shadow transition hover:bg-[#e04f4f]" %>
+  </div>
+
+  <% if @stage_performances.any? %>
+    <div class="mt-8 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+      <table class="min-w-full divide-y divide-slate-200 text-sm text-slate-800">
+        <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-600">
+          <tr>
+            <th class="px-4 py-3">フェス / 日付</th>
+            <th class="px-4 py-3">アーティスト</th>
+            <th class="px-4 py-3">ステージ</th>
+            <th class="px-4 py-3">時間</th>
+            <th class="px-4 py-3">状態</th>
+            <th class="px-4 py-3 text-right">操作</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-100">
+          <% @stage_performances.each do |sp| %>
+            <% day = sp.festival_day %>
+            <% fes = day&.festival %>
+            <% tz  = ActiveSupport::TimeZone[fes&.timezone] || Time.zone %>
+            <tr class="align-top transition hover:bg-slate-50/60">
+              <td class="px-4 py-3">
+                <div class="font-semibold text-slate-900"><%= fes&.name || "-" %></div>
+                <div class="text-xs text-slate-500"><%= day&.date&.strftime("%Y/%m/%d (%a)") || "-" %></div>
+              </td>
+              <td class="px-4 py-3"><%= sp.artist&.name || "-" %></td>
+              <td class="px-4 py-3 text-slate-700"><%= sp.stage&.name || "(未定)" %></td>
+              <td class="px-4 py-3 font-mono text-xs text-slate-600">
+                <% if sp.starts_at && sp.ends_at %>
+                  <%= sp.starts_at.in_time_zone(tz).strftime("%H:%M") %>–<%= sp.ends_at.in_time_zone(tz).strftime("%H:%M") %>
+                <% else %>
+                  -
+                <% end %>
+              </td>
+              <td class="px-4 py-3">
+                <% if sp.scheduled? %>
+                  <span class="inline-flex items-center rounded-full bg-emerald-100 px-2.5 py-0.5 text-xs font-semibold text-emerald-700">scheduled</span>
+                <% else %>
+                  <span class="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-semibold text-slate-700">draft</span>
+                <% end %>
+              </td>
+              <td class="px-4 py-3">
+                <div class="flex justify-end gap-2 text-sm font-semibold">
+                  <%= link_to "詳細", admin_stage_performance_path(sp), class: "text-slate-700 transition hover:text-slate-900" %>
+                  <%= link_to "編集", edit_admin_stage_performance_path(sp), class: "text-indigo-600 transition hover:text-indigo-700" %>
+                  <%= link_to "削除", admin_stage_performance_path(sp),
+                        data: { turbo_method: :delete, turbo_confirm: "削除しますか？" },
+                        class: "text-rose-600 transition hover:text-rose-700" %>
+                </div>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="mt-6">
+      <%= render "shared/pagination", pagy: @pagy %>
+    </div>
+  <% else %>
+    <p class="mt-8 rounded-xl border border-dashed border-slate-300 bg-slate-50 px-4 py-6 text-sm text-slate-500">
+      まだ出演枠がありません。右上の「新規作成」から追加してください。
+    </p>
+  <% end %>
+</div>

--- a/app/views/admin/stage_performances/new.html.erb
+++ b/app/views/admin/stage_performances/new.html.erb
@@ -1,0 +1,17 @@
+<div class="mx-auto max-w-4xl px-4 py-10 min-h-[calc(100vh-var(--header-offset,4.5rem)-var(--footer-offset,6rem))]">
+  <div class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+    <div>
+      <h1 class="text-2xl font-bold text-slate-900">出演枠を追加</h1>
+      <p class="mt-1 text-sm text-slate-600">
+        出演者だけ先に登録したい場合は status を <code>draft</code> のままにしてください。
+      </p>
+    </div>
+    <%= link_to "一覧に戻る",
+          admin_stage_performances_path,
+          class: "inline-flex items-center justify-center rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50" %>
+  </div>
+
+  <div class="mt-8">
+    <%= render "form", stage_performance: @stage_performance %>
+  </div>
+</div>

--- a/app/views/admin/stage_performances/show.html.erb
+++ b/app/views/admin/stage_performances/show.html.erb
@@ -1,0 +1,167 @@
+<% day       = @stage_performance.festival_day %>
+<% festival  = day&.festival %>
+<% stage     = @stage_performance.stage %>
+<% artist    = @stage_performance.artist %>
+<% time_zone = ActiveSupport::TimeZone[festival&.timezone] || Time.zone %>
+<% starts_at = @stage_performance.starts_at&.in_time_zone(time_zone) %>
+<% ends_at   = @stage_performance.ends_at&.in_time_zone(time_zone) %>
+<% duration  = (starts_at && ends_at) ? ((ends_at - starts_at) / 60.0).round : nil %>
+
+<div class="mx-auto max-w-4xl px-4 py-10 min-h-[calc(100vh-var(--header-offset,4.5rem)-var(--footer-offset,6rem))]">
+  <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+    <div>
+      <div class="flex items-center gap-3">
+        <h1 class="text-2xl font-bold text-slate-900">出演枠詳細</h1>
+        <% if @stage_performance.scheduled? %>
+          <span class="inline-flex items-center rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-700">
+            scheduled
+          </span>
+        <% else %>
+          <span class="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-700">
+            draft
+          </span>
+        <% end %>
+      </div>
+      <p class="mt-2 text-sm text-slate-600">
+        フェス・日程・出演者の詳細を確認できます。
+      </p>
+    </div>
+    <div class="flex flex-wrap gap-2">
+      <%= link_to "一覧に戻る",
+            admin_stage_performances_path,
+            class: "inline-flex items-center justify-center rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50" %>
+      <%= link_to "編集",
+            edit_admin_stage_performance_path(@stage_performance),
+            class: "inline-flex items-center justify-center rounded-lg bg-indigo-50 px-4 py-2 text-sm font-semibold text-indigo-700 transition hover:bg-indigo-100" %>
+      <%= link_to "削除",
+            admin_stage_performance_path(@stage_performance),
+            data: { turbo_method: :delete, turbo_confirm: "削除しますか？" },
+            class: "inline-flex items-center justify-center rounded-lg bg-rose-50 px-4 py-2 text-sm font-semibold text-rose-700 transition hover:bg-rose-100" %>
+    </div>
+  </div>
+
+  <div class="mt-10 space-y-10">
+    <section>
+      <h2 class="text-lg font-semibold text-slate-800">基本情報</h2>
+      <div class="mt-4 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+        <dl class="divide-y divide-slate-100 text-sm text-slate-700">
+          <div class="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-3">
+            <dt class="font-semibold text-slate-500">フェス</dt>
+            <dd class="sm:col-span-2">
+              <% if festival.present? %>
+                <%= link_to festival.name,
+                      admin_festival_path(festival),
+                      class: "text-indigo-600 hover:underline" %>
+                <div class="text-xs text-slate-500">ID: <span class="font-mono"><%= festival.id %></span></div>
+              <% else %>
+                -
+              <% end %>
+            </dd>
+          </div>
+          <div class="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-3">
+            <dt class="font-semibold text-slate-500">日付</dt>
+            <dd class="sm:col-span-2">
+              <% if day&.date.present? %>
+                <%= day.date.strftime("%Y/%m/%d (%a)") %>
+              <% else %>
+                -
+              <% end %>
+            </dd>
+          </div>
+          <div class="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-3">
+            <dt class="font-semibold text-slate-500">アーティスト</dt>
+            <dd class="sm:col-span-2">
+              <% if artist.present? %>
+                <%= link_to artist.name,
+                      admin_artist_path(artist),
+                      class: "text-slate-900 hover:underline" %>
+              <% else %>
+                -
+              <% end %>
+            </dd>
+          </div>
+          <div class="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-3">
+            <dt class="font-semibold text-slate-500">ステージ</dt>
+            <dd class="sm:col-span-2">
+              <% if stage.present? %>
+                <span class="text-slate-900"><%= stage.name %></span>
+                <% if stage.color_key.present? %>
+                  <span class="ml-2 inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold"
+                        style="background-color: <%= stage.color_hex %>; color: <%= stage_text_color(stage.color_hex) %>;">
+                    <span><%= stage.color_key %></span>
+                  </span>
+                <% end %>
+              <% else %>
+                (未定)
+              <% end %>
+            </dd>
+          </div>
+          <div class="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-3">
+            <dt class="font-semibold text-slate-500">状態</dt>
+            <dd class="sm:col-span-2">
+              <% if @stage_performance.scheduled? %>
+                <span class="inline-flex items-center rounded-full bg-emerald-100 px-2.5 py-0.5 text-xs font-semibold text-emerald-700">scheduled</span>
+              <% else %>
+                <span class="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-semibold text-slate-700">draft</span>
+              <% end %>
+            </dd>
+          </div>
+        </dl>
+      </div>
+    </section>
+
+    <section>
+      <h2 class="text-lg font-semibold text-slate-800">スケジュール</h2>
+      <div class="mt-4 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+        <dl class="divide-y divide-slate-100 text-sm text-slate-700">
+          <div class="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-3">
+            <dt class="font-semibold text-slate-500">開始</dt>
+            <dd class="sm:col-span-2">
+              <%= starts_at ? starts_at.strftime("%Y/%m/%d %H:%M") : "-" %>
+            </dd>
+          </div>
+          <div class="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-3">
+            <dt class="font-semibold text-slate-500">終了</dt>
+            <dd class="sm:col-span-2">
+              <%= ends_at ? ends_at.strftime("%Y/%m/%d %H:%M") : "-" %>
+            </dd>
+          </div>
+          <div class="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-3">
+            <dt class="font-semibold text-slate-500">所要時間</dt>
+            <dd class="sm:col-span-2">
+              <%= duration ? "#{duration.to_i} 分" : "-" %>
+            </dd>
+          </div>
+          <div class="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-3">
+            <dt class="font-semibold text-slate-500">タイムゾーン</dt>
+            <dd class="sm:col-span-2">
+              <span class="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-semibold text-slate-700">
+                <%= festival&.timezone || time_zone.tzinfo.name %>
+              </span>
+            </dd>
+          </div>
+        </dl>
+      </div>
+    </section>
+
+    <section>
+      <h2 class="text-lg font-semibold text-slate-800">メタ情報</h2>
+      <div class="mt-4 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+        <dl class="divide-y divide-slate-100 text-xs text-slate-600">
+          <div class="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-3">
+            <dt class="font-semibold uppercase tracking-wide text-slate-500">ID</dt>
+            <dd class="sm:col-span-2 font-mono text-sm text-slate-700"><%= @stage_performance.id %></dd>
+          </div>
+          <div class="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-3">
+            <dt class="font-semibold uppercase tracking-wide text-slate-500">作成日時</dt>
+            <dd class="sm:col-span-2"><%= l(@stage_performance.created_at, format: :long) %></dd>
+          </div>
+          <div class="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-3">
+            <dt class="font-semibold uppercase tracking-wide text-slate-500">更新日時</dt>
+            <dd class="sm:col-span-2"><%= l(@stage_performance.updated_at, format: :long) %></dd>
+          </div>
+        </dl>
+      </div>
+    </section>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root "home#top"
-
   get "up" => "rails/health#show", as: :rails_health_check
-
   resources :artists, only: [ :index, :show ]
 
   namespace :admin do
@@ -11,10 +9,11 @@ Rails.application.routes.draw do
     get "spotify/search", to: "spotify#search"
     resources :users, only: :index
     resources :artists
+    resources :stage_performances
     resources :festivals do
       member do
-        get  :setup   # 日程・ステージをまとめて編集する画面
-        patch :apply  # ネスト更新のsubmit先
+        get  :setup
+        patch :apply
       end
     end
   end

--- a/db/migrate/20251015055830_create_stage_performances.rb
+++ b/db/migrate/20251015055830_create_stage_performances.rb
@@ -1,0 +1,45 @@
+class CreateStagePerformances < ActiveRecord::Migration[8.0]
+  def change
+    enable_extension 'btree_gist' unless extension_enabled?('btree_gist')
+
+    create_table :stage_performances do |t|
+      t.references :festival_day, null: false, foreign_key: true
+      t.references :stage,        null: true, foreign_key: true
+      t.references :artist,       null: false, foreign_key: true
+      t.datetime   :starts_at,    null: true
+      t.datetime   :ends_at,      null: true
+      t.integer    :status,       null: false, default: 0
+      t.timestamps
+    end
+
+    # “その日に同じアーティストを重複登録しない”用（下書き/確定どちらでも有効）
+    add_index :stage_performances, [ :festival_day_id, :artist_id ], unique: true
+
+    # 実用インデックス
+    add_index :stage_performances, [ :festival_day_id, :stage_id, :starts_at ]
+    add_index :stage_performances, [ :artist_id, :starts_at ]
+
+    # 確定済み(scheduled)のみ適用するユニーク制約（同じ枠の二重登録防止）
+    execute <<~SQL
+      CREATE UNIQUE INDEX uniq_sp_slot_when_scheduled
+      ON stage_performances (festival_day_id, stage_id, artist_id, starts_at)
+      WHERE status = 1 AND stage_id IS NOT NULL AND starts_at IS NOT NULL;
+    SQL
+
+    # 同一ステージでの時間帯重複を禁止（確定済みのみ／半開区間）
+    execute <<~SQL
+      ALTER TABLE stage_performances
+        ADD CONSTRAINT no_overlap_on_same_stage_when_scheduled
+        EXCLUDE USING gist (
+          stage_id WITH =,
+          tsrange(starts_at, ends_at, '[)') WITH &&
+        )
+        WHERE (
+          status = 1
+          AND stage_id IS NOT NULL
+          AND starts_at IS NOT NULL
+          AND ends_at IS NOT NULL
+        );
+    SQL
+  end
+end

--- a/test/fixtures/stage_performances.yml
+++ b/test/fixtures/stage_performances.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/stage_performance_test.rb
+++ b/test/models/stage_performance_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class StagePerformanceTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
- stage_performancesテーブルの追加
- 出演枠一覧画面の追加
- 出演枠新規登録・編集フォームの追加
- 新規登録・編集・削除機能実装

## 対応Issue
- close #42
- close #43 
- close #44 
- close #45 
- close #46 

## 関連Issue
なし

## 特記事項
- statusカラムを追加実装 { draft: 0, scheduled: 1 }
- status: draft状態ではステージ情報、出演開始・終了時間をnullで登録可能
