### PR TITLE
[add]festivalsテーブルにタイムテーブル公開/非公開カラムの追加

### DIFF
--- a/db/migrate/20251021020350_add_timetable_status_to_festivals.rb
+++ b/db/migrate/20251021020350_add_timetable_status_to_festivals.rb
@@ -1,0 +1,6 @@
+class AddTimetableStatusToFestivals < ActiveRecord::Migration[8.0]
+  def change
+    add_column :festivals, :timetable_published, :boolean, null: false, default: false
+    add_index  :festivals, :timetable_published
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_15_055830) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_21_020350) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "pg_catalog.plpgsql"
@@ -50,8 +50,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_15_055830) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "official_url"
+    t.boolean "timetable_published", default: false, null: false
     t.index ["slug"], name: "index_festivals_on_slug", unique: true
     t.index ["start_date"], name: "index_festivals_on_start_date"
+    t.index ["timetable_published"], name: "index_festivals_on_timetable_published"
   end
 
   create_table "stage_performances", force: :cascade do |t|


### PR DESCRIPTION
## 概要
- festivalsテーブルにタイムテーブル公開/非公開カラムの追加（timetable_published）

## 対応Issue
なし

## 関連Issue
- #55 
- #63 

## 特記事項
- admin画面で編集中のデータをユーザーに非表示にできるようにカラムを追加