### PR TITLE
[fix]タイムテーブル公開/非公開が反映されない問題の修正

### DIFF
--- a/app/controllers/admin/festivals_controller.rb
+++ b/app/controllers/admin/festivals_controller.rb
@@ -63,14 +63,14 @@ class Admin::FestivalsController < Admin::BaseController
     params.require(:festival).permit(
       :name, :slug, :venue_name, :city, :prefecture,
       :start_date, :end_date, :timezone,
-      :official_url
+      :official_url, :timetable_published
     )
   end
 
   # setupページ（ネスト＋必要なら基本も一緒に）
   def festival_params_nested
     params.require(:festival).permit(
-      :name, :venue_name, :city, :prefecture, :timezone, :start_date, :end_date, :official_url,
+      :name, :venue_name, :city, :prefecture, :timezone, :start_date, :end_date, :official_url, :timetable_published,
       festival_days_attributes: [ :id, :date, :doors_at, :start_at, :end_at, :note, :_destroy ],
       stages_attributes:        [ :id, :name, :sort_order, :environment, :note, :color_key, :_destroy ]
     )

--- a/app/views/admin/festivals/show.html.erb
+++ b/app/views/admin/festivals/show.html.erb
@@ -83,6 +83,22 @@
             </dd>
           </div>
           <div class="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-3">
+            <dt class="font-semibold text-slate-500">タイムテーブル公開状態</dt>
+            <dd class="sm:col-span-2">
+              <% if @festival.timetable_published? %>
+                <span class="inline-flex items-center gap-2 rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700">
+                  <span class="inline-block h-2 w-2 rounded-full bg-emerald-500"></span>
+                  公開中
+                </span>
+              <% else %>
+                <span class="inline-flex items-center gap-2 rounded-full bg-slate-200 px-3 py-1 text-xs font-semibold text-slate-600">
+                  <span class="inline-block h-2 w-2 rounded-full bg-slate-400"></span>
+                  非公開
+                </span>
+              <% end %>
+            </dd>
+          </div>
+          <div class="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-3">
             <dt class="font-semibold text-slate-500">登録日時</dt>
             <dd class="sm:col-span-2 text-xs text-slate-500"><%= l(@festival.created_at, format: :long) %></dd>
           </div>


### PR DESCRIPTION
## 概要
- 管理画面のストロングパラメータに timetable_published を追加し、チェックボックスの値が保存されるように修正。
- フェス詳細画面に「タイムテーブル公開状態」のバッジを追加し、公開/非公開を一目で確認できるように修正。

## 対応Issue
なし

## 関連Issue
- #63 

## 特記事項
なし