### PR TITLE
[fix]spotify_artirt_idの無いアーティスト登録の修正

### DIFF
--- a/app/controllers/admin/artists_controller.rb
+++ b/app/controllers/admin/artists_controller.rb
@@ -39,6 +39,8 @@ class Admin::ArtistsController < Admin::BaseController
   end
 
   def artist_params
-    params.require(:artist).permit(:name, :spotify_artist_id, :image_url)
+    params.require(:artist).permit(:name, :spotify_artist_id, :image_url).tap do |p|
+      p[:spotify_artist_id] = p[:spotify_artist_id].presence
+    end
   end
 end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -8,11 +8,14 @@ class Artist < ApplicationRecord
   def self.ransackable_attributes(_ = nil); %w[name]; end
   def self.ransackable_associations(_ = nil); []; end
 
+  # 空文字・前後空白を取り除いて nil 正規化
+  normalizes :spotify_artist_id, with: ->(v) { v&.strip.presence }
+
   # SpotifyのIDは Base62 22文字（例: 0OdUWJ0sBjDrqHygGUXeCF）
   validates :spotify_artist_id,
            format: { with: /\A[0-9A-Za-z]{22}\z/, message: "is invalid (22-char base62)" },
-           allow_blank: true,
-           uniqueness: true
+           allow_nil: true,
+           uniqueness: { allow_nil: true }
 
   # 将来: has_many :performances など
 end


### PR DESCRIPTION
## 概要
- spotify_artist_idが " "（空配列）で登録されており、nil化することでレコードの重複のバリエーションに引っかからないように改善。

## 対応Issue
なし

## 関連Issue
なし

## 特記事項
なし
