### PR TITLE
[update]URLにフェスのスラッグを使用

### DIFF
--- a/app/controllers/admin/festivals_controller.rb
+++ b/app/controllers/admin/festivals_controller.rb
@@ -55,7 +55,7 @@ class Admin::FestivalsController < Admin::BaseController
   private
 
   def set_festival
-    @festival = Festival.find(params[:id])
+    @festival = Festival.find_by!(slug: params[:id])
   end
 
   # 1ページ目（基本情報のみ）

--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -1,6 +1,6 @@
 class ArtistsController < ApplicationController
   def index
-    @festival = Festival.find_by(id: params[:festival_id])
+    @festival = Festival.find_by(slug: params[:festival_id])
 
     base =
     if @festival

--- a/app/controllers/festivals_controller.rb
+++ b/app/controllers/festivals_controller.rb
@@ -98,7 +98,7 @@ class FestivalsController < ApplicationController
   private
 
   def set_festival
-    @festival = Festival.includes(:festival_days, :stages).find(params[:id])
+    @festival = Festival.includes(:festival_days, :stages).find_by!(slug: params[:id])
   end
 
   def ensure_timetable_published!

--- a/app/controllers/my_timetables_controller.rb
+++ b/app/controllers/my_timetables_controller.rb
@@ -70,8 +70,8 @@ class MyTimetablesController < ApplicationController
   private
 
   def set_festival!
-    festival_id = params[:festival_id] || params[:id]
-    @festival = Festival.find(festival_id)
+    slug = params[:festival_id] || params[:id]
+    @festival = Festival.find_by!(slug: slug)
   end
 
   def set_selected_day!

--- a/app/models/festival.rb
+++ b/app/models/festival.rb
@@ -24,6 +24,10 @@ class Festival < ApplicationRecord
   validates :official_url, allow_blank: true,
             format: { with: VALID_URL, message: "は http/https の正しいURL形式で入力してください" }
 
+  def to_param
+    slug.presence || super
+  end
+
   def timetable_days
     festival_days.order(:date)
   end


### PR DESCRIPTION
## 概要
- Festivalモデルにインスタンスメソッドto_paramを追加し、設定されたスラッグをURL内で使用するように変更。
- 各コントローラのset_festivalメソッドを、idではなくスラッグを使うように変更。

## 対応Issue
なし

## 関連Issue
なし

## 特記事項
- festivalsテーブルのslugカラムは既に追加済み。