### PR TITLE
[add]マイタイムテーブル作成ビュー・コントローラ・ルーティング追加

### DIFF
--- a/app/controllers/my_timetables_controller.rb
+++ b/app/controllers/my_timetables_controller.rb
@@ -1,0 +1,155 @@
+class MyTimetablesController < ApplicationController
+  before_action :authenticate_user!, except: :show
+  before_action :set_festival!
+  before_action :set_selected_day!
+  before_action :prepare_timetable_context!, only: [:build, :show]
+  before_action :set_timetable_owner!, only: :show
+
+  def build
+    @picked_ids = current_user
+                    .user_timetable_entries
+                    .joins(:stage_performance)
+                    .where(stage_performances: { festival_day_id: @selected_day.id })
+                    .pluck(:stage_performance_id)
+  end
+
+  def create
+    ids = Array(params[:stage_performance_ids]).map!(&:to_i)
+
+    allowed_ids = StagePerformance.where(festival_day_id: @selected_day.id).pluck(:id)
+    ids &= allowed_ids
+
+    ActiveRecord::Base.transaction do
+      current_user.user_timetable_entries
+                  .joins(:stage_performance)
+                  .where(stage_performances: { festival_day_id: @selected_day.id })
+                  .delete_all
+
+      ids.uniq.each do |sp_id|
+        current_user.user_timetable_entries.create!(stage_performance_id: sp_id)
+      end
+    end
+
+    redirect_to my_timetable_festival_path(@festival, date: @selected_day.date.to_s, user_id: current_user.id),
+                notice: "マイタイムテーブルを保存しました。"
+  end
+
+  def show
+    @performances = @timetable_owner
+                      .my_stage_performances
+                      .includes(:artist, :stage, :festival_day)
+                      .where(stage_performances: { festival_day_id: @selected_day.id })
+                      .order(:starts_at, :ends_at, :id)
+    @conflicts = detect_conflicts(@performances)
+
+    @selected_performance_ids = @performances.map(&:id)
+  end
+
+  private
+
+  def set_festival!
+    festival_id = params[:festival_id] || params[:id]
+    @festival = Festival.find(festival_id)
+  end
+
+  def set_selected_day!
+    @festival_days = @festival.timetable_days
+    raise ActiveRecord::RecordNotFound if @festival_days.blank?
+
+    @selected_day =
+      if params[:date].present?
+        @festival.festival_days.find_by!(date: Date.parse(params[:date]))
+      else
+        @festival_days.first
+      end
+  end
+
+  def detect_conflicts(list)
+    conflicts = Set.new
+    last_end = nil
+    last_id  = nil
+    list.each do |sp|
+      if last_end && sp.starts_at && sp.ends_at && sp.starts_at < last_end
+        conflicts << last_id
+        conflicts << sp.id
+      end
+      last_end = sp.ends_at || last_end
+      last_id  = sp.id
+    end
+    conflicts
+  end
+
+  def set_timetable_owner!
+    @timetable_owner =
+      if params[:user_id].present?
+        User.find(params[:user_id])
+      elsif user_signed_in?
+        current_user
+      else
+        raise ActiveRecord::RecordNotFound
+      end
+  end
+
+  def prepare_timetable_context!
+    @timezone = ActiveSupport::TimeZone[@festival.timezone] || Time.zone
+    @stages   = @festival.stages.order(:sort_order, :id)
+
+    @performances =
+      @festival
+        .stage_performances_for(@selected_day)
+        .scheduled
+        .includes(:stage, :artist)
+
+    @performances_by_stage =
+      @performances
+        .reject { |performance| performance.stage_id.blank? }
+        .group_by(&:stage_id)
+
+    @performances_without_stage =
+      @performances
+        .select { |performance| performance.stage_id.blank? }
+
+    day_date  = @selected_day.date
+    day_start = @timezone.local(day_date.year, day_date.month, day_date.day).beginning_of_day
+    day_end   = day_start.end_of_day
+
+    compose_time = lambda do |time|
+      next nil unless time
+      local = time.in_time_zone(@timezone)
+      @timezone.local(day_date.year, day_date.month, day_date.day, local.hour, local.min, local.sec)
+    rescue
+      nil
+    end
+
+    doors_at = compose_time.call(@selected_day.doors_at)
+    start_at = compose_time.call(@selected_day.start_at)
+    end_at   = compose_time.call(@selected_day.end_at)
+
+    default_start = doors_at || start_at || @timezone.local(day_date.year, day_date.month, day_date.day, 9, 0, 0)
+    default_end   = end_at || (start_at || default_start) + 8.hours
+
+    @timeline_start = [[default_start, day_start].max, day_end].min
+    @timeline_end   = [[default_end, day_start].max, day_end].min
+
+    if @timeline_end <= @timeline_start
+      @timeline_end = [@timeline_start + 1.hour, day_end].min
+    end
+
+    @time_markers = []
+    @time_markers << @timeline_start
+
+    marker =
+      if @timeline_start.min.zero? && @timeline_start.sec.zero?
+        @timeline_start + 1.hour
+      else
+        (@timeline_start + 1.hour).change(min: 0, sec: 0)
+      end
+
+    while marker <= @timeline_end
+      @time_markers << marker
+      marker += 1.hour
+    end
+
+    @time_markers << @timeline_end unless @time_markers.last == @timeline_end
+  end
+end

--- a/app/views/festivals/timetable.html.erb
+++ b/app/views/festivals/timetable.html.erb
@@ -57,6 +57,14 @@
           <% end %>
         </div>
       </div>
+      <% if user_signed_in? %>
+        <div class="mt-4 flex justify-center">
+          <%= link_to "この日程のマイタイムテーブルを作成",
+                      build_my_timetable_festival_path(@festival, date: @selected_day.date.to_s),
+                      class: "inline-flex items-center justify-center rounded-2xl bg-indigo-500 px-6 py-3 text-sm font-bold text-white shadow-md interactive-lift hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500",
+                      data: { controller: "tap-feedback" } %>
+        </div>
+      <% end %>
     </header>
 
     <section class="rounded-3xl border border-slate-200 bg-gradient-to-b from-slate-100 via-white to-slate-100 p-3 shadow-lg shadow-slate-200/60 sm:p-4">

--- a/app/views/my_timetables/_stage_column_picker.html.erb
+++ b/app/views/my_timetables/_stage_column_picker.html.erb
@@ -1,0 +1,59 @@
+<% hex = stage.color_hex %>
+<% text_color = stage_text_color(hex) %>
+<% total_seconds ||= ((timeline_end - timeline_start) / 1.second).to_i %>
+<% total_seconds = [total_seconds, 3600].max %>
+<% hour_height_px = 90 %>
+<% column_height ||= [total_seconds / 3600.0 * hour_height_px, hour_height_px].max %>
+
+<div class="flex h-full min-w-[90px] flex-1 flex-col rounded-xl bg-white shadow-sm sm:min-w-[150px]">
+  <div class="flex h-10 items-center justify-center rounded-t-xl px-2 text-center text-[11px] font-semibold uppercase tracking-wide sm:h-12 sm:px-3 sm:text-xs"
+       style="background-color: <%= hex %>; color: <%= text_color %>;">
+    <%= stage.name %>
+  </div>
+  <div class="relative overflow-hidden rounded-b-xl border border-slate-200 bg-slate-50"
+       style="height: <%= column_height %>px;">
+    <% time_markers.each do |marker_time| %>
+      <% next if marker_time <= timeline_start %>
+      <% marker_offset_seconds = ((marker_time - timeline_start) / 1.second).to_f %>
+      <% offset = marker_offset_seconds / total_seconds.to_f %>
+      <% next if offset.negative? || offset > 1 %>
+      <div class="absolute inset-x-0 border-t border-slate-200/70" style="top: <%= offset * 100 %>%;"></div>
+    <% end %>
+
+    <div class="relative h-full w-full">
+      <% Array(performances).each do |performance| %>
+        <% block = timeline_performance_block(
+              performance,
+              timeline_start: timeline_start,
+              timeline_end: timeline_end,
+              timezone: timezone,
+              column_height: column_height
+            ) %>
+        <% next unless block %>
+        <% input_id = "stage-performance-#{performance.id}" %>
+        <div class="absolute inset-x-1.5 sm:inset-x-2"
+             style="top: <%= block.top_percent %>%; height: <%= block.height_percent %>%;">
+          <%= check_box_tag "stage_performance_ids[]",
+                             performance.id,
+                             picked_ids.include?(performance.id),
+                             id: input_id,
+                             class: "peer sr-only" %>
+          <label for="<%= input_id %>"
+                 class="flex h-full cursor-pointer flex-col justify-start gap-px rounded-md border border-white/50 px-1.5 py-1 text-left text-[11px] font-semibold shadow-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 peer-checked:border-2 peer-checked:border-rose-500 peer-checked:shadow-lg interactive-lift sm:px-2.5 sm:py-2 sm:text-xs"
+                 data-controller="tap-feedback"
+                 style="background-color: <%= hex %>; color: <%= text_color %>;">
+            <div class="font-mono text-[9px] font-medium leading-none opacity-90 sm:text-[10px]">
+              <div class="whitespace-nowrap">
+                <%= block.start_label %><% if block.end_label %>-<%= block.end_label %><% end %>
+              </div>
+            </div>
+            <div class="flex-1 overflow-hidden text-ellipsis whitespace-normal text-[11px] font-bold leading-tight sm:text-xs">
+              <%= performance.artist.name %>
+            </div>
+            <span class="mt-auto hidden text-[10px] font-semibold uppercase tracking-wide peer-checked:inline opacity-100">選択中</span>
+          </label>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/my_timetables/_stage_column_show.html.erb
+++ b/app/views/my_timetables/_stage_column_show.html.erb
@@ -1,0 +1,64 @@
+<% hex = stage.color_hex %>
+<% text_color = stage_text_color(hex) %>
+<% unselected_hex = "#e2e8f0" %>
+<% unselected_text_color = "#1f2937" %>
+<% total_seconds ||= ((timeline_end - timeline_start) / 1.second).to_i %>
+<% total_seconds = [total_seconds, 3600].max %>
+<% hour_height_px = 90 %>
+<% column_height ||= [total_seconds / 3600.0 * hour_height_px, hour_height_px].max %>
+<% selected_ids ||= [] %>
+
+<div class="flex h-full min-w-[90px] flex-1 flex-col rounded-xl bg-white shadow-sm sm:min-w-[150px]">
+  <div class="flex h-10 items-center justify-center rounded-t-xl px-2 text-center text-[11px] font-semibold uppercase tracking-wide sm:h-12 sm:px-3 sm:text-xs"
+       style="background-color: <%= hex %>; color: <%= text_color %>;">
+    <%= stage.name %>
+  </div>
+  <div class="relative overflow-hidden rounded-b-xl border border-slate-200 bg-slate-50"
+       style="height: <%= column_height %>px;">
+    <% time_markers.each do |marker_time| %>
+      <% next if marker_time <= timeline_start %>
+      <% marker_offset_seconds = ((marker_time - timeline_start) / 1.second).to_f %>
+      <% offset = marker_offset_seconds / total_seconds.to_f %>
+      <% next if offset.negative? || offset > 1 %>
+      <div class="absolute inset-x-0 border-t border-slate-200/70" style="top: <%= offset * 100 %>%;"></div>
+    <% end %>
+
+    <div class="relative h-full w-full">
+      <% Array(performances).each do |performance| %>
+        <% block = timeline_performance_block(
+              performance,
+              timeline_start: timeline_start,
+              timeline_end: timeline_end,
+              timezone: timezone,
+              column_height: column_height
+            ) %>
+        <% next unless block %>
+        <% selected = selected_ids.include?(performance.id) %>
+        <% block_bg_color = selected ? hex : unselected_hex %>
+        <% block_text_color = selected ? text_color : unselected_text_color %>
+        <% border_color = selected ? "rgba(255,255,255,0.7)" : "rgba(148,163,184,0.7)" %>
+        <% opacity_class = selected ? "" : "opacity-80" %>
+        <% label_classes = [
+             "absolute inset-x-1.5 rounded-md px-2 py-1 text-[11px] font-semibold shadow-sm sm:inset-x-2 sm:px-3 sm:py-2 sm:text-xs",
+             "interactive-lift",
+             opacity_class
+           ].reject(&:blank?).join(" ") %>
+        <%= link_to artist_path(performance.artist),
+                    class: label_classes,
+                    data: { controller: "tap-feedback" },
+                    style: "top: #{block.top_percent}%; height: #{block.height_percent}%; background-color: #{block_bg_color}; color: #{block_text_color}; border: 1px solid #{border_color};" do %>
+          <div class="flex h-full flex-col justify-start gap-px text-left">
+            <div class="font-mono text-[9px] font-medium leading-none opacity-90 sm:text-[10px]">
+              <div class="whitespace-nowrap">
+                <%= block.start_label %><% if block.end_label %>-<%= block.end_label %><% end %>
+              </div>
+            </div>
+            <div class="flex-1 overflow-hidden text-ellipsis text-[11px] font-bold leading-tight sm:text-xs">
+              <%= block.artist_name %>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/my_timetables/build.html.erb
+++ b/app/views/my_timetables/build.html.erb
@@ -1,0 +1,165 @@
+<% raw_total_seconds = ((@timeline_end - @timeline_start) / 1.second).to_i %>
+<% total_seconds = [raw_total_seconds, 3600].max %>
+<% hour_height = 90 %>
+<% column_height = [total_seconds / 3600.0 * hour_height, hour_height].max %>
+
+<div class="min-h-screen px-4 pb-24 pt-6">
+  <div class="mx-auto flex max-w-6xl flex-col gap-6">
+    <header class="rounded-3xl border border-slate-200 bg-gradient-to-b from-sky-100 via-slate-100 to-white p-6 shadow-lg shadow-slate-200/60">
+      <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">マイタイムテーブル作成</p>
+      <h1 class="mt-2 text-2xl font-extrabold text-slate-900"><%= @festival.name %></h1>
+      <div class="mt-4 flex flex-wrap items-center gap-4 text-sm text-slate-600">
+        <div class="flex flex-wrap items-center gap-3">
+          <div>
+            <span class="text-xs font-semibold uppercase tracking-wide text-slate-500">日付</span>
+            <div class="text-base font-semibold text-slate-900"><%= format_date_with_weekday(@selected_day.date) %></div>
+          </div>
+          <div class="flex items-center gap-4 text-xs">
+            <div>
+              <span class="font-semibold uppercase tracking-wide text-slate-500">開場</span>
+              <div class="font-mono text-sm text-slate-800">
+                <%= @selected_day.doors_at ? @selected_day.doors_at.in_time_zone(@timezone).strftime("%H:%M") : "—" %>
+              </div>
+            </div>
+            <div>
+              <span class="font-semibold uppercase tracking-wide text-slate-500">開演</span>
+              <div class="font-mono text-sm text-slate-800">
+                <%= @selected_day.start_at ? @selected_day.start_at.in_time_zone(@timezone).strftime("%H:%M") : "—" %>
+              </div>
+            </div>
+            <div>
+              <span class="font-semibold uppercase tracking-wide text-slate-500">終演</span>
+              <div class="font-mono text-sm text-slate-800">
+                <%= @selected_day.end_at ? @selected_day.end_at.in_time_zone(@timezone).strftime("%H:%M") : "—" %>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <% if @selected_day.note.present? %>
+        <p class="mt-4 text-xs text-slate-600"><%= @selected_day.note %></p>
+      <% end %>
+
+      <p class="mt-4 text-sm text-slate-700">
+        見たいアーティストのブロックをタップして選択してください。選択した内容は「保存する」を押すとマイタイムテーブルに反映されます。
+      </p>
+    </header>
+
+    <%= form_with url: my_timetable_festival_path(@festival, date: @selected_day.date.to_s, user_id: current_user.id),
+                  method: :post,
+                  class: "flex flex-col gap-6" do %>
+      <section class="rounded-3xl border border-slate-200 bg-gradient-to-b from-slate-100 via-white to-slate-100 p-3 shadow-lg shadow-slate-200/60 sm:p-4">
+        <div class="overflow-x-auto overflow-y-hidden">
+          <div class="flex items-start gap-2 md:gap-3">
+            <div class="flex flex-shrink-0 flex-col items-center">
+              <div class="h-10 w-14 sm:h-12 sm:w-16"></div>
+              <div class="relative w-14 rounded-xl border border-slate-200 bg-white/80 text-[10px] font-semibold text-slate-600 sm:w-16 sm:text-[11px]"
+                   style="height: <%= column_height %>px;">
+                <% @time_markers.each do |marker| %>
+                  <% next if marker <= @timeline_start %>
+                  <% marker_offset_seconds = ((marker - @timeline_start) / 1.second).to_f %>
+                  <% offset_ratio = marker_offset_seconds / total_seconds.to_f %>
+                  <% next if offset_ratio.negative? || offset_ratio > 1 %>
+                  <div class="absolute inset-x-0 border-t border-slate-200/70"
+                       style="top: <%= offset_ratio * 100 %>%;"></div>
+                <% end %>
+                <% marker_count = @time_markers.length %>
+                <% @time_markers.each_with_index do |marker, index| %>
+                  <% marker_offset_seconds = ((marker - @timeline_start) / 1.second).to_f %>
+                  <% offset_ratio = marker_offset_seconds / total_seconds.to_f %>
+                  <% next if offset_ratio.negative? || offset_ratio > 1 %>
+                  <% top_percent = offset_ratio * 100 %>
+                  <% base_classes = "absolute inset-x-0 text-center pointer-events-none" %>
+                  <% if index.zero? %>
+                    <div class="<%= [base_classes, 'translate-y-0'].join(' ') %>"
+                         style="top: <%= top_percent %>%;">
+                      <span class="inline-block rounded bg-white/90 px-[3px] py-0.5 font-mono text-[9px] text-slate-700 shadow-sm sm:px-1 sm:text-[10px]">
+                        <%= marker.in_time_zone(@timezone).strftime("%H:%M") %>
+                      </span>
+                    </div>
+                  <% else %>
+                    <% translation_class =
+                         if index == marker_count - 1
+                           '-translate-y-full'
+                         else
+                           '-translate-y-1/2'
+                         end %>
+                    <div class="<%= [base_classes, translation_class].join(' ') %>"
+                         style="top: <%= top_percent %>%;">
+                      <span class="inline-block rounded bg-white/90 px-[3px] py-0.5 font-mono text-[9px] text-slate-700 shadow-sm sm:px-1 sm:text-[10px]">
+                        <%= marker.in_time_zone(@timezone).strftime("%H:%M") %>
+                      </span>
+                    </div>
+                  <% end %>
+                <% end %>
+              </div>
+            </div>
+
+            <div class="flex flex-1 gap-2 md:gap-3">
+              <% if @stages.any? %>
+                <% @stages.each do |stage| %>
+                  <%= render "stage_column_picker",
+                             stage: stage,
+                             performances: @performances_by_stage[stage.id],
+                             timeline_start: @timeline_start,
+                             timeline_end: @timeline_end,
+                             time_markers: @time_markers,
+                             timezone: @timezone,
+                             total_seconds: total_seconds,
+                             column_height: column_height,
+                             picked_ids: @picked_ids %>
+                <% end %>
+              <% else %>
+                <div class="flex h-full min-h-[320px] flex-1 items-center justify-center rounded-2xl border border-dashed border-slate-300 bg-white/70 px-6 py-12 text-center text-sm text-slate-500">
+                  登録されたステージがありません
+                </div>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <% if @performances_without_stage.present? %>
+        <section class="rounded-3xl border border-dashed border-slate-300 bg-white/80 p-4 shadow-sm">
+          <h2 class="text-sm font-bold text-slate-700">ステージ未設定の出演</h2>
+          <p class="mt-2 text-xs text-slate-500">以下の出演はステージが未設定のため、リスト形式で選択できます。</p>
+          <div class="mt-4 space-y-3">
+            <% @performances_without_stage.each do |performance| %>
+              <% checkbox_id = "stage-performance-#{performance.id}" %>
+              <div class="rounded-2xl border border-slate-200 bg-white p-3 shadow-sm">
+                <%= check_box_tag "stage_performance_ids[]",
+                                   performance.id,
+                                   @picked_ids.include?(performance.id),
+                                   id: checkbox_id,
+                                   class: "peer sr-only" %>
+                <label for="<%= checkbox_id %>"
+                       class="block w-full rounded-xl border border-transparent px-3 py-2 transition interactive-lift peer-checked:border-rose-500 peer-checked:bg-rose-50 peer-checked:shadow-md"
+                       data-controller="tap-feedback">
+                  <div class="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                      <div class="text-sm font-semibold text-slate-800">
+                        <%= performance.artist.name %>
+                      </div>
+                      <div class="text-xs font-mono text-slate-500">
+                        <%= performance.starts_at&.in_time_zone(@timezone)&.strftime("%H:%M") %> - <%= performance.ends_at&.in_time_zone(@timezone)&.strftime("%H:%M") %>
+                      </div>
+                    </div>
+                    <span class="mt-1 inline-flex items-center rounded-full border border-slate-300 px-3 py-1 text-xs font-semibold text-slate-600 transition peer-checked:border-rose-500 peer-checked:bg-rose-500 peer-checked:text-white sm:mt-0">
+                      <span class="hidden peer-checked:inline">選択中</span>
+                    </span>
+                  </div>
+                </label>
+              </div>
+            <% end %>
+          </div>
+        </section>
+      <% end %>
+
+      <div class="flex justify-end">
+        <%= submit_tag "保存する",
+                       class: "inline-flex items-center justify-center rounded-2xl bg-indigo-500 px-6 py-3 text-sm font-bold text-white shadow-md interactive-lift hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/my_timetables/show.html.erb
+++ b/app/views/my_timetables/show.html.erb
@@ -1,0 +1,163 @@
+<% raw_total_seconds = ((@timeline_end - @timeline_start) / 1.second).to_i %>
+<% total_seconds = [raw_total_seconds, 3600].max %>
+<% hour_height = 90 %>
+<% column_height = [total_seconds / 3600.0 * hour_height, hour_height].max %>
+
+<div class="min-h-screen px-4 pb-24 pt-6">
+  <div class="mx-auto flex max-w-6xl flex-col gap-6">
+    <header class="rounded-3xl border border-slate-200 bg-gradient-to-b from-indigo-100 via-white to-slate-100 p-6 shadow-lg shadow-slate-200/60">
+      <p class="text-xs font-semibold tracking-[0.3em] text-slate-500"><%= @timetable_owner.nickname %>のマイタイムテーブル</p>
+      <h1 class="mt-2 text-2xl font-extrabold text-slate-900"><%= @festival.name %></h1>
+      <div class="mt-4 flex flex-wrap items-center gap-4 text-sm text-slate-600">
+        <div class="flex flex-wrap items-center gap-3">
+          <div>
+            <span class="text-xs font-semibold uppercase tracking-wide text-slate-500">日付</span>
+            <div class="text-base font-semibold text-slate-900"><%= format_date_with_weekday(@selected_day.date) %></div>
+          </div>
+          <div class="flex items-center gap-4 text-xs">
+            <div>
+              <span class="font-semibold uppercase tracking-wide text-slate-500">開場</span>
+              <div class="font-mono text-sm text-slate-800">
+                <%= @selected_day.doors_at ? @selected_day.doors_at.in_time_zone(@timezone).strftime("%H:%M") : "—" %>
+              </div>
+            </div>
+            <div>
+              <span class="font-semibold uppercase tracking-wide text-slate-500">開演</span>
+              <div class="font-mono text-sm text-slate-800">
+                <%= @selected_day.start_at ? @selected_day.start_at.in_time_zone(@timezone).strftime("%H:%M") : "—" %>
+              </div>
+            </div>
+            <div>
+              <span class="font-semibold uppercase tracking-wide text-slate-500">終演</span>
+              <div class="font-mono text-sm text-slate-800">
+                <%= @selected_day.end_at ? @selected_day.end_at.in_time_zone(@timezone).strftime("%H:%M") : "—" %>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <% if @selected_day.note.present? %>
+        <p class="mt-4 text-xs text-slate-600"><%= @selected_day.note %></p>
+      <% end %>
+
+      <div class="mt-6 flex flex-col items-center gap-3 sm:flex-row sm:justify-between">
+        <% if @timetable_owner == current_user %>
+          <%= link_to "マイタイムテーブルを編集する",
+                      build_my_timetable_festival_path(@festival, date: @selected_day.date.to_s),
+                      class: "inline-flex items-center justify-center rounded-2xl bg-indigo-500 px-5 py-2.5 text-sm font-bold text-white shadow-md interactive-lift hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500",
+                      data: { controller: "tap-feedback" } %>
+        <% end %>
+      </div>
+    </header>
+
+    <% if @performances.blank? %>
+      <div class="rounded-3xl border border-dashed border-slate-300 bg-white/80 px-6 py-12 text-center text-sm text-slate-600 shadow-sm">
+        この日に選択した出演がまだありません。<br class="hidden sm:block" />
+        <%= link_to "マイタイムテーブルを作成する",
+                    build_my_timetable_festival_path(@festival, date: @selected_day.date.to_s),
+                    class: "inline-flex items-center justify-center rounded-full bg-indigo-500 px-4 py-2 text-sm font-semibold text-white shadow-md interactive-lift hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 mt-4",
+                    data: { controller: "tap-feedback" } %>
+      </div>
+    <% else %>
+      <% if @conflicts.present? %>
+        <div class="rounded-2xl border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-700 shadow-sm">
+          選択した出演の一部に時間帯が重なるものがあります。現地での移動時間にご注意ください。
+        </div>
+      <% end %>
+
+      <section class="rounded-3xl border border-slate-200 bg-gradient-to-b from-slate-100 via-white to-slate-100 p-3 shadow-lg shadow-slate-200/60 sm:p-4">
+        <div class="overflow-x-auto overflow-y-hidden">
+          <div class="flex items-start gap-2 md:gap-3">
+            <div class="flex flex-shrink-0 flex-col items-center">
+              <div class="h-10 w-14 sm:h-12 sm:w-16"></div>
+              <div class="relative w-14 rounded-xl border border-slate-200 bg-white/80 text-[10px] font-semibold text-slate-600 sm:w-16 sm:text-[11px]"
+                   style="height: <%= column_height %>px;">
+                <% @time_markers.each do |marker| %>
+                  <% next if marker <= @timeline_start %>
+                  <% marker_offset_seconds = ((marker - @timeline_start) / 1.second).to_f %>
+                  <% offset_ratio = marker_offset_seconds / total_seconds.to_f %>
+                  <% next if offset_ratio.negative? || offset_ratio > 1 %>
+                  <div class="absolute inset-x-0 border-t border-slate-200/70"
+                       style="top: <%= offset_ratio * 100 %>%;"></div>
+                <% end %>
+                <% marker_count = @time_markers.length %>
+                <% @time_markers.each_with_index do |marker, index| %>
+                  <% marker_offset_seconds = ((marker - @timeline_start) / 1.second).to_f %>
+                  <% offset_ratio = marker_offset_seconds / total_seconds.to_f %>
+                  <% next if offset_ratio.negative? || offset_ratio > 1 %>
+                  <% top_percent = offset_ratio * 100 %>
+                  <% base_classes = "absolute inset-x-0 text-center pointer-events-none" %>
+                  <% if index.zero? %>
+                    <div class="<%= [base_classes, 'translate-y-0'].join(' ') %>"
+                         style="top: <%= top_percent %>%;">
+                      <span class="inline-block rounded bg-white/90 px-[3px] py-0.5 font-mono text-[9px] text-slate-700 shadow-sm sm:px-1 sm:text-[10px]">
+                        <%= marker.in_time_zone(@timezone).strftime("%H:%M") %>
+                      </span>
+                    </div>
+                  <% else %>
+                    <% translation_class =
+                         if index == marker_count - 1
+                           '-translate-y-full'
+                         else
+                           '-translate-y-1/2'
+                         end %>
+                    <div class="<%= [base_classes, translation_class].join(' ') %>"
+                         style="top: <%= top_percent %>%;">
+                      <span class="inline-block rounded bg-white/90 px-[3px] py-0.5 font-mono text-[9px] text-slate-700 shadow-sm sm:px-1 sm:text-[10px]">
+                        <%= marker.in_time_zone(@timezone).strftime("%H:%M") %>
+                      </span>
+                    </div>
+                  <% end %>
+                <% end %>
+              </div>
+            </div>
+
+            <div class="flex flex-1 gap-2 md:gap-3">
+              <% if @stages.any? %>
+                <% @stages.each do |stage| %>
+                  <%= render "my_timetables/stage_column_show",
+                             stage: stage,
+                             performances: @performances_by_stage[stage.id],
+                             timeline_start: @timeline_start,
+                             timeline_end: @timeline_end,
+                             time_markers: @time_markers,
+                             timezone: @timezone,
+                             total_seconds: total_seconds,
+                             column_height: column_height,
+                             selected_ids: @selected_performance_ids %>
+                <% end %>
+              <% else %>
+                <div class="flex h-full min-h-[320px] flex-1 items-center justify-center rounded-2xl border border-dashed border-slate-300 bg-white/70 px-6 py-12 text-center text-sm text-slate-500">
+                  ステージ情報がありません。
+                </div>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <% if @performances_without_stage.present? %>
+        <section class="rounded-3xl border border-dashed border-slate-300 bg-white/80 p-4 shadow-sm">
+          <h2 class="text-sm font-bold text-slate-700">ステージ未設定の出演</h2>
+          <div class="mt-3 space-y-2">
+            <% @performances_without_stage.each do |performance| %>
+              <% selected = @selected_performance_ids.include?(performance.id) %>
+              <div class="rounded-2xl border px-4 py-3 shadow-sm <%= selected ? 'border-indigo-200 bg-indigo-500 text-white' : 'border-slate-200 bg-slate-100 text-slate-700' %>">
+                <div class="text-sm font-semibold"><%= performance.artist.name %></div>
+                <div class="mt-1 text-xs font-mono <%= selected ? 'text-indigo-100' : 'text-slate-500' %>">
+                  <%= performance.starts_at&.in_time_zone(@timezone)&.strftime("%H:%M") %> - <%= performance.ends_at&.in_time_zone(@timezone)&.strftime("%H:%M") %>
+                </div>
+                <% if selected %>
+                  <div class="mt-2 inline-flex items-center rounded-full border border-white/70 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-white/90">
+                    選択中
+                  </div>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+        </section>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,13 @@ Rails.application.routes.draw do
 
   resources :festivals, only: [:index, :show] do
     resources :artists, only: [:index], controller: :artists
-    member { get :timetable }
+    member do
+      get :timetable
+      # マイタイムテーブル（作成→保存→表示）
+      get  "my_timetable/build", to: "my_timetables#build",  as: :build_my_timetable
+      post "my_timetable",       to: "my_timetables#create", as: :my_timetable
+      get  "my_timetable",       to: "my_timetables#show"
+    end
   end
 
   namespace :admin do


### PR DESCRIPTION
## 概要
- マイタイムテーブル作成・詳細ビューの作成
- マイタイムテーブルのコントローラを作成
- マイタイムテーブル用のルーティングを追加
- マイタイムテーブルの作成・編集機能の追加

## 対応Issue
- close #56 
- close #57 
- close #58 
- close #59 

## 関連Issue
なし

## 特記事項
- マイタイムテーブル詳細ページは未ログインでも閲覧可。
- 作成したマイタイムテーブルの一覧に関しては別で作成予定。