### PR TITLE
[add]フェス詳細ページ作成

### DIFF
--- a/app/controllers/admin/stage_performances_controller.rb
+++ b/app/controllers/admin/stage_performances_controller.rb
@@ -1,5 +1,5 @@
 class Admin::StagePerformancesController < Admin::BaseController
-  before_action :set_sp, only: %i[show edit update destroy]
+  before_action :set_stage_performance, only: %i[show edit update destroy]
 
   def index
     @pagy, @stage_performances =
@@ -47,7 +47,7 @@ class Admin::StagePerformancesController < Admin::BaseController
 
   private
 
-  def set_sp
+  def set_stage_performance
     @stage_performance = StagePerformance.includes(:artist, :stage, festival_day: :festival).find(params[:id])
   end
 

--- a/app/controllers/festivals_controller.rb
+++ b/app/controllers/festivals_controller.rb
@@ -1,4 +1,8 @@
 class FestivalsController < ApplicationController
+  def show
+    @festival = Festival.find(params[:id])
+  end
+
   def index
     @status = params[:status]
     @status = "upcoming" unless %w[upcoming past].include?(@status)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,4 +8,11 @@ module ApplicationHelper
     else              "bg-slate-800 text-white"
     end
   end
+
+  def format_date_with_weekday(date)
+    return if date.blank?
+
+    weekday_names = %w[日 月 火 水 木 金 土]
+    "#{date.strftime('%Y/%m/%d')}(#{weekday_names[date.wday]})"
+  end
 end

--- a/app/views/festivals/index.html.erb
+++ b/app/views/festivals/index.html.erb
@@ -22,7 +22,7 @@
           <div class="w-full">
             <%= render "shared/nav_stack_button",
                        label: festival.name,
-                       url: "#" %>
+                       url: festival_path(festival) %>
           </div>
         <% end %>
       <% else %>

--- a/app/views/festivals/show.html.erb
+++ b/app/views/festivals/show.html.erb
@@ -1,0 +1,76 @@
+<div class="min-h-screen px-4 pb-24 pt-6">
+  <div class="mx-auto max-w-3xl space-y-6">
+    <article class="rounded-3xl border border-slate-200 bg-white p-6 shadow-lg shadow-slate-200/60">
+      <header class="flex items-start justify-between gap-4">
+        <h1 class="text-2xl font-bold text-slate-900"><%= @festival.name %></h1>
+      </header>
+
+      <dl class="mt-4 space-y-3 text-sm text-slate-600">
+        <div class="flex flex-col gap-1">
+          <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">公式サイト</dt>
+          <dd>
+            <% if @festival.official_url.present? %>
+              <%= link_to @festival.official_url,
+                          @festival.official_url,
+                          class: "inline-flex items-center gap-2 text-rose-600 underline decoration-2 underline-offset-4 hover:text-rose-500",
+                          target: "_blank",
+                          rel: "noopener" %>
+            <% else %>
+              <span class="text-slate-400">未登録</span>
+            <% end %>
+          </dd>
+        </div>
+
+        <div class="flex flex-col gap-1">
+          <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">開催期間</dt>
+          <dd class="font-semibold text-slate-800">
+            <% if @festival.start_date.present? %>
+              <% start_label = format_date_with_weekday(@festival.start_date) %>
+              <% end_label = format_date_with_weekday(@festival.end_date) %>
+              <% if end_label.present? && @festival.end_date != @festival.start_date %>
+                <%= start_label %> 〜 <%= end_label %>
+              <% else %>
+                <%= start_label %>
+              <% end %>
+            <% else %>
+              <span class="text-slate-400">未定</span>
+            <% end %>
+          </dd>
+        </div>
+
+        <div class="flex flex-col gap-1">
+          <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">会場</dt>
+          <dd class="flex flex-wrap items-center gap-2 text-slate-800">
+            <% location_parts = [] %>
+            <% location_parts << "＠#{@festival.prefecture}" if @festival.prefecture.present? %>
+            <% location_parts << @festival.city if @festival.city.present? %>
+            <% location_parts << @festival.venue_name if @festival.venue_name.present? %>
+
+            <% if location_parts.any? %>
+              <span><%= location_parts.join(" ") %></span>
+            <% else %>
+              <span class="text-slate-400">未定</span>
+            <% end %>
+          </dd>
+        </div>
+      </dl>
+
+      <hr class="my-6 border-slate-200" />
+
+      <div class="space-y-3">
+        <%= link_to "#",
+                    class: "block w-full rounded-2xl bg-indigo-500 py-3 text-center text-sm font-bold text-white shadow-md transition hover:bg-indigo-400" do %>
+          出演アーティスト一覧へ
+        <% end %>
+        <%= link_to "#",
+                    class: "block w-full rounded-2xl bg-indigo-500 py-3 text-center text-sm font-bold text-white shadow-md transition hover:bg-indigo-400" do %>
+          タイムテーブルへ
+        <% end %>
+        <%= link_to "#",
+                    class: "block w-full rounded-2xl bg-indigo-500 py-3 text-center text-sm font-bold text-white shadow-md transition hover:bg-indigo-400" do %>
+          フェス予習リストへ
+        <% end %>
+      </div>
+    </article>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   root "home#top"
   get "up" => "rails/health#show", as: :rails_health_check
   resources :artists, only: [ :index, :show ]
-  resources :festivals, only: :index
+  resources :festivals, only: [ :index, :show ]
 
   namespace :admin do
     root "home#top"


### PR DESCRIPTION
## 概要
- フェス詳細ページを作成
- それに伴うルーティング・コントローラの追記
- フェス一覧ページの各フェスボタンにパスを追加

## 対応Issue
- close #48 

## 関連Issue
なし

## 特記事項
なし