### PR TITLE
[fix]Xシェア時のOGP画像が表示されない問題の修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,8 @@
     <%= csp_meta_tag %>
 
     <meta property="og:site_name" content="FES READY">
+    <meta property="og:title" content="<%= content_for(:title) || 'FES READY' %>">
+    <meta name="twitter:title" content="<%= content_for(:title) || 'FES READY' %>">
     <meta property="og:image" content="<%= image_url('fesready_ogp.png') %>">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:image" content="<%= image_url('fesready_ogp.png') %>">


### PR DESCRIPTION
## 概要
- og:title と twitter:titleを定義することで、Xでシェアした際のOGP画像が反映されない問題を解決。

## 対応Issue
なし

## 関連Issue
- #61 

## 特記事項
- Xの開発者向けサイト（<https://cards-dev.x.com/validator>）で表示検証済。