### PR TITLE
[update]アーティスト関連のURLにuuidを反映

### DIFF
--- a/app/controllers/admin/artists_controller.rb
+++ b/app/controllers/admin/artists_controller.rb
@@ -35,12 +35,16 @@ class Admin::ArtistsController < Admin::BaseController
 
   private
   def set_artist
-    @artist = Artist.find(params[:id])
+    @artist = find_artist_by_identifier!(params[:id])
   end
 
   def artist_params
     params.require(:artist).permit(:name, :spotify_artist_id, :image_url).tap do |p|
       p[:spotify_artist_id] = p[:spotify_artist_id].presence
     end
+  end
+
+  def find_artist_by_identifier!(identifier)
+    Artist.find_by(uuid: identifier) || Artist.find(identifier)
   end
 end

--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -34,6 +34,12 @@ class ArtistsController < ApplicationController
   end
 
   def show
-    @artist = Artist.find(params[:id])
+    @artist = find_artist_by_identifier!(params[:id])
+  end
+
+  private
+
+  def find_artist_by_identifier!(identifier)
+    Artist.find_by(uuid: identifier) || Artist.find(identifier)
   end
 end

--- a/app/controllers/festivals_controller.rb
+++ b/app/controllers/festivals_controller.rb
@@ -3,7 +3,7 @@ class FestivalsController < ApplicationController
   before_action :ensure_timetable_published!, only: :timetable
 
   def index
-    @artist = Artist.find(params[:artist_id]) if params[:artist_id].present?
+    @artist = find_artist_by_identifier!(params[:artist_id]) if params[:artist_id].present?
 
     @status = params[:status]
     @status = "upcoming" unless %w[upcoming past].include?(@status)
@@ -124,5 +124,9 @@ class FestivalsController < ApplicationController
       end
 
     scoped.distinct
+  end
+
+  def find_artist_by_identifier!(identifier)
+    Artist.find_by(uuid: identifier) || Artist.find(identifier)
   end
 end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -1,9 +1,13 @@
+require "securerandom"
+
 class Artist < ApplicationRecord
   validates :name, presence: true
 
   has_many :stage_performances, dependent: :destroy
   has_many :festival_days, through: :stage_performances
   has_many :festivals, -> { distinct }, through: :festival_days
+
+  before_create :ensure_uuid!
 
   def self.ransackable_attributes(_ = nil); %w[name]; end
   def self.ransackable_associations(_ = nil); []; end
@@ -18,4 +22,14 @@ class Artist < ApplicationRecord
            uniqueness: { allow_nil: true }
 
   # 将来: has_many :performances など
+
+  def to_param
+    uuid
+  end
+
+  private
+
+  def ensure_uuid!
+    self.uuid ||= SecureRandom.uuid
+  end
 end


### PR DESCRIPTION
## 概要
- Artist モデルに UUID の自動付番と to_param 設定を追加し、今後の URL 生成が UUID ベースで安定するようにした。
- 公開側／管理側／フェス一覧の各コントローラで、UUID でも従来 ID でもアーティストを参照できるよう統一した。

## 実施内容
- app/models/artist.rb に require "securerandom", before_create :ensure_uuid!, def to_param = uuid, ensure_uuid! を追加して新規作成時に UUID を割り当てるよう変更。
- app/controllers/artists_controller.rb の show で find_artist_by_identifier! を用い、UUID/ID 両対応の検索に変更。
- app/controllers/admin/artists_controller.rb の set_artist を同じヘルパーで置き換え、管理画面の編集・削除も UUID URL で扱えるようにした。
- app/controllers/festivals_controller.rb でネストされた /artists/:artist_id/festivals の artist_id を同ヘルパー経由で解決し、UUID クエリが機能するようにした。

## 対応Issue
- close #189

## 関連Issue
なし

## 特記事項