### PR TITLE
[fix]タイムテーブル詳細ページの見た目・機能の修正

### DIFF
--- a/app/controllers/festivals_controller.rb
+++ b/app/controllers/festivals_controller.rb
@@ -78,11 +78,20 @@ class FestivalsController < ApplicationController
     end
 
     @time_markers = []
-    marker = @timeline_start
+    @time_markers << @timeline_start
+
+    marker =
+      if @timeline_start.min.zero? && @timeline_start.sec.zero?
+        @timeline_start + 1.hour
+      else
+        (@timeline_start + 1.hour).change(min: 0, sec: 0)
+      end
+
     while marker <= @timeline_end
       @time_markers << marker
       marker += 1.hour
     end
+
     @time_markers << @timeline_end unless @time_markers.last == @timeline_end
   end
 

--- a/app/helpers/timetables_helper.rb
+++ b/app/helpers/timetables_helper.rb
@@ -29,8 +29,19 @@ module TimetablesHelper
     top_percent        = ((offset_minutes / total_minutes) * 100).clamp(0, 100)
     remaining_percent  = [100 - top_percent, 0].max
     block_percent      = (duration_minutes / total_minutes) * 100
-    min_percent        = [(44.0 / column_height) * 100, remaining_percent].min
-    height_percent     = [[block_percent, min_percent].max, remaining_percent].min
+
+    min_block_height_px = 24.0
+    min_height_percent  = (min_block_height_px / column_height) * 100
+    block_height_px     = (block_percent / 100.0) * column_height
+
+    adjusted_percent =
+      if block_height_px < min_block_height_px
+        [min_height_percent, remaining_percent].min
+      else
+        block_percent
+      end
+
+    height_percent = [adjusted_percent, remaining_percent].min
 
     PerformanceBlock.new(
       top_percent:   top_percent,

--- a/app/views/festivals/_stage_column.html.erb
+++ b/app/views/festivals/_stage_column.html.erb
@@ -2,7 +2,8 @@
 <% text_color = stage_text_color(hex) %>
 <% total_seconds ||= ((timeline_end - timeline_start) / 1.second).to_i %>
 <% total_seconds = [total_seconds, 3600].max %>
-<% column_height ||= [total_seconds / 3600.0 * 56, 56].max %>
+<% hour_height_px = 90 %>
+<% column_height ||= [total_seconds / 3600.0 * hour_height_px, hour_height_px].max %>
 
 <div class="flex h-full min-w-[90px] flex-1 flex-col rounded-xl bg-white shadow-sm sm:min-w-[150px]">
   <div class="flex h-10 items-center justify-center rounded-t-xl px-2 text-center text-[11px] font-semibold uppercase tracking-wide sm:h-12 sm:px-3 sm:text-xs"
@@ -29,18 +30,19 @@
               column_height: column_height
             ) %>
         <% next unless block %>
-        <div class="absolute inset-x-1.5 rounded-md px-2 py-1 text-[11px] font-semibold shadow-sm interactive-lift sm:inset-x-2 sm:px-3 sm:py-2 sm:text-xs"
-             data-controller="tap-feedback"
-             style="top: <%= block.top_percent %>%; height: <%= block.height_percent %>%; background-color: <%= hex %>; color: <%= text_color %>;">
+        <%= link_to artist_path(performance.artist),
+                    class: "absolute inset-x-1.5 rounded-md px-2 py-1 text-[11px] font-semibold shadow-sm interactive-lift sm:inset-x-2 sm:px-3 sm:py-2 sm:text-xs",
+                    data: { controller: "tap-feedback" },
+                    style: "top: #{block.top_percent}%; height: #{block.height_percent}%; background-color: #{hex}; color: #{text_color};" do %>
           <div class="flex h-full flex-col justify-start gap-px text-left">
             <div class="font-mono text-[9px] font-medium leading-none opacity-90 sm:text-[10px]">
-              <div class="whitespace-nowrap"><%= block.start_label %><% if block.end_label %> – <%= block.end_label %><% end %></div>
+              <div class="whitespace-nowrap"><%= block.start_label %><% if block.end_label %>-<%= block.end_label %><% end %></div>
             </div>
             <div class="flex-1 overflow-hidden text-ellipsis text-[11px] font-bold leading-tight sm:text-xs">
               <%= block.artist_name %>
             </div>
           </div>
-        </div>
+        <% end %>
       <% end %>
     </div>
   </div>

--- a/app/views/festivals/timetable.html.erb
+++ b/app/views/festivals/timetable.html.erb
@@ -1,6 +1,6 @@
 <% raw_total_seconds = ((@timeline_end - @timeline_start) / 1.second).to_i %>
 <% total_seconds = [raw_total_seconds, 3600].max %>
-<% hour_height = 56 %>
+<% hour_height = 90 %>
 <% column_height = [total_seconds / 3600.0 * hour_height, hour_height].max %>
 
 <div class="min-h-screen px-4 pb-24 pt-6">


### PR DESCRIPTION
## 概要
- タイムテーブル表示にて、各アーティストのパフォーマンス枠の時間に視覚的な差が出るように調整（30分枠と40分枠の見た目の差が以前はなかった）
- フェスの開場時間が8:30のような半端な時刻でも、最初のマーカーを開始時刻（8:30）に固定しつつ、次のマーカーを9:00にそろえ、その後は1時間刻み（10:00, 11:00, …）で並ぶように調整。
- タイムテーブル内の各アーティストのパフォーマンスブロックがアーティスト詳細ページへのリンクになるように調整。

## 対応Issue
- #55 

## 関連Issue
なし

## 特記事項
なし