### PR TITLE
[fix]戻るボタンの挙動の修正

### DIFF
--- a/app/controllers/festivals_controller.rb
+++ b/app/controllers/festivals_controller.rb
@@ -1,5 +1,4 @@
 class FestivalsController < ApplicationController
-  before_action :set_header_back_path, only: [ :index, :show, :timetable ]
   before_action :set_festival, only: [ :show, :timetable ]
   before_action :ensure_timetable_published!, only: :timetable
 
@@ -124,13 +123,4 @@ class FestivalsController < ApplicationController
     scoped.distinct
   end
 
-  def set_header_back_path
-    if params[:from] == "artist_festivals" && params[:artist_id].present?
-      @header_back_path = artist_festivals_path(params[:artist_id])
-    elsif params[:artist_id].present?
-      @header_back_path = artist_path(params[:artist_id])
-    elsif params[:from] == "timetables"
-      @header_back_path = timetables_path
-    end
-  end
 end

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -18,6 +18,15 @@ module NavigationHelper
   private
 
   def festivals_back_path
+    case params[:from]
+    when "artist_festivals"
+      return artist_festivals_path(params[:artist_id]) if params[:artist_id].present?
+    when "timetables"
+      return timetables_path
+    end
+
+    return artist_path(params[:artist_id]) if params[:artist_id].present?
+
     case action_name
     when "index" then root_path
     when "timetable" then festival_path(params[:id])
@@ -27,6 +36,13 @@ module NavigationHelper
   end
 
   def artists_back_path
+    case params[:from]
+    when "festival_timetable"
+      return timetable_back_path if params[:festival_id].present?
+    when "my_timetable"
+      return my_timetable_back_path
+    end
+
     return festival_path(params[:festival_id]) if params[:festival_id].present?
 
     case action_name
@@ -34,6 +50,20 @@ module NavigationHelper
     else
       artists_path
     end
+  end
+
+  def timetable_back_path
+    options = {}
+    options[:date] = params[:date] if params[:date].present?
+    timetable_festival_path(params[:festival_id], options)
+  end
+
+  def my_timetable_back_path
+    return root_path if params[:festival_id].blank?
+    options = {}
+    options[:date] = params[:date] if params[:date].present?
+    options[:user_id] = params[:user_id] if params[:user_id].present?
+    my_timetable_festival_path(params[:festival_id], options)
   end
 
   def my_timetables_back_path

--- a/app/views/festivals/_stage_column.html.erb
+++ b/app/views/festivals/_stage_column.html.erb
@@ -30,7 +30,12 @@
               column_height: column_height
             ) %>
         <% next unless block %>
-        <%= link_to artist_path(performance.artist),
+        <% artist_link_params = {
+             from: "festival_timetable",
+             festival_id: @festival.slug,
+             date: @selected_day&.date&.to_s
+           }.compact %>
+        <%= link_to artist_path(performance.artist, artist_link_params),
                     class: "absolute inset-x-1.5 rounded-md px-2 py-1 text-[11px] font-semibold shadow-sm interactive-lift sm:inset-x-2 sm:px-3 sm:py-2 sm:text-xs",
                     data: { controller: "tap-feedback" },
                     style: "top: #{block.top_percent}%; height: #{block.height_percent}%; background-color: #{hex}; color: #{text_color};" do %>

--- a/app/views/my_timetables/_stage_column_show.html.erb
+++ b/app/views/my_timetables/_stage_column_show.html.erb
@@ -43,7 +43,14 @@
              "interactive-lift",
              opacity_class
            ].reject(&:blank?).join(" ") %>
-        <%= link_to artist_path(performance.artist),
+        <% artist_link_params = {
+             from: "my_timetable",
+             festival_id: @festival.slug,
+             date: @selected_day&.date&.to_s
+           } %>
+        <% artist_link_params.compact! %>
+        <% artist_link_params[:user_id] = params[:user_id] if params[:user_id].present? %>
+        <%= link_to artist_path(performance.artist, artist_link_params),
                     class: label_classes,
                     data: { controller: "tap-feedback" },
                     style: "top: #{block.top_percent}%; height: #{block.height_percent}%; background-color: #{block_bg_color}; color: #{block_text_color}; border: 1px solid #{border_color};" do %>


### PR DESCRIPTION
## 概要
- フェス画面の戻り先判定を NavigationHelper#festivals_back_path に統合し、from や artist_id パラメータから適切な戻りURLを決定するように変更。
- タイムテーブル・マイタイムテーブルからアーティスト詳細へ遷移した際の戻り先を解決するため、timetable_back_path と my_timetable_back_path をヘルパーに追加。
- 共通化に伴い、コントローラから戻り先判定ロジックを排除。

## 対応Issue
なし

## 関連Issue
なし

## 特記事項
なし