### PR TITLE
[fix]CSSクラス未定義によるデプロイエラー解消

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -29,7 +29,7 @@ h1, h2, h3, h4 {
   }
 
   .nav-stack-button {
-    @apply block w-full rounded-xl bg-white px-5 py-3 text-left font-semibold text-slate-900 shadow-sm ring-1 ring-slate-200 interactive-lift focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-500;
+    @apply block w-full rounded-xl bg-white px-5 py-3 text-left font-semibold text-slate-900 shadow-sm ring-1 ring-slate-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-500;
   }
 
   .interactive-lift {

--- a/app/views/shared/_nav_stack_button.html.erb
+++ b/app/views/shared/_nav_stack_button.html.erb
@@ -1,3 +1,3 @@
-<%= link_to url, class: "nav-stack-button", data: { controller: "tap-feedback" } do %>
+<%= link_to url, class: "nav-stack-button interactive-lift", data: { controller: "tap-feedback" } do %>
   <span><%= label %></span>
 <% end %>


### PR DESCRIPTION
## 概要
- デプロイ時のTailwindCSSクラスが読み込めないエラーの解消。
- application.tailwind.cssファイルで定義したクラスをそのファイル内の別のクラス定義内で使用していたことによるエラー。
- パーシャル内に定義したクラスを書くことで解消。

## 対応Issue
なし

## 関連Issue
なし

## 特記事項
- Tailwind CSS 4 では、@apply の引数に「Tailwind がまだ知らないカスタムクラス」を書くと unknown utility エラーになる。