### PR TITLE
[add]スマホビューで各ボタンタップ時のアクションを追加

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -29,7 +29,25 @@ h1, h2, h3, h4 {
   }
 
   .nav-stack-button {
-    @apply block w-full rounded-xl bg-white px-5 py-3 text-left font-semibold text-slate-900 shadow-sm ring-1 ring-slate-200 transition hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-500;
+    @apply block w-full rounded-xl bg-white px-5 py-3 text-left font-semibold text-slate-900 shadow-sm ring-1 ring-slate-200 interactive-lift focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-500;
+  }
+
+  .interactive-lift {
+    @apply transition duration-150 ease-out touch-manipulation hover:-translate-y-0.5 hover:shadow-md active:-translate-y-0.5 active:shadow-md;
+  }
+
+  .is-touch-active {
+    @apply -translate-y-0.5 shadow-md;
+  }
+
+  @screen sm {
+    .interactive-lift {
+      @apply hover:-translate-y-1 hover:shadow-lg active:-translate-y-1 active:shadow-lg;
+    }
+
+    .is-touch-active {
+      @apply -translate-y-1 shadow-lg;
+    }
   }
 }
 

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -18,3 +18,6 @@ application.register("nested-form", NestedFormController)
 
 import StagePerformanceFormController from "./stage_performance_form_controller"
 application.register("stage-performance-form", StagePerformanceFormController)
+
+import TapFeedbackController from "./tap_feedback_controller"
+application.register("tap-feedback", TapFeedbackController)

--- a/app/javascript/controllers/tap_feedback_controller.js
+++ b/app/javascript/controllers/tap_feedback_controller.js
@@ -1,0 +1,52 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Adds and removes a CSS class while a touch interaction is active so mobile taps
+// feel the same as hover interactions on desktop.
+export default class extends Controller {
+  static values = {
+    releaseDelay: { type: Number, default: 120 },
+    activeClass: { type: String, default: "is-touch-active" }
+  }
+
+  connect() {
+    this.handleTouchStart = this.handleTouchStart.bind(this)
+    this.handleTouchEnd = this.handleTouchEnd.bind(this)
+    this.handleTouchCancel = this.handleTouchCancel.bind(this)
+
+    this.element.addEventListener("touchstart", this.handleTouchStart, { passive: true })
+    this.element.addEventListener("touchend", this.handleTouchEnd, { passive: true })
+    this.element.addEventListener("touchcancel", this.handleTouchCancel, { passive: true })
+  }
+
+  disconnect() {
+    this.element.removeEventListener("touchstart", this.handleTouchStart)
+    this.element.removeEventListener("touchend", this.handleTouchEnd)
+    this.element.removeEventListener("touchcancel", this.handleTouchCancel)
+    this.clearReleaseTimeout()
+  }
+
+  handleTouchStart() {
+    this.clearReleaseTimeout()
+    this.element.classList.add(this.activeClassValue)
+  }
+
+  handleTouchEnd() {
+    this.clearReleaseTimeout()
+    this.releaseTimeout = setTimeout(() => {
+      this.element.classList.remove(this.activeClassValue)
+      this.releaseTimeout = null
+    }, this.releaseDelayValue)
+  }
+
+  handleTouchCancel() {
+    this.clearReleaseTimeout()
+    this.element.classList.remove(this.activeClassValue)
+  }
+
+  clearReleaseTimeout() {
+    if (!this.releaseTimeout) return
+
+    clearTimeout(this.releaseTimeout)
+    this.releaseTimeout = null
+  }
+}

--- a/app/views/admin/artists/_form.html.erb
+++ b/app/views/admin/artists/_form.html.erb
@@ -8,8 +8,9 @@
              data-spotify-artist-search-target="query"
              data-action="keydown.enter->spotify-artist-search#onSearch" />
       <button type="button"
-              class="sm:w-auto px-4 py-2 rounded bg-slate-800 text-white hover:bg-slate-900"
-              data-action="click->spotify-artist-search#onSearch">
+              class="sm:w-auto px-4 py-2 rounded bg-slate-800 text-white shadow-sm interactive-lift hover:bg-slate-900"
+              data-action="click->spotify-artist-search#onSearch"
+              data-controller="tap-feedback">
         Search
       </button>
     </div>
@@ -42,6 +43,6 @@
   </div>
 
   <div class="pt-4">
-    <%= f.submit "登録する", class: "px-4 py-2 rounded bg-[#F95858] text-white" %>
+    <%= f.submit "登録する", class: "px-4 py-2 rounded bg-[#F95858] text-white shadow-sm interactive-lift hover:bg-[#e14f4f] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#F95858]", data: { controller: "tap-feedback" } %>
   </div>
 <% end %>

--- a/app/views/admin/festivals/_festival_day_fields.html.erb
+++ b/app/views/admin/festivals/_festival_day_fields.html.erb
@@ -24,6 +24,6 @@
   </div>
   <div class="flex justify-end">
     <%= f.hidden_field :_destroy, value: "0" %>
-    <button class="text-xs font-semibold text-red-600 transition hover:text-red-700" data-action="click->nested-form#remove" type="button">削除</button>
+    <button class="text-xs font-semibold text-red-600 rounded px-2 py-1 shadow-sm interactive-lift hover:text-red-700" data-action="click->nested-form#remove" data-controller="tap-feedback" type="button">削除</button>
   </div>
 </div>

--- a/app/views/admin/festivals/_stage_fields.html.erb
+++ b/app/views/admin/festivals/_stage_fields.html.erb
@@ -22,6 +22,6 @@
 
   <%= f.hidden_field :_destroy, value: "0" %>
   <div class="md:col-span-3">
-    <button class="text-xs px-2 py-1 rounded border" data-action="click->nested-form#remove" type="button">削除</button>
+    <button class="text-xs px-2 py-1 rounded border shadow-sm interactive-lift" data-action="click->nested-form#remove" data-controller="tap-feedback" type="button">削除</button>
   </div>
 </div>

--- a/app/views/admin/festivals/setup.html.erb
+++ b/app/views/admin/festivals/setup.html.erb
@@ -21,8 +21,9 @@
     <!-- 追加ボタン -->
     <div class="mt-2">
       <button type="button"
-              class="text-sm text-[#F95858]"
-              data-action="click->nested-form#add">
+              class="text-sm text-[#F95858] rounded px-3 py-1 shadow-sm interactive-lift hover:text-[#d94444]"
+              data-action="click->nested-form#add"
+              data-controller="tap-feedback">
         日程を追加
       </button>
     </div>
@@ -48,8 +49,9 @@
     <!-- 追加ボタン -->
     <div class="mt-2">
       <button type="button"
-              class="text-sm text-[#F95858]"
-              data-action="click->nested-form#add">
+              class="text-sm text-[#F95858] rounded px-3 py-1 shadow-sm interactive-lift hover:text-[#d94444]"
+              data-action="click->nested-form#add"
+              data-controller="tap-feedback">
         ステージを追加
       </button>
     </div>
@@ -62,5 +64,5 @@
     </template>
   </div>
 
-  <%= f.submit "適用する", class: "px-4 py-2 rounded bg-[#F95858] text-white" %>
+  <%= f.submit "適用する", class: "px-4 py-2 rounded bg-[#F95858] text-white shadow-sm interactive-lift hover:bg-[#e14f4f] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#F95858]", data: { controller: "tap-feedback" } %>
 <% end %>

--- a/app/views/artists/show.html.erb
+++ b/app/views/artists/show.html.erb
@@ -40,12 +40,14 @@
 
       <div class="space-y-3">
         <%= link_to artist_festivals_path(@artist),
-                    class: "block w-full rounded-2xl bg-indigo-500 py-3 text-center text-sm font-bold text-white shadow-md transition hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-400" do %>
+                    class: "block w-full rounded-2xl bg-indigo-500 py-3 text-center text-sm font-bold text-white shadow-md interactive-lift hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-400",
+                    data: { controller: "tap-feedback" } do %>
           出演フェス一覧
         <% end %>
 
         <%= link_to "#",
-                    class: "block w-full rounded-2xl bg-indigo-500 py-3 text-center text-sm font-bold text-white shadow-md transition hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-400" do %>
+                    class: "block w-full rounded-2xl bg-indigo-500 py-3 text-center text-sm font-bold text-white shadow-md interactive-lift hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-400",
+                    data: { controller: "tap-feedback" } do %>
           アーティスト予習リストへ
         <% end %>
       </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -46,13 +46,16 @@
         に同意の上、ご登録をお願いします
       </p>
 
-      <%= f.submit "会員登録する", class: "w-full rounded-full bg-[#F95858] px-4 py-2 text-base font-bold tracking-wide text-white shadow-sm transition hover:bg-[#ea4a4a] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#F95858]" %>
+      <%= f.submit "会員登録する",
+            class: "w-full rounded-full bg-[#F95858] px-4 py-2 text-base font-bold tracking-wide text-white shadow-sm interactive-lift hover:bg-[#ea4a4a] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#F95858]",
+            data: { controller: "tap-feedback" } %>
     <% end %>
 
     <div class="mt-4">
       <%= link_to "#",
-            class: "flex w-full items-center justify-center gap-2 rounded-full bg-slate-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-600",
-            role: "button" do %>
+            class: "flex w-full items-center justify-center gap-2 rounded-full bg-slate-600 px-4 py-2 text-base font-semibold text-white shadow-sm interactive-lift hover:bg-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-600",
+            role: "button",
+            data: { controller: "tap-feedback" } do %>
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 533.5 544.3" class="h-5 w-5" aria-hidden="true">
           <path fill="#4285f4" d="M533.5 278.4c0-17.4-1.6-34.1-4.7-50.2H272.1v95.0h146.9c-6.3 34.0-25.2 62.9-53.5 82.1v68.2h86.6c50.7-46.7 81.4-115.4 81.4-195.1Z"/>
           <path fill="#34a853" d="M272.1 544.3c72.6 0 133.6-24.0 178.2-65.8l-86.6-68.2c-24.0 16.1-54.7 25.7-91.6 25.7-70.5 0-130.2-47.6-151.6-111.6H32.9v70.2c44.7 88.3 136.6 149.7 239.2 149.7Z"/>
@@ -69,7 +72,8 @@
     <div class="mt-2">
       <%= link_to "ログイン画面へ",
             new_session_path(resource_name),
-            class: "flex w-full items-center justify-center rounded-full bg-[#5858F9] px-4 py-2 text-base font-bold tracking-wide text-white shadow-sm transition hover:bg-[#4b4be0] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#5858F9]" %>
+            class: "flex w-full items-center justify-center rounded-full bg-[#5858F9] px-4 py-2 text-base font-bold tracking-wide text-white shadow-sm interactive-lift hover:bg-[#4b4be0] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#5858F9]",
+            data: { controller: "tap-feedback" } %>
     </div>
   </div>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -28,7 +28,9 @@
         </div>
       <% end %>
 
-      <%= f.submit "ログインする", class: "w-full rounded-full bg-[#F95858] px-4 py-2 text-base font-bold tracking-wide text-white shadow-sm transition hover:bg-[#ea4a4a] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#F95858]" %>
+      <%= f.submit "ログインする",
+            class: "w-full rounded-full bg-[#F95858] px-4 py-2 text-base font-bold tracking-wide text-white shadow-sm interactive-lift hover:bg-[#ea4a4a] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#F95858]",
+            data: { controller: "tap-feedback" } %>
     <% end %>
 
     <div class="mt-2 text-center">
@@ -37,8 +39,9 @@
 
     <div class="mt-4">
       <%= link_to "#",
-            class: "flex w-full items-center justify-center gap-2 rounded-full bg-slate-600 px-4 py-2 text-base font-semibold text-white shadow-sm transition hover:bg-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-600",
-            role: "button" do %>
+            class: "flex w-full items-center justify-center gap-2 rounded-full bg-slate-600 px-4 py-2 text-base font-semibold text-white shadow-sm interactive-lift hover:bg-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-600",
+            role: "button",
+            data: { controller: "tap-feedback" } do %>
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 533.5 544.3" class="h-5 w-5" aria-hidden="true">
           <path fill="#4285f4" d="M533.5 278.4c0-17.4-1.6-34.1-4.7-50.2H272.1v95.0h146.9c-6.3 34.0-25.2 62.9-53.5 82.1v68.2h86.6c50.7-46.7 81.4-115.4 81.4-195.1Z"/>
           <path fill="#34a853" d="M272.1 544.3c72.6 0 133.6-24.0 178.2-65.8l-86.6-68.2c-24.0 16.1-54.7 25.7-91.6 25.7-70.5 0-130.2-47.6-151.6-111.6H32.9v70.2c44.7 88.3 136.6 149.7 239.2 149.7Z"/>
@@ -55,7 +58,8 @@
     <div class="mt-2">
       <%= link_to "新規会員登録",
             new_registration_path(resource_name),
-            class: "flex w-full items-center justify-center rounded-full bg-[#5858F9] px-4 py-2 text-base font-bold tracking-wide text-white shadow-sm transition hover:bg-[#4b4be0] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#5858F9]" %>
+            class: "flex w-full items-center justify-center rounded-full bg-[#5858F9] px-4 py-2 text-base font-bold tracking-wide text-white shadow-sm interactive-lift hover:bg-[#4b4be0] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#5858F9]",
+            data: { controller: "tap-feedback" } %>
     </div>
   </div>
 </div>

--- a/app/views/festivals/_stage_column.html.erb
+++ b/app/views/festivals/_stage_column.html.erb
@@ -29,7 +29,8 @@
               column_height: column_height
             ) %>
         <% next unless block %>
-        <div class="absolute inset-x-1.5 rounded-md px-2 py-1 text-[11px] font-semibold shadow-sm sm:inset-x-2 sm:px-3 sm:py-2 sm:text-xs"
+        <div class="absolute inset-x-1.5 rounded-md px-2 py-1 text-[11px] font-semibold shadow-sm interactive-lift sm:inset-x-2 sm:px-3 sm:py-2 sm:text-xs"
+             data-controller="tap-feedback"
              style="top: <%= block.top_percent %>%; height: <%= block.height_percent %>%; background-color: <%= hex %>; color: <%= text_color %>;">
           <div class="flex h-full flex-col justify-start gap-px text-left">
             <div class="font-mono text-[9px] font-medium leading-none opacity-90 sm:text-[10px]">

--- a/app/views/festivals/show.html.erb
+++ b/app/views/festivals/show.html.erb
@@ -59,15 +59,18 @@
 
       <div class="space-y-3">
         <%= link_to festival_artists_path(@festival),
-                    class: "block w-full rounded-2xl bg-indigo-500 py-3 text-center text-sm font-bold text-white shadow-md transition hover:bg-indigo-400" do %>
+                    class: "block w-full rounded-2xl bg-indigo-500 py-3 text-center text-sm font-bold text-white shadow-md interactive-lift hover:bg-indigo-400",
+                    data: { controller: "tap-feedback" } do %>
           出演アーティスト一覧へ
         <% end %>
         <%= link_to "#",
-                    class: "block w-full rounded-2xl bg-indigo-500 py-3 text-center text-sm font-bold text-white shadow-md transition hover:bg-indigo-400" do %>
+                    class: "block w-full rounded-2xl bg-indigo-500 py-3 text-center text-sm font-bold text-white shadow-md interactive-lift hover:bg-indigo-400",
+                    data: { controller: "tap-feedback" } do %>
           タイムテーブルへ
         <% end %>
         <%= link_to "#",
-                    class: "block w-full rounded-2xl bg-indigo-500 py-3 text-center text-sm font-bold text-white shadow-md transition hover:bg-indigo-400" do %>
+                    class: "block w-full rounded-2xl bg-indigo-500 py-3 text-center text-sm font-bold text-white shadow-md interactive-lift hover:bg-indigo-400",
+                    data: { controller: "tap-feedback" } do %>
           フェス予習リストへ
         <% end %>
       </div>

--- a/app/views/shared/_artist_card.html.erb
+++ b/app/views/shared/_artist_card.html.erb
@@ -1,6 +1,7 @@
 <div class="relative h-full">
   <%= link_to artist_path(artist),
-              class: "flex h-full w-full flex-col items-center rounded-3xl border border-slate-200 bg-white p-4 pb-12 shadow-sm transition hover:-translate-y-1 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-400" do %>
+              class: "flex h-full w-full flex-col items-center rounded-3xl border border-slate-200 bg-white p-4 pb-12 shadow-sm interactive-lift focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-400",
+              data: { controller: "tap-feedback" } do %>
     <div class="aspect-square w-full overflow-hidden rounded-2xl border border-slate-200 bg-slate-50">
       <% if artist.image_url.present? %>
       <%= image_tag artist.image_url,
@@ -23,7 +24,7 @@
     <%= link_to "https://open.spotify.com/artist/#{artist.spotify_artist_id}",
                 target: "_blank",
                 rel: "noopener",
-                class: "absolute bottom-3 right-3 z-10 inline-flex items-center justify-center transition hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-400" do %>
+                class: "absolute bottom-3 right-3 z-10 inline-flex items-center justify-center rounded-full transition hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-400" do %>
       <span class="sr-only"><%= "#{artist.name} をSpotifyで開く" %></span>
       <%= image_tag "spotify_icon.png",
                     alt: "",

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,5 +1,5 @@
 <% nav_link_classes = "flex flex-1 flex-col items-center gap-1 rounded-xl py-2 text-[11px] md:text-[13px] 
-font-bold tracking-tight transition hover:bg-[#ea4a4a]/60 focus-visible:outline focus-visible:outline-2 
+font-bold tracking-tight shadow-sm interactive-lift hover:bg-[#ea4a4a]/60 focus-visible:outline focus-visible:outline-2 
 focus-visible:outline-offset-2 focus-visible:outline-white" %>
 
 <nav class="fixed inset-x-0 bottom-0 z-40 bg-[#F95858] text-white shadow-[0_-8px_24px_rgba(0,0,0,0.2)]">
@@ -7,27 +7,27 @@ focus-visible:outline-offset-2 focus-visible:outline-white" %>
     class="mx-auto flex w-full max-w-screen-md items-end justify-between gap-2 px-4 pt-2
           pb-[calc(env(safe-area-inset-bottom,0px)+0.5rem)]"
   >
-    <%= link_to festivals_path, class: nav_link_classes do %>
+    <%= link_to festivals_path, class: nav_link_classes, data: { controller: "tap-feedback" } do %>
       <%= icon 'fes' %>
       <span class="whitespace-nowrap">フェス</span>
     <% end %>
 
-    <%= link_to artists_path, class: nav_link_classes do %>
+    <%= link_to artists_path, class: nav_link_classes, data: { controller: "tap-feedback" } do %>
       <%= icon 'artists' %>
       <span class="whitespace-nowrap">アーティスト</span>
     <% end %>
 
-    <%= link_to timetables_path, class: nav_link_classes do %>
+    <%= link_to timetables_path, class: nav_link_classes, data: { controller: "tap-feedback" } do %>
       <%= icon 'timetable' %>
       <span class="whitespace-nowrap">タイムテーブル</span>
     <% end %>
 
-    <%= link_to '#', class: nav_link_classes do %>
+    <%= link_to '#', class: nav_link_classes, data: { controller: "tap-feedback" } do %>
       <%= icon 'practice' %>
       <span class="whitespace-nowrap">予習</span>
     <% end %>
 
-    <%= link_to '#', class: nav_link_classes do %>
+    <%= link_to '#', class: nav_link_classes, data: { controller: "tap-feedback" } do %>
       <%= icon 'checklist' %>
       <span class="whitespace-nowrap">持ち物</span>
     <% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -13,7 +13,8 @@
       <button
         type="button"
         onclick="history.back()"
-        class="flex h-10 w-10 items-center justify-center rounded-full transition hover:bg-[#ea4a4a]/50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+        class="flex h-10 w-10 items-center justify-center rounded-full shadow-sm interactive-lift hover:bg-[#ea4a4a]/50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+        data-controller="tap-feedback"
         aria-label="前の画面に戻る"
       >
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="h-6 w-6">
@@ -30,12 +31,13 @@
 
     <button
       type="button"
-      class="flex h-10 w-10 items-center justify-center rounded-full transition hover:bg-[#ea4a4a]/50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+      class="flex h-10 w-10 items-center justify-center rounded-full shadow-sm interactive-lift hover:bg-[#ea4a4a]/50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
       aria-label="メニューを開く"
       data-action="click->side-menu#toggle"
       data-side-menu-target="button"
       aria-controls="app-side-menu"
       aria-expanded="false"
+      data-controller="tap-feedback"
     >
       <span class="sr-only">メニュー</span>
       <span class="relative flex h-5 w-6 flex-col items-center justify-between">

--- a/app/views/shared/_nav_stack_button.html.erb
+++ b/app/views/shared/_nav_stack_button.html.erb
@@ -1,3 +1,3 @@
-<%= link_to url, class: "nav-stack-button" do %>
+<%= link_to url, class: "nav-stack-button", data: { controller: "tap-feedback" } do %>
   <span><%= label %></span>
 <% end %>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -16,7 +16,8 @@
 
     <%= f.submit "検索",
       class: "inline-flex h-12 min-w-[90px] flex-shrink-0 items-center justify-center rounded-lg bg-gradient-to-r from-indigo-500 
-             to-violet-500 px-4 text-sm font-semibold text-white shadow-sm transition hover:from-indigo-600 hover:to-violet-600 
-             focus:outline-none focus:ring-2 focus:ring-indigo-200 whitespace-nowrap" %>
+             to-violet-500 px-4 text-sm font-semibold text-white shadow-sm interactive-lift hover:from-indigo-600 hover:to-violet-600 
+             focus:outline-none focus:ring-2 focus:ring-indigo-200 whitespace-nowrap",
+      data: { controller: "tap-feedback" } %>
   </div>
 <% end %>


### PR DESCRIPTION
## 概要
- 新たにタップ時のstimulusコントローラ（tap_feedback_controller.js）を追加。
- 各ボタンにdata: { controller: "tap-feedback" }を追加し、タップ時にわずかに浮き上がるアクションを加えることで、UX向上へ。

## 対応Issue
なし

## 関連Issue
なし

## 特記事項