### PR TITLE
[add]タイムテーブル一覧ページ追加

### DIFF
--- a/app/controllers/timetables_controller.rb
+++ b/app/controllers/timetables_controller.rb
@@ -1,0 +1,22 @@
+class TimetablesController < ApplicationController
+  def index
+    @status = params[:status]
+    @status = "upcoming" unless %w[upcoming past].include?(@status)
+    @status_labels = { "upcoming" => "開催前", "past" => "開催済み" }
+
+    today = Date.current
+    base  = Festival.with_published_timetable.ordered
+
+    scoped =
+      case @status
+      when "past" then base.merge(Festival.past(today))
+      else             base.merge(Festival.upcoming(today))
+      end
+
+    @q = scoped.ransack(params[:q])
+    result = @q.result(distinct: true)
+
+    pagy_params = request.query_parameters.merge(status: @status)
+    @pagy, @festivals = pagy(result, items: 20, params: pagy_params)
+  end
+end

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -17,7 +17,7 @@ focus-visible:outline-offset-2 focus-visible:outline-white" %>
       <span class="whitespace-nowrap">アーティスト</span>
     <% end %>
 
-    <%= link_to '#', class: nav_link_classes do %>
+    <%= link_to timetables_path, class: nav_link_classes do %>
       <%= icon 'timetable' %>
       <span class="whitespace-nowrap">タイムテーブル</span>
     <% end %>

--- a/app/views/timetables/index.html.erb
+++ b/app/views/timetables/index.html.erb
@@ -1,0 +1,47 @@
+<div class="min-h-screen px-4 py-6">
+  <div class="mx-auto max-w-5xl space-y-6">
+    <header class="space-y-4">
+      <h1 class="text-2xl font-bold text-slate-900">タイムテーブルを見たいフェスを選択</h1>
+      <p class="text-sm text-slate-600">公開中のタイムテーブルのみ表示しています。</p>
+      <div class="flex justify-center">
+        <div class="inline-flex rounded-xl bg-white p-1 shadow-md">
+          <% preserved_query = request.query_parameters.except(:page, :status) %>
+          <% @status_labels.each do |key, label| %>
+            <% active = @status == key %>
+            <% link_classes = [
+              "rounded-lg px-4 py-2 text-sm font-semibold transition",
+              active ? "bg-rose-500 text-white shadow-sm" : "text-slate-500 hover:text-rose-500"
+            ].join(" ") %>
+            <% path_options = preserved_query.merge(status: key) %>
+            <%= link_to label,
+                        timetables_path(path_options),
+                        class: link_classes %>
+          <% end %>
+        </div>
+      </div>
+    </header>
+
+    <%= render "shared/search_form",
+               query: @q,
+               url: timetables_path,
+               placeholder: "フェス名を入力",
+               status: @status %>
+
+    <section class="grid gap-3 md:grid-cols-2 md:gap-4">
+      <% if @festivals.any? %>
+        <% @festivals.each do |festival| %>
+          <div class="w-full">
+            <%= render "shared/nav_stack_button",
+                       label: festival.name,
+                       url: "#" %>
+          </div>
+        <% end %>
+      <% else %>
+        <p class="rounded-xl bg-white px-4 py-12 text-center text-sm text-slate-500 shadow md:col-span-2">
+          公開中のタイムテーブルはありません
+        </p>
+      <% end %>
+    </section>
+  </div>
+  <%= render "shared/pagination", pagy: @pagy %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,18 @@
 Rails.application.routes.draw do
   devise_for :users
+
   root "home#top"
   get "up" => "rails/health#show", as: :rails_health_check
+
   resources :artists, only: [:index, :show] do
     resources :festivals, only: [:index], controller: :festivals
   end
+
+  resources :timetables, only: [:index]
+
   resources :festivals, only: [:index, :show] do
     resources :artists, only: [:index], controller: :artists
+    member { get :timetable }
   end
 
   namespace :admin do


### PR DESCRIPTION
## 概要
- タイムテーブル一覧用ルートを追加。
- 公開設定済みフェスのみを検索・ページングするTimetablesController#index を実装。
- タイムテーブル選択ページを新規作成し、各フェスのタイムテーブル詳細へ遷移できるカードを配置。
- フッターの「タイムテーブル」ボタンにリンクを追加。
- FestivalsController#timetableを追加し、こちらをタイムテーブル詳細のアクションとする。

## 対応Issue
- close #63 

## 関連Issue
- #55 

## 特記事項
- 個別フェスのタイムテーブル表示はフェスに紐づく詳細機能なので、FestivalsController#timetable で member ルート（/festivals/:id/timetable）として持たせることで REST 的にも自然に対応。