### PR TITLE
[add]stage_performance入力時の改良

### DIFF
--- a/app/controllers/admin/stage_performances_controller.rb
+++ b/app/controllers/admin/stage_performances_controller.rb
@@ -1,5 +1,6 @@
 class Admin::StagePerformancesController < Admin::BaseController
   before_action :set_stage_performance, only: %i[show edit update destroy]
+  before_action :prepare_form_options, only: %i[new create edit update]
 
   def index
     @pagy, @stage_performances =
@@ -63,5 +64,13 @@ class Admin::StagePerformancesController < Admin::BaseController
     return "同一ステージで時間帯が重複しています（確定枠）。時間を見直してください。" if msg.include?("no_overlap_on_same_stage_when_scheduled")
     return "同一スロットの二重登録です（確定枠）。開始時刻・ステージ・アーティストの組み合わせを見直してください。" if msg.include?("uniq_sp_slot_when_scheduled")
     "保存に失敗しました（DB制約）。入力内容を確認してください。"
+  end
+
+  def prepare_form_options
+    @festival_days = FestivalDay.includes(:festival).order(:date)
+    @artists = Artist.order(:name)
+    @stages_by_festival = Stage.order(:sort_order, :id).group_by(&:festival_id)
+    @festival_day_festival_map = @festival_days.map { |day| [day.id, day.festival_id] }.to_h
+    @festival_day_date_map = @festival_days.map { |day| [day.id, day.date.iso8601] }.to_h
   end
 end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -15,3 +15,6 @@ application.register("spotify-artist-search", SpotifyArtistSearchController)
 
 import NestedFormController from "./nested_form_controller"
 application.register("nested-form", NestedFormController)
+
+import StagePerformanceFormController from "./stage_performance_form_controller"
+application.register("stage-performance-form", StagePerformanceFormController)

--- a/app/javascript/controllers/stage_performance_form_controller.js
+++ b/app/javascript/controllers/stage_performance_form_controller.js
@@ -1,0 +1,152 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["festivalDaySelect", "stageSelect", "startsAt", "endsAt"]
+  static values = {
+    stages: Object,
+    festivalDayMap: Object,
+    festivalDayDates: Object,
+    stagePlaceholder: String,
+    minuteStep: Number
+  }
+
+  connect() {
+    this.applyMinuteStep()
+    this.updateStageOptions()
+    this.syncDateInputs()
+  }
+
+  onFestivalDayChange() {
+    this.updateStageOptions()
+    this.syncDateInputs()
+  }
+
+  updateStageOptions() {
+    if (!this.hasStageSelectTarget || !this.hasFestivalDaySelectTarget) return
+
+    const stageSelect = this.stageSelectTarget
+    const previousValue = stageSelect.value
+    const festivalDayId = this.festivalDaySelectTarget.value
+
+    this.resetStageOptions(stageSelect)
+
+    if (!festivalDayId) return
+
+    const festivalId = this.festivalDayMapValue[festivalDayId]
+    if (!festivalId) return
+
+    const festivalKey = String(festivalId)
+    const stages = this.stagesValue[festivalKey] || []
+    stages.forEach((stage) => {
+      const option = document.createElement("option")
+      option.value = String(stage.id)
+      option.textContent = stage.name
+      stageSelect.appendChild(option)
+    })
+
+    if (stages.some((stage) => String(stage.id) === previousValue)) {
+      stageSelect.value = previousValue
+    }
+  }
+
+  syncDateInputs() {
+    if (!this.hasFestivalDaySelectTarget) return
+
+    const festivalDayId = this.festivalDaySelectTarget.value
+    if (!festivalDayId) return
+
+    const isoDate = this.festivalDayDatesValue[festivalDayId]
+    if (!isoDate) return
+
+    if (this.hasStartsAtTarget) {
+      this.syncDateForInput(this.startsAtTarget, isoDate)
+    }
+    if (this.hasEndsAtTarget) {
+      this.syncDateForInput(this.endsAtTarget, isoDate)
+    }
+  }
+
+  syncDateForInput(input, isoDate) {
+    const defaultTime = input.dataset.defaultTime || "00:00"
+    const currentValue = input.value
+
+    if (currentValue) {
+      const [currentDate, currentTime] = currentValue.split("T")
+      const normalizedTime = (currentTime || defaultTime).slice(0, 5)
+      if (currentDate !== isoDate) {
+        input.value = `${isoDate}T${normalizedTime}`
+      }
+    } else {
+      input.value = `${isoDate}T${defaultTime}`
+    }
+
+    this.normalizeTimeForInput(input)
+  }
+
+  resetStageOptions(stageSelect) {
+    const placeholderText = this.stagePlaceholderValue || ""
+    stageSelect.innerHTML = ""
+
+    const placeholder = document.createElement("option")
+    placeholder.value = ""
+    placeholder.textContent = placeholderText
+    stageSelect.appendChild(placeholder)
+  }
+
+  normalizeTime(event) {
+    this.normalizeTimeForInput(event.target)
+  }
+
+  normalizeTimeForInput(input) {
+    if (!input) return
+    const value = input.value
+    if (!value) return
+
+    const [date, timePart] = value.split("T")
+    if (!timePart) return
+
+    const [time] = timePart.split(".")
+    const segments = time.split(":")
+    if (segments.length < 2) return
+
+    const hour = parseInt(segments[0], 10)
+    const minute = parseInt(segments[1], 10)
+    if (Number.isNaN(hour) || Number.isNaN(minute)) return
+
+    const normalizedMinute = this.normalizeMinuteValue(minute)
+    if (normalizedMinute === minute) return
+
+    const normalizedTime = `${this.pad(hour)}:${this.pad(normalizedMinute)}`
+    input.value = `${date}T${normalizedTime}`
+  }
+
+  applyMinuteStep() {
+    const stepSeconds = this.minuteStepInSeconds()
+    if (this.hasStartsAtTarget) {
+      this.startsAtTarget.step = stepSeconds
+      this.normalizeTimeForInput(this.startsAtTarget)
+    }
+    if (this.hasEndsAtTarget) {
+      this.endsAtTarget.step = stepSeconds
+      this.normalizeTimeForInput(this.endsAtTarget)
+    }
+  }
+
+  normalizeMinuteValue(minute) {
+    const step = this.minuteStepAmount()
+    if (step <= 0) return minute
+    return Math.floor(minute / step) * step
+  }
+
+  minuteStepInSeconds() {
+    return this.minuteStepAmount() * 60
+  }
+
+  minuteStepAmount() {
+    return this.hasMinuteStepValue ? this.minuteStepValue : 5
+  }
+
+  pad(value) {
+    return String(value).padStart(2, "0")
+  }
+}

--- a/app/views/admin/stage_performances/_form.html.erb
+++ b/app/views/admin/stage_performances/_form.html.erb
@@ -1,21 +1,37 @@
 <% stage_performance = local_assigns.fetch(:stage_performance, @stage_performance) %>
+<% stage_placeholder = "(未定)" %>
+<% stage_options = @stages_by_festival.transform_values { |stages| stages.map { |stage| { id: stage.id, name: stage.name } } } %>
+<% stage_collection = @stages_by_festival.values.flatten %>
 
-<%= form_with model: [:admin, stage_performance], class: "space-y-6" do |f| %>
+<%= form_with model: [:admin, stage_performance],
+      class: "space-y-6",
+      data: {
+        controller: "stage-performance-form",
+        "stage-performance-form-stages-value": json_escape(stage_options.to_json),
+        "stage-performance-form-festival-day-map-value": json_escape(@festival_day_festival_map.to_json),
+        "stage-performance-form-festival-day-dates-value": json_escape(@festival_day_date_map.to_json),
+        "stage-performance-form-stage-placeholder-value": stage_placeholder,
+        "stage-performance-form-minute-step-value": 5
+      } do |f| %>
   <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm space-y-6">
     <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
       <div>
         <%= f.label :festival_day_id, "日程", class: "block text-sm font-semibold text-slate-700" %>
         <%= f.collection_select :festival_day_id,
-              FestivalDay.includes(:festival).order(:date),
+              @festival_days,
               :id,
               ->(d) { "#{d.festival.name} / #{d.date.strftime('%Y/%m/%d')}" },
               {},
-              class: "mt-2 w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200" %>
+              class: "mt-2 w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200",
+              data: {
+                action: "change->stage-performance-form#onFestivalDayChange",
+                "stage-performance-form-target": "festivalDaySelect"
+              } %>
       </div>
       <div>
         <%= f.label :artist_id, "アーティスト", class: "block text-sm font-semibold text-slate-700" %>
         <%= f.collection_select :artist_id,
-              Artist.order(:name),
+              @artists,
               :id,
               :name,
               {},
@@ -26,11 +42,14 @@
     <div>
       <%= f.label :stage_id, "ステージ（確定時）", class: "block text-sm font-semibold text-slate-700" %>
       <%= f.collection_select :stage_id,
-            Stage.order(:sort_order, :id),
+            stage_collection,
             :id,
             :name,
-            { include_blank: "(未定)" },
-            class: "mt-2 w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200" %>
+            { include_blank: stage_placeholder },
+            class: "mt-2 w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200",
+            data: {
+              "stage-performance-form-target": "stageSelect"
+            } %>
       <p class="mt-2 text-xs text-slate-500">status が scheduled の場合は必須です。</p>
     </div>
 
@@ -38,12 +57,24 @@
       <div>
         <%= f.label :starts_at, "開始", class: "block text-sm font-semibold text-slate-700" %>
         <%= f.datetime_local_field :starts_at,
-              class: "mt-2 w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200" %>
+              class: "mt-2 w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200",
+              step: 300,
+              data: {
+                "stage-performance-form-target": "startsAt",
+                default_time: "00:00",
+                action: "input->stage-performance-form#normalizeTime change->stage-performance-form#normalizeTime"
+              } %>
       </div>
       <div>
         <%= f.label :ends_at, "終了", class: "block text-sm font-semibold text-slate-700" %>
         <%= f.datetime_local_field :ends_at,
-              class: "mt-2 w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200" %>
+              class: "mt-2 w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200",
+              step: 300,
+              data: {
+                "stage-performance-form-target": "endsAt",
+                default_time: "00:00",
+                action: "input->stage-performance-form#normalizeTime change->stage-performance-form#normalizeTime"
+              } %>
       </div>
     </div>
 


### PR DESCRIPTION
## 概要
 - adminユーザーがstage_performance入力時に、選んだフェスによって紐づいているステージ情報を出しわけるように修正。
 - 開始・終了日時のデフォルト値の日付をフェス日程に合うように修正。
 - 開始・終了時間の入力値が５分刻みになるように修正。

## 対応Issue
なし

## 関連Issue
- #44 

## 特記事項
- ブラウザ組み込みの datetime-local ピッカーは UI 上の候補分を制限できないため、表示では 0〜59 が並ぶが、今回の変更で 5 の倍数以外は即座に補正され保存されなくなるように修正した。