### PR TITLE
[fix]タイムテーブル詳細ページのUI調整

### DIFF
--- a/app/views/festivals/_stage_column.html.erb
+++ b/app/views/festivals/_stage_column.html.erb
@@ -33,9 +33,9 @@
              style="top: <%= block.top_percent %>%; height: <%= block.height_percent %>%; background-color: <%= hex %>; color: <%= text_color %>;">
           <div class="flex h-full flex-col justify-start gap-px text-left">
             <div class="font-mono text-[9px] font-medium leading-none opacity-90 sm:text-[10px]">
-              <div><%= block.start_label %><% if block.end_label %> – <%= block.end_label %><% end %></div>
+              <div class="whitespace-nowrap"><%= block.start_label %><% if block.end_label %> – <%= block.end_label %><% end %></div>
             </div>
-            <div class="flex-1 overflow-hidden text-ellipsis text-[11px] font-bold leading-snug sm:text-xs">
+            <div class="flex-1 overflow-hidden text-ellipsis text-[11px] font-bold leading-tight sm:text-xs">
               <%= block.artist_name %>
             </div>
           </div>


### PR DESCRIPTION
## 概要
- タイムテーブル詳細ページのステージ列パーシャル（_stage_column.html.erb）における、スマホ表示した場合にアーティスト名が改行で表示されない問題を改善。
- ステージ列パーシャル（_stage_column.html.erb）における、スマホ表示した場合に開始-終了時間が改行される問題を改善。

## 対応Issue
なし

## 関連Issue
- #55 

## 特記事項
- 今後文字サイズの大きさも考慮し、ステージ列のUI改善予定。