### PR TITLE
[add]タイムテーブル詳細ページ・機能追加

### DIFF
--- a/app/helpers/timetables_helper.rb
+++ b/app/helpers/timetables_helper.rb
@@ -1,0 +1,53 @@
+module TimetablesHelper
+  PerformanceBlock = Struct.new(
+    :top_percent,
+    :height_percent,
+    :start_label,
+    :end_label,
+    :artist_name,
+    keyword_init: true
+  )
+
+  def timeline_performance_block(performance, timeline_start:, timeline_end:, timezone:, column_height:)
+    start_time = align_time_to_day(performance.starts_at, timeline_start, timezone)
+    return unless start_time
+
+    end_time =
+      align_time_to_day(performance.ends_at, timeline_start, timezone) ||
+      start_time + 30.minutes
+
+    return if end_time <= timeline_start || start_time >= timeline_end
+
+    clipped_start = [start_time, timeline_start].max
+    clipped_end   = [end_time,   timeline_end].min
+    return if clipped_end <= clipped_start
+
+    total_minutes      = (timeline_end - timeline_start) / 60.0
+    duration_minutes   = [(clipped_end - clipped_start) / 60.0, 15].max
+    offset_minutes     = [((clipped_start - timeline_start) / 60.0), 0].max
+
+    top_percent        = ((offset_minutes / total_minutes) * 100).clamp(0, 100)
+    remaining_percent  = [100 - top_percent, 0].max
+    block_percent      = (duration_minutes / total_minutes) * 100
+    min_percent        = [(44.0 / column_height) * 100, remaining_percent].min
+    height_percent     = [[block_percent, min_percent].max, remaining_percent].min
+
+    PerformanceBlock.new(
+      top_percent:   top_percent,
+      height_percent: height_percent,
+      start_label:   start_time.strftime("%H:%M"),
+      end_label:     end_time&.strftime("%H:%M"),
+      artist_name:   performance.artist.name
+    )
+  end
+
+  private
+
+  def align_time_to_day(time, timeline_start, timezone)
+    return unless time
+
+    day   = timeline_start.to_date
+    local = time.in_time_zone(timezone)
+    timezone.local(day.year, day.month, day.day, local.hour, local.min, local.sec)
+  end
+end

--- a/app/views/festivals/_stage_column.html.erb
+++ b/app/views/festivals/_stage_column.html.erb
@@ -1,0 +1,46 @@
+<% hex = stage.color_hex %>
+<% text_color = stage_text_color(hex) %>
+<% total_seconds ||= ((timeline_end - timeline_start) / 1.second).to_i %>
+<% total_seconds = [total_seconds, 3600].max %>
+<% column_height ||= [total_seconds / 3600.0 * 56, 56].max %>
+
+<div class="flex h-full min-w-[90px] flex-1 flex-col rounded-xl bg-white shadow-sm sm:min-w-[150px]">
+  <div class="flex h-10 items-center justify-center rounded-t-xl px-2 text-center text-[11px] font-semibold uppercase tracking-wide sm:h-12 sm:px-3 sm:text-xs"
+       style="background-color: <%= hex %>; color: <%= text_color %>;">
+    <%= stage.name %>
+  </div>
+  <div class="relative overflow-hidden rounded-b-xl border border-slate-200 bg-slate-50"
+       style="height: <%= column_height %>px;">
+    <% time_markers.each do |marker_time| %>
+      <% next if marker_time <= timeline_start %>
+      <% marker_offset_seconds = ((marker_time - timeline_start) / 1.second).to_f %>
+      <% offset = marker_offset_seconds / total_seconds.to_f %>
+      <% next if offset.negative? || offset > 1 %>
+      <div class="absolute inset-x-0 border-t border-slate-200/70" style="top: <%= offset * 100 %>%;"></div>
+    <% end %>
+
+    <div class="relative h-full w-full">
+      <% Array(performances).each do |performance| %>
+        <% block = timeline_performance_block(
+              performance,
+              timeline_start: timeline_start,
+              timeline_end: timeline_end,
+              timezone: timezone,
+              column_height: column_height
+            ) %>
+        <% next unless block %>
+        <div class="absolute inset-x-1.5 rounded-md px-2 py-1 text-[11px] font-semibold shadow-sm sm:inset-x-2 sm:px-3 sm:py-2 sm:text-xs"
+             style="top: <%= block.top_percent %>%; height: <%= block.height_percent %>%; background-color: <%= hex %>; color: <%= text_color %>;">
+          <div class="flex h-full flex-col justify-start gap-px text-left">
+            <div class="font-mono text-[9px] font-medium leading-none opacity-90 sm:text-[10px]">
+              <div><%= block.start_label %><% if block.end_label %> – <%= block.end_label %><% end %></div>
+            </div>
+            <div class="flex-1 overflow-hidden text-ellipsis text-[11px] font-bold leading-snug sm:text-xs">
+              <%= block.artist_name %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/festivals/timetable.html.erb
+++ b/app/views/festivals/timetable.html.erb
@@ -1,0 +1,128 @@
+<% raw_total_seconds = ((@timeline_end - @timeline_start) / 1.second).to_i %>
+<% total_seconds = [raw_total_seconds, 3600].max %>
+<% hour_height = 56 %>
+<% column_height = [total_seconds / 3600.0 * hour_height, hour_height].max %>
+
+<div class="min-h-screen px-4 pb-24 pt-6">
+  <div class="mx-auto flex max-w-6xl flex-col gap-6">
+    <header class="rounded-3xl border border-slate-200 bg-gradient-to-b from-sky-100 via-slate-100 to-white p-6 shadow-lg shadow-slate-200/60">
+      <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">タイムテーブル</p>
+      <h1 class="mt-2 text-2xl font-extrabold text-slate-900"><%= @festival.name %></h1>
+
+      <div class="mt-4 flex flex-wrap items-center gap-4 text-sm text-slate-600">
+        <div class="flex flex-wrap items-center gap-3">
+          <div>
+            <span class="text-xs font-semibold uppercase tracking-wide text-slate-500">日付</span>
+            <div class="text-base font-semibold text-slate-900"><%= format_date_with_weekday(@selected_day.date) %></div>
+          </div>
+          <div class="flex items-center gap-4 text-xs">
+            <div>
+              <span class="font-semibold uppercase tracking-wide text-slate-500">開場</span>
+              <div class="font-mono text-sm text-slate-800">
+                <%= @selected_day.doors_at ? @selected_day.doors_at.in_time_zone(@timezone).strftime("%H:%M") : "—" %>
+              </div>
+            </div>
+            <div>
+              <span class="font-semibold uppercase tracking-wide text-slate-500">開演</span>
+              <div class="font-mono text-sm text-slate-800">
+                <%= @selected_day.start_at ? @selected_day.start_at.in_time_zone(@timezone).strftime("%H:%M") : "—" %>
+              </div>
+            </div>
+            <div>
+              <span class="font-semibold uppercase tracking-wide text-slate-500">終演</span>
+              <div class="font-mono text-sm text-slate-800">
+                <%= @selected_day.end_at ? @selected_day.end_at.in_time_zone(@timezone).strftime("%H:%M") : "—" %>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <% if @selected_day.note.present? %>
+        <p class="mt-4 text-xs text-slate-600"><%= @selected_day.note %></p>
+      <% end %>
+
+      <div class="mt-6 flex justify-center">
+        <div class="inline-flex overflow-hidden rounded-xl bg-white p-1 shadow-md">
+          <% @festival_days.each do |day| %>
+            <% active = day.id == @selected_day.id %>
+            <% label = day.date.strftime("%-m/%-d") %>
+            <% button_classes = [
+              "rounded-lg px-3 py-2 text-sm font-semibold transition",
+              active ? "bg-rose-500 text-white shadow-sm" : "text-slate-500 hover:text-rose-500"
+            ].join(" ") %>
+            <%= link_to label,
+                        timetable_festival_path(@festival, date: day.date.to_s),
+                        class: button_classes %>
+          <% end %>
+        </div>
+      </div>
+    </header>
+
+    <section class="rounded-3xl border border-slate-200 bg-gradient-to-b from-slate-100 via-white to-slate-100 p-3 shadow-lg shadow-slate-200/60 sm:p-4">
+      <div class="overflow-x-auto overflow-y-hidden">
+        <div class="flex items-start gap-2 md:gap-3">
+          <div class="flex flex-shrink-0 flex-col items-center">
+            <div class="h-10 w-14 sm:h-12 sm:w-16"></div>
+            <div class="relative w-14 rounded-xl border border-slate-200 bg-white/80 text-[10px] font-semibold text-slate-600 sm:w-16 sm:text-[11px]" style="height: <%= column_height %>px;">
+              <% @time_markers.each do |marker| %>
+                <% next if marker <= @timeline_start %>
+                <% marker_offset_seconds = ((marker - @timeline_start) / 1.second).to_f %>
+                <% offset_ratio = marker_offset_seconds / total_seconds.to_f %>
+                <% next if offset_ratio.negative? || offset_ratio > 1 %>
+                <div class="absolute inset-x-0 border-t border-slate-200/70" style="top: <%= offset_ratio * 100 %>%;"></div>
+              <% end %>
+              <% marker_count = @time_markers.length %>
+              <% @time_markers.each_with_index do |marker, index| %>
+                <% marker_offset_seconds = ((marker - @timeline_start) / 1.second).to_f %>
+                <% offset_ratio = marker_offset_seconds / total_seconds.to_f %>
+                <% next if offset_ratio.negative? || offset_ratio > 1 %>
+                <% top_percent = offset_ratio * 100 %>
+                <% base_classes = "absolute inset-x-0 text-center pointer-events-none" %>
+                <% if index.zero? %>
+                  <div class="<%= [base_classes, 'translate-y-0'].join(' ') %>" style="top: <%= top_percent %>%;">
+                    <span class="inline-block rounded bg-white/90 px-[3px] py-0.5 font-mono text-[9px] text-slate-700 shadow-sm sm:px-1 sm:text-[10px]">
+                      <%= marker.in_time_zone(@timezone).strftime("%H:%M") %>
+                    </span>
+                  </div>
+                <% else %>
+                  <% translation_class =
+                       if index == marker_count - 1
+                         '-translate-y-full'
+                       else
+                         '-translate-y-1/2'
+                       end %>
+                  <div class="<%= [base_classes, translation_class].join(' ') %>" style="top: <%= top_percent %>%;">
+                    <span class="inline-block rounded bg-white/90 px-[3px] py-0.5 font-mono text-[9px] text-slate-700 shadow-sm sm:px-1 sm:text-[10px]">
+                      <%= marker.in_time_zone(@timezone).strftime("%H:%M") %>
+                    </span>
+                  </div>
+                <% end %>
+              <% end %>
+            </div>
+          </div>
+
+          <div class="flex flex-1 gap-2 md:gap-3">
+            <% if @stages.any? %>
+              <% @stages.each do |stage| %>
+                <%= render "stage_column",
+                           stage: stage,
+                           performances: @performances_by_stage[stage.id],
+                           timeline_start: @timeline_start,
+                           timeline_end: @timeline_end,
+                           time_markers: @time_markers,
+                           timezone: @timezone,
+                           total_seconds: total_seconds,
+                           column_height: column_height %>
+              <% end %>
+            <% else %>
+              <div class="flex h-full min-h-[320px] flex-1 items-center justify-center rounded-2xl border border-dashed border-slate-300 bg-white/70 px-6 py-12 text-center text-sm text-slate-500">
+                登録されたステージがありません
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</div>

--- a/app/views/timetables/index.html.erb
+++ b/app/views/timetables/index.html.erb
@@ -33,7 +33,7 @@
           <div class="w-full">
             <%= render "shared/nav_stack_button",
                        label: festival.name,
-                       url: "#" %>
+                       url: timetable_festival_path(festival) %>
           </div>
         <% end %>
       <% else %>


### PR DESCRIPTION
## 概要
- フェスごとのタイムテーブル詳細ページ（views/festivals/timetable.html.erb）を追加
- 各ステージごとの列を表示するためのパーシャル（_stage_column.html.erb）を追加
- パーシャル内で使用するロジックを含んだヘルパーファイル（timetables_helper.rb）を追加
- views/timetables/index.html.erbにタイムテーブル詳細へのパスを追加

## 対応Issue
- close #55 

## 関連Issue
なし

## 特記事項
なし