### PR TITLE
[add]既存データにuuid値を追加し、null値を許可しない

### DIFF
--- a/db/migrate/20251110072932_backfill_and_enforce_uuid_on_artists.rb
+++ b/db/migrate/20251110072932_backfill_and_enforce_uuid_on_artists.rb
@@ -1,0 +1,31 @@
+class BackfillAndEnforceUuidOnArtists < ActiveRecord::Migration[8.0]
+  # 並列でインデックスを貼るため、トランザクションを無効化
+  disable_ddl_transaction!
+
+  def up
+    # gen_random_uuid() を使うための拡張（未有効なら有効化）
+    enable_extension "pgcrypto" unless extension_enabled?("pgcrypto")
+
+    # 1) 既存のNULLを一気に埋める（行ごとに関数評価され全員ユニーク）
+    execute <<~SQL
+      UPDATE artists
+      SET uuid = gen_random_uuid()
+      WHERE uuid IS NULL;
+    SQL
+
+    # 2) NOT NULL 制約
+    change_column_null :artists, :uuid, false
+
+    # 3) ユニークインデックス（未作成なら並列で作成）
+    add_index :artists, :uuid,
+              unique: true,
+              name: "index_artists_on_uuid",
+              algorithm: :concurrently unless index_exists?(:artists, :uuid, name: "index_artists_on_uuid", unique: true)
+  end
+
+  def down
+    # 巻き戻し：インデックス削除 → NOT NULL解除（値は残す）
+    remove_index :artists, name: "index_artists_on_uuid" if index_exists?(:artists, :uuid, name: "index_artists_on_uuid")
+    change_column_null :artists, :uuid, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_11_10_070618) do
+ActiveRecord::Schema[8.0].define(version: 2025_11_10_072932) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "pg_catalog.plpgsql"
@@ -22,9 +22,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_10_070618) do
     t.string "image_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "uuid"
+    t.uuid "uuid", null: false
     t.index ["name"], name: "index_artists_on_name"
     t.index ["spotify_artist_id"], name: "index_artists_on_spotify_artist_id_unique_when_present", unique: true, where: "(spotify_artist_id IS NOT NULL)"
+    t.index ["uuid"], name: "index_artists_on_uuid", unique: true
   end
 
   create_table "festival_days", force: :cascade do |t|


### PR DESCRIPTION
## 概要
- 既存のartistsテーブルのuuidにユニークな値を追加し、nullを許可しないように設定。

## 実施内容
- 既存のartistsテーブルのデータのuuidカラムに値を追加し、null値を許可しない変更を行うマイグレーションファイルを作成し、実行。
- インデックスも追加するマイグレーションファイルを作成し、実行。

## 対応Issue
- #189 

## 関連Issue
なし

## 特記事項