### PR TITLE
[fix]タイムテーブル詳細ページの戻るボタンの挙動修正

### DIFF
--- a/app/controllers/festivals_controller.rb
+++ b/app/controllers/festivals_controller.rb
@@ -24,6 +24,9 @@ class FestivalsController < ApplicationController
     @festival_days = @festival.timetable_days
     raise ActiveRecord::RecordNotFound if @festival_days.blank?
 
+    @timetable_query_params =
+      params.permit(:from, :artist_id, :festival_id, :user_id).to_h
+
     @selected_day =
       if params[:date].present?
         begin

--- a/app/views/festivals/timetable.html.erb
+++ b/app/views/festivals/timetable.html.erb
@@ -51,8 +51,9 @@
               "rounded-lg px-3 py-2 text-sm font-semibold transition",
               active ? "bg-rose-500 text-white shadow-sm" : "text-slate-500 hover:text-rose-500"
             ].join(" ") %>
+            <% path_options = @timetable_query_params.merge("date" => day.date.to_s) %>
             <%= link_to label,
-                        timetable_festival_path(@festival, date: day.date.to_s),
+                        timetable_festival_path(@festival, path_options),
                         class: button_classes %>
           <% end %>
         </div>


### PR DESCRIPTION
## 概要
- フェスのタイムテーブル表示で日付タブを切り替えた際も戻り先情報（from 等）を保持するため、許可済みパラメータを集めた @timetable_query_params を FestivalsController#timetable で用意。

## 対応Issue
なし

## 関連Issue
なし

## 特記事項
なし