### PR TITLE
[update]戻るボタンの挙動を変更

### DIFF
--- a/app/controllers/festivals_controller.rb
+++ b/app/controllers/festivals_controller.rb
@@ -1,4 +1,5 @@
 class FestivalsController < ApplicationController
+  before_action :set_header_back_path, only: [ :index, :show, :timetable ]
   before_action :set_festival, only: [ :show, :timetable ]
   before_action :ensure_timetable_published!, only: :timetable
 
@@ -121,5 +122,15 @@ class FestivalsController < ApplicationController
       end
 
     scoped.distinct
+  end
+
+  def set_header_back_path
+    if params[:from] == "artist_festivals" && params[:artist_id].present?
+      @header_back_path = artist_festivals_path(params[:artist_id])
+    elsif params[:artist_id].present?
+      @header_back_path = artist_path(params[:artist_id])
+    elsif params[:from] == "timetables"
+      @header_back_path = timetables_path
+    end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,6 @@
 module ApplicationHelper
   include Pagy::Frontend
+  include NavigationHelper
 
   def flash_class(key)
     case key.to_sym

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -1,0 +1,50 @@
+module NavigationHelper
+  def header_back_path
+    return nil if current_page?(root_path)
+    return @header_back_path if defined?(@header_back_path) && @header_back_path.present?
+
+    case controller_path
+    when "festivals"
+      festivals_back_path
+    when "artists"
+      artists_back_path
+    when "my_timetables"
+      my_timetables_back_path
+    else
+      root_path
+    end
+  end
+
+  private
+
+  def festivals_back_path
+    case action_name
+    when "index" then root_path
+    when "timetable" then festival_path(params[:id])
+    else
+      festivals_path
+    end
+  end
+
+  def artists_back_path
+    return festival_path(params[:festival_id]) if params[:festival_id].present?
+
+    case action_name
+    when "index" then root_path
+    else
+      artists_path
+    end
+  end
+
+  def my_timetables_back_path
+    case action_name
+    when "index"
+      timetables_path
+    when "show"
+      my_timetables_path
+    else
+      identifier = params[:festival_id] || params[:id]
+      identifier.present? ? timetable_festival_path(identifier) : root_path
+    end
+  end
+end

--- a/app/views/festivals/index.html.erb
+++ b/app/views/festivals/index.html.erb
@@ -33,9 +33,15 @@
       <% if @festivals.any? %>
         <% @festivals.each do |festival| %>
           <div class="w-full">
+            <% festival_url =
+               if @artist
+                 festival_path(festival, from: "artist_festivals", artist_id: @artist.to_param)
+               else
+                 festival_path(festival)
+               end %>
             <%= render "shared/nav_stack_button",
                        label: festival.name,
-                       url: festival_path(festival) %>
+                       url: festival_url %>
           </div>
         <% end %>
       <% else %>

--- a/app/views/festivals/show.html.erb
+++ b/app/views/festivals/show.html.erb
@@ -63,10 +63,12 @@
                     data: { controller: "tap-feedback" } do %>
           出演アーティスト一覧へ
         <% end %>
-        <%= link_to "#",
-                    class: "block w-full rounded-2xl bg-indigo-500 py-3 text-center text-sm font-bold text-white shadow-md interactive-lift hover:bg-indigo-400",
-                    data: { controller: "tap-feedback" } do %>
-          タイムテーブルへ
+        <% if @festival.timetable_published? %>
+          <%= link_to timetable_festival_path(@festival),
+                      class: "block w-full rounded-2xl bg-indigo-500 py-3 text-center text-sm font-bold text-white shadow-md interactive-lift hover:bg-indigo-400",
+                      data: { controller: "tap-feedback" } do %>
+            タイムテーブルへ
+          <% end %>
         <% end %>
         <%= link_to "#",
                     class: "block w-full rounded-2xl bg-indigo-500 py-3 text-center text-sm font-bold text-white shadow-md interactive-lift hover:bg-indigo-400",

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,6 +1,16 @@
 <header class="fixed inset-x-0 top-0 z-50 bg-[#F95858] text-white h-16">
   <div class="h-full mx-auto flex w-full max-w-screen-xl items-center gap-4 px-4">
-    <% if current_page?(root_path) %>
+    <% back_path = header_back_path %>
+    <% if back_path.present? %>
+      <%= link_to back_path,
+          class: "flex h-10 w-10 items-center justify-center rounded-full shadow-sm interactive-lift hover:bg-[#ea4a4a]/50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white",
+          data: { controller: "tap-feedback" },
+          aria: { label: "前の画面に戻る" } do %>
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="h-6 w-6">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
+        </svg>
+      <% end %>
+    <% else %>
       <span
         class="flex h-10 w-10 items-center justify-center rounded-full opacity-50"
         aria-hidden="true"
@@ -9,18 +19,6 @@
           <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
         </svg>
       </span>
-    <% else %>
-      <button
-        type="button"
-        onclick="history.back()"
-        class="flex h-10 w-10 items-center justify-center rounded-full shadow-sm interactive-lift hover:bg-[#ea4a4a]/50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
-        data-controller="tap-feedback"
-        aria-label="前の画面に戻る"
-      >
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="h-6 w-6">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
-        </svg>
-      </button>
     <% end %>
 
     <div class="flex-1 text-center">

--- a/app/views/timetables/index.html.erb
+++ b/app/views/timetables/index.html.erb
@@ -41,7 +41,7 @@
           <div class="w-full">
             <%= render "shared/nav_stack_button",
                        label: festival.name,
-                       url: timetable_festival_path(festival) %>
+                       url: timetable_festival_path(festival, from: "timetables") %>
           </div>
         <% end %>
       <% else %>


### PR DESCRIPTION
## 概要
- app/helpers/navigation_helper.rb のヘッダー専用ヘルパーを新設し、コントローラ・パラメータごとに戻り先URLを判定するロジックを集約。
- app/views/shared/_header.html.erb の戻るボタンを history.back() からヘルパー経由のリンクに変更し、戻り先がないページでは無効表示に。
- app/controllers/festivals_controller.rb ほか各アクションに before_action を追加して @header_back_path を設定し、アーティスト経由・タイムテーブル経由など複数導線で期待するページへ戻れるよう分岐。
- app/views/festivals/index.html.erb や app/views/timetables/index.html.erbなど、導線ごとに from/artist_id パラメータを付与して戻り先を識別。
- app/helpers/navigation_helper.rb のマイタイムテーブル関連の戻り先も一覧・タイムテーブルに誘導するよう調整

## 対応Issue
なし

## 関連Issue
なし

## 特記事項
- 不具合があれば随時対応予定。