### PR TITLE
[fix]adminトップページのUI変更

### DIFF
--- a/app/views/admin/home/top.html.erb
+++ b/app/views/admin/home/top.html.erb
@@ -6,7 +6,7 @@
     <%= render "shared/nav_stack_button", label: "ユーザー管理", url: admin_users_path %>
     <%= render "shared/nav_stack_button", label: "フェス管理", url: admin_festivals_path %>
     <%= render "shared/nav_stack_button", label: "アーティスト管理", url: admin_artists_path %>
-    <%= render "shared/nav_stack_button", label: "ステージパフォーマンス管理", url: admin_stage_performances_path %>
+    <%= render "shared/nav_stack_button", label: "出演枠管理", url: admin_stage_performances_path %>
     <%= render "shared/nav_stack_button", label: "セットリスト管理", url: "#" %>
   </nav>
 </div>


### PR DESCRIPTION
## 概要
- adminトップページのボタンUIの表示名を「ステージパフォーマンス管理」→「出演枠管理」に変更

## 対応Issue
- #30 

## 関連Issue
なし

## 特記事項
なし