### PR TITLE
[refactor]タイムテーブルビューのヘッダー部分のパーシャル化

### DIFF
--- a/app/views/festivals/timetable.html.erb
+++ b/app/views/festivals/timetable.html.erb
@@ -1,42 +1,10 @@
 <div class="min-h-screen px-4 pb-24 pt-6">
   <div class="mx-auto flex max-w-6xl flex-col gap-6">
-    <header class="rounded-3xl border border-slate-200 bg-gradient-to-b from-sky-100 via-slate-100 to-white p-6 shadow-lg shadow-slate-200/60">
-      <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">タイムテーブル</p>
-      <h1 class="mt-2 text-2xl font-extrabold text-slate-900"><%= @festival.name %></h1>
-
-      <div class="mt-4 flex flex-wrap items-center gap-4 text-sm text-slate-600">
-        <div class="flex flex-wrap items-center gap-3">
-          <div>
-            <span class="text-xs font-semibold uppercase tracking-wide text-slate-500">日付</span>
-            <div class="text-base font-semibold text-slate-900"><%= format_date_with_weekday(@selected_day.date) %></div>
-          </div>
-          <div class="flex items-center gap-4 text-xs">
-            <div>
-              <span class="font-semibold uppercase tracking-wide text-slate-500">開場</span>
-              <div class="font-mono text-sm text-slate-800">
-                <%= @selected_day.doors_at ? @selected_day.doors_at.in_time_zone(@timezone).strftime("%H:%M") : "—" %>
-              </div>
-            </div>
-            <div>
-              <span class="font-semibold uppercase tracking-wide text-slate-500">開演</span>
-              <div class="font-mono text-sm text-slate-800">
-                <%= @selected_day.start_at ? @selected_day.start_at.in_time_zone(@timezone).strftime("%H:%M") : "—" %>
-              </div>
-            </div>
-            <div>
-              <span class="font-semibold uppercase tracking-wide text-slate-500">終演</span>
-              <div class="font-mono text-sm text-slate-800">
-                <%= @selected_day.end_at ? @selected_day.end_at.in_time_zone(@timezone).strftime("%H:%M") : "—" %>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <% if @selected_day.note.present? %>
-        <p class="mt-4 text-xs text-slate-600"><%= @selected_day.note %></p>
-      <% end %>
-
+    <%= render "shared/timetable_header",
+               title: "タイムテーブル",
+               festival_name: @festival.name,
+               selected_day: @selected_day,
+               timezone: @timezone do %>
       <div class="mt-6 flex justify-center">
         <div class="inline-flex overflow-hidden rounded-xl bg-white p-1 shadow-md">
           <% @festival_days.each do |day| %>
@@ -61,7 +29,7 @@
                       data: { controller: "tap-feedback" } %>
         </div>
       <% end %>
-    </header>
+    <% end %>
 
     <section class="rounded-3xl border border-slate-200 bg-gradient-to-b from-slate-100 via-white to-slate-100 p-3 shadow-lg shadow-slate-200/60 sm:p-4">
       <div class="overflow-x-auto overflow-y-hidden">

--- a/app/views/my_timetables/build.html.erb
+++ b/app/views/my_timetables/build.html.erb
@@ -1,45 +1,14 @@
 <div class="min-h-screen px-4 pb-24 pt-6">
   <div class="mx-auto flex max-w-6xl flex-col gap-6">
-    <header class="rounded-3xl border border-slate-200 bg-gradient-to-b from-sky-100 via-slate-100 to-white p-6 shadow-lg shadow-slate-200/60">
-      <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">マイタイムテーブル作成</p>
-      <h1 class="mt-2 text-2xl font-extrabold text-slate-900"><%= @festival.name %></h1>
-      <div class="mt-4 flex flex-wrap items-center gap-4 text-sm text-slate-600">
-        <div class="flex flex-wrap items-center gap-3">
-          <div>
-            <span class="text-xs font-semibold uppercase tracking-wide text-slate-500">日付</span>
-            <div class="text-base font-semibold text-slate-900"><%= format_date_with_weekday(@selected_day.date) %></div>
-          </div>
-          <div class="flex items-center gap-4 text-xs">
-            <div>
-              <span class="font-semibold uppercase tracking-wide text-slate-500">開場</span>
-              <div class="font-mono text-sm text-slate-800">
-                <%= @selected_day.doors_at ? @selected_day.doors_at.in_time_zone(@timezone).strftime("%H:%M") : "—" %>
-              </div>
-            </div>
-            <div>
-              <span class="font-semibold uppercase tracking-wide text-slate-500">開演</span>
-              <div class="font-mono text-sm text-slate-800">
-                <%= @selected_day.start_at ? @selected_day.start_at.in_time_zone(@timezone).strftime("%H:%M") : "—" %>
-              </div>
-            </div>
-            <div>
-              <span class="font-semibold uppercase tracking-wide text-slate-500">終演</span>
-              <div class="font-mono text-sm text-slate-800">
-                <%= @selected_day.end_at ? @selected_day.end_at.in_time_zone(@timezone).strftime("%H:%M") : "—" %>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <% if @selected_day.note.present? %>
-        <p class="mt-4 text-xs text-slate-600"><%= @selected_day.note %></p>
-      <% end %>
-
+    <%= render "shared/timetable_header",
+               title: "マイタイムテーブル作成",
+               festival_name: @festival.name,
+               selected_day: @selected_day,
+               timezone: @timezone do %>
       <p class="mt-4 text-sm text-slate-700">
         見たいアーティストのブロックをタップして選択してください。選択した内容は「保存する」を押すとマイタイムテーブルに反映されます。
       </p>
-    </header>
+    <% end %>
 
     <%= form_with url: my_timetable_festival_path(@festival, date: @selected_day.date.to_s, user_id: current_user.uuid),
                   method: :post,

--- a/app/views/my_timetables/show.html.erb
+++ b/app/views/my_timetables/show.html.erb
@@ -1,41 +1,11 @@
 <div class="min-h-screen px-4 pb-24 pt-6">
   <div class="mx-auto flex max-w-6xl flex-col gap-6">
-    <header class="rounded-3xl border border-slate-200 bg-gradient-to-b from-indigo-100 via-white to-slate-100 p-6 shadow-lg shadow-slate-200/60">
-      <p class="text-xs font-semibold tracking-[0.3em] text-slate-500"><%= @timetable_owner.nickname %>のマイタイムテーブル</p>
-      <h1 class="mt-2 text-2xl font-extrabold text-slate-900"><%= @festival.name %></h1>
-      <div class="mt-4 flex flex-wrap items-center gap-4 text-sm text-slate-600">
-        <div class="flex flex-wrap items-center gap-3">
-          <div>
-            <span class="text-xs font-semibold uppercase tracking-wide text-slate-500">日付</span>
-            <div class="text-base font-semibold text-slate-900"><%= format_date_with_weekday(@selected_day.date) %></div>
-          </div>
-          <div class="flex items-center gap-4 text-xs">
-            <div>
-              <span class="font-semibold uppercase tracking-wide text-slate-500">開場</span>
-              <div class="font-mono text-sm text-slate-800">
-                <%= @selected_day.doors_at ? @selected_day.doors_at.in_time_zone(@timezone).strftime("%H:%M") : "—" %>
-              </div>
-            </div>
-            <div>
-              <span class="font-semibold uppercase tracking-wide text-slate-500">開演</span>
-              <div class="font-mono text-sm text-slate-800">
-                <%= @selected_day.start_at ? @selected_day.start_at.in_time_zone(@timezone).strftime("%H:%M") : "—" %>
-              </div>
-            </div>
-            <div>
-              <span class="font-semibold uppercase tracking-wide text-slate-500">終演</span>
-              <div class="font-mono text-sm text-slate-800">
-                <%= @selected_day.end_at ? @selected_day.end_at.in_time_zone(@timezone).strftime("%H:%M") : "—" %>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <% if @selected_day.note.present? %>
-        <p class="mt-4 text-xs text-slate-600"><%= @selected_day.note %></p>
-      <% end %>
-
+    <%= render "shared/timetable_header",
+               title: "#{@timetable_owner.nickname}のマイタイムテーブル",
+               festival_name: @festival.name,
+               selected_day: @selected_day,
+               timezone: @timezone,
+               header_classes: "rounded-3xl border border-slate-200 bg-gradient-to-b from-indigo-100 via-white to-slate-100 p-6 shadow-lg shadow-slate-200/60" do %>
       <div class="mt-6 flex flex-col items-center gap-3 sm:flex-row sm:justify-between">
         <% if @timetable_owner == current_user %>
           <div class="flex items-center gap-3">
@@ -51,7 +21,7 @@
           </div>
         <% end %>
       </div>
-    </header>
+    <% end %>
 
     <% if @performances.blank? %>
       <div class="rounded-3xl border border-dashed border-slate-300 bg-white/80 px-6 py-12 text-center text-sm text-slate-600 shadow-sm">

--- a/app/views/shared/_timetable_header.html.erb
+++ b/app/views/shared/_timetable_header.html.erb
@@ -1,0 +1,44 @@
+<% header_classes ||= "rounded-3xl border border-slate-200 bg-gradient-to-b from-sky-100 via-slate-100 to-white p-6 shadow-lg shadow-slate-200/60" %>
+<% format_time = ->(time) { time ? time.in_time_zone(timezone).strftime("%H:%M") : "—" } %>
+
+<header class="<%= header_classes %>">
+  <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500"><%= title %></p>
+  <h1 class="mt-2 text-2xl font-extrabold text-slate-900"><%= festival_name %></h1>
+
+  <div class="mt-4 flex flex-wrap items-center gap-4 text-sm text-slate-600">
+    <div class="flex flex-wrap items-center gap-3 text-slate-900">
+      <div>
+        <span class="text-xs font-semibold uppercase tracking-wide text-slate-500">日付</span>
+        <div class="text-base font-semibold text-slate-900"><%= format_date_with_weekday(selected_day.date) %></div>
+      </div>
+      <div class="flex items-center gap-4 text-xs">
+        <div>
+          <span class="font-semibold uppercase tracking-wide text-slate-500">開場</span>
+          <div class="font-mono text-sm text-slate-800">
+            <%= format_time.call(selected_day.doors_at) %>
+          </div>
+        </div>
+        <div>
+          <span class="font-semibold uppercase tracking-wide text-slate-500">開演</span>
+          <div class="font-mono text-sm text-slate-800">
+            <%= format_time.call(selected_day.start_at) %>
+          </div>
+        </div>
+        <div>
+          <span class="font-semibold uppercase tracking-wide text-slate-500">終演</span>
+          <div class="font-mono text-sm text-slate-800">
+            <%= format_time.call(selected_day.end_at) %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <% if selected_day.note.present? %>
+    <p class="mt-4 text-xs text-slate-600"><%= selected_day.note %></p>
+  <% end %>
+
+  <% if block_given? %>
+    <%= yield %>
+  <% end %>
+</header>


### PR DESCRIPTION
## 概要
- タイムテーブル画面とマイタイムテーブル画面のヘッダーのパーシャル化。

## 実施内容
- タイムテーブル画面とマイタイムテーブル画面のヘッダー（フェス名＋日付＋開場/開演/終演表示）をshared/_timetable_header.html.erb にまとめ、パーシャル化し呼び出しで対応。
## 対応Issue
- #165 
## 関連Issue
なし
## 特記事項