### PR TITLE
[refactor]「開催前/開催済」、「日程」の切り替えボタンUIのコンポーネント化

### DIFF
--- a/app/components/shared/segmented_tabs_component.rb
+++ b/app/components/shared/segmented_tabs_component.rb
@@ -1,0 +1,35 @@
+module Shared
+  class SegmentedTabsComponent < ViewComponent::Base
+    def initialize(items:, active_key:, url_builder:)
+      @items = items
+      @active_key = active_key
+      @url_builder = url_builder
+    end
+
+    def call
+      content_tag(:div, class: "inline-flex rounded-xl bg-white p-1 shadow-md") do
+        safe_join(items.map { |key, label| tab_link(key, label) })
+      end
+    end
+
+    private
+
+    attr_reader :items, :active_key, :url_builder
+
+    def tab_link(key, label)
+      active = key == active_key
+      classes = [
+        "rounded-lg px-4 py-2 text-sm font-semibold transition",
+        active ? "bg-rose-500 text-white shadow-sm" : "text-slate-500 hover:text-rose-500"
+      ].join(" ")
+
+      link_to(label,
+              url_for_key(key),
+              class: classes)
+    end
+
+    def url_for_key(key)
+      url_builder.respond_to?(:call) ? url_builder.call(key) : url_builder
+    end
+  end
+end

--- a/app/views/artists/index.html.erb
+++ b/app/views/artists/index.html.erb
@@ -7,19 +7,15 @@
 
       <% if @festival.present? && @festival_days.any? %>
         <% preserved_query = request.query_parameters.except(:page, :festival_day_id) %>
+        <% tab_items = @festival_days.map { |festival_day| [ festival_day.id, format_date_with_weekday(festival_day.date) ] }.to_h %>
         <div class="flex justify-center">
-          <div class="inline-flex rounded-xl bg-white p-1 shadow-md">
-            <% @festival_days.each do |festival_day| %>
-              <% active = @selected_festival_day&.id == festival_day.id %>
-              <% link_classes = [
-                "rounded-lg px-4 py-2 text-sm font-semibold transition",
-                active ? "bg-rose-500 text-white shadow-sm" : "text-slate-500 hover:text-rose-500"
-              ].join(" ") %>
-              <%= link_to format_date_with_weekday(festival_day.date),
-                          festival_artists_path(@festival, preserved_query.merge(festival_day_id: festival_day.id)),
-                          class: link_classes %>
-            <% end %>
-          </div>
+          <%= render Shared::SegmentedTabsComponent.new(
+                items: tab_items,
+                active_key: @selected_festival_day&.id,
+                url_builder: ->(festival_day_id) {
+                  festival_artists_path(@festival, preserved_query.merge(festival_day_id: festival_day_id))
+                }
+              ) %>
         </div>
       <% end %>
 

--- a/app/views/festivals/index.html.erb
+++ b/app/views/festivals/index.html.erb
@@ -4,21 +4,16 @@
       <h1 class="text-2xl font-bold text-slate-900">
         <%= @artist ? "#{@artist.name} の出演フェス" : "フェスを選択" %>
       </h1>
+      <% preserved_query = request.query_parameters.except(:page, :status) %>
       <div class="flex justify-center">
-        <div class="inline-flex rounded-xl bg-white p-1 shadow-md">
-          <% preserved_query = request.query_parameters.except(:page, :status) %>
-          <% @status_labels.each do |key, label| %>
-            <% active = @status == key %>
-            <% link_classes = [
-              "rounded-lg px-4 py-2 text-sm font-semibold transition",
-              active ? "bg-rose-500 text-white shadow-sm" : "text-slate-500 hover:text-rose-500"
-            ].join(" ") %>
-            <% path_options = preserved_query.merge(status: key) %>
-            <%= link_to label,
-                        (@artist ? artist_festivals_path(@artist, path_options) : festivals_path(path_options)),
-                        class: link_classes %>
-          <% end %>
-        </div>
+        <%= render Shared::SegmentedTabsComponent.new(
+              items: @status_labels,
+              active_key: @status,
+              url_builder: ->(key) do
+                path_options = preserved_query.merge(status: key)
+                @artist ? artist_festivals_path(@artist, path_options) : festivals_path(path_options)
+              end
+            ) %>
       </div>
     </header>
 

--- a/app/views/festivals/timetable.html.erb
+++ b/app/views/festivals/timetable.html.erb
@@ -6,21 +6,17 @@
                  selected_day: @selected_day,
                  timezone: @timezone
                ) do %>
+      <% day_lookup = @festival_days.index_by(&:id) %>
+      <% tab_items = day_lookup.transform_values { |day| day.date.strftime("%-m/%-d") } %>
       <div class="mt-6 flex justify-center">
-        <div class="inline-flex overflow-hidden rounded-xl bg-white p-1 shadow-md">
-          <% @festival_days.each do |day| %>
-            <% active = day.id == @selected_day.id %>
-            <% label = day.date.strftime("%-m/%-d") %>
-            <% button_classes = [
-              "rounded-lg px-3 py-2 text-sm font-semibold transition",
-              active ? "bg-rose-500 text-white shadow-sm" : "text-slate-500 hover:text-rose-500"
-            ].join(" ") %>
-            <% path_options = @timetable_query_params.merge("date" => day.date.to_s) %>
-            <%= link_to label,
-                        timetable_festival_path(@festival, path_options),
-                        class: button_classes %>
-          <% end %>
-        </div>
+        <%= render Shared::SegmentedTabsComponent.new(
+              items: tab_items,
+              active_key: @selected_day.id,
+              url_builder: ->(festival_day_id) do
+                day = day_lookup[festival_day_id]
+                timetable_festival_path(@festival, @timetable_query_params.merge("date" => day.date.to_s))
+              end
+            ) %>
       </div>
       <% if user_signed_in? %>
         <div class="mt-4 flex justify-center">

--- a/app/views/timetables/index.html.erb
+++ b/app/views/timetables/index.html.erb
@@ -11,21 +11,13 @@
                       data: { controller: "tap-feedback" } %>
         <% end %>
       </div>
+      <% preserved_query = request.query_parameters.except(:page, :status) %>
       <div class="flex justify-center">
-        <div class="inline-flex rounded-xl bg-white p-1 shadow-md">
-          <% preserved_query = request.query_parameters.except(:page, :status) %>
-          <% @status_labels.each do |key, label| %>
-            <% active = @status == key %>
-            <% link_classes = [
-              "rounded-lg px-4 py-2 text-sm font-semibold transition",
-              active ? "bg-rose-500 text-white shadow-sm" : "text-slate-500 hover:text-rose-500"
-            ].join(" ") %>
-            <% path_options = preserved_query.merge(status: key) %>
-            <%= link_to label,
-                        timetables_path(path_options),
-                        class: link_classes %>
-          <% end %>
-        </div>
+        <%= render Shared::SegmentedTabsComponent.new(
+              items: @status_labels,
+              active_key: @status,
+              url_builder: ->(key) { timetables_path(preserved_query.merge(status: key)) }
+            ) %>
       </div>
     </header>
 


### PR DESCRIPTION
## 概要
- 開催前/開催済みや日付タブの UI を共通コンポーネント化し、複数ビューに散らばっていたリンク生成・アクティブ判定ロジックを一元化。
- 各ビューは Shared::SegmentedTabsComponent を呼び出すだけでタブを描画できるようにした。
## 実施内容
- app/components/shared/segmented_tabs_component.rb を追加し、タブのクラス切替・リンク生成・アクティブ状態の判定を実装。
- app/views/festivals/index.html.erb, app/views/timetables/index.html.erb, app/views/artists/index.html.erb, app/views/festivals/timetable.html.erb のタブ UI をコンポーネント呼び出しへ置き換え、各ビューから重複ロジックを削除。
## 対応Issue
- #165 
## 関連Issue
なし
## 特記事項