### PR TITLE
[add]usersテーブルにuuidのカラムを追加

### DIFF
--- a/db/migrate/20251109063637_add_uuid_to_users.rb
+++ b/db/migrate/20251109063637_add_uuid_to_users.rb
@@ -1,0 +1,27 @@
+class AddUuidToUsers < ActiveRecord::Migration[8.0]
+  def up
+    # gen_random_uuid() を使うための拡張（DBに1回だけ有効化すればOK）
+    enable_extension "pgcrypto" unless extension_enabled?("pgcrypto")
+
+    # 1) まず追加（NULL許容・defaultなし）
+    add_column :users, :uuid, :uuid
+
+    # 2) 既存レコードそれぞれにUUID採番（行ごとに関数が評価されて全員ユニークになる）
+    execute "UPDATE users SET uuid = gen_random_uuid() WHERE uuid IS NULL;"
+
+    # 3) 空欄禁止
+    change_column_null :users, :uuid, false
+
+    # 4) 今後のINSERTは自動採番
+    change_column_default :users, :uuid, "gen_random_uuid()"
+
+    # 5) 重複禁止（ユニークインデックス）
+    add_index :users, :uuid, unique: true, name: "index_users_on_uuid"
+  end
+
+  def down
+    remove_index :users, name: "index_users_on_uuid"
+    change_column_default :users, :uuid, nil
+    remove_column :users, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_27_015710) do
+ActiveRecord::Schema[8.0].define(version: 2025_11_09_063637) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "pg_catalog.plpgsql"
+  enable_extension "pgcrypto"
 
   create_table "artists", force: :cascade do |t|
     t.string "name", null: false
@@ -108,8 +109,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_27_015710) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["uuid"], name: "index_users_on_uuid", unique: true
   end
 
   add_foreign_key "festival_days", "festivals"


### PR DESCRIPTION
## 概要
- ユーザーに外部公開用の安全な識別子（UUID）を持たせるため、users テーブルに uuid カラムを追加。
- 既存ユーザーにもユニークなUUIDを採番し、今後作成されるユーザーには自動でUUIDが付与されるようにマイグレーションを実行。

## 実施内容 
- PostgreSQL拡張 "pgcrypto" を有効化（gen_random_uuid() 利用のため）
- users テーブルに uuid カラムを追加
  - 既存レコードに対して gen_random_uuid() で一括採番
  - NOT NULL 制約を追加
  - デフォルト値に gen_random_uuid() を設定（新規登録時に自動採番）
  - 一意制約インデックスを追加

## 対応Issue
- #189 

## 関連Issue
なし

## 特記事項
- URLの反映は現コミット時点では未実装