### PR TITLE
[fix]不要なビュー内のコードを削除

### DIFF
--- a/app/controllers/my_timetables_controller.rb
+++ b/app/controllers/my_timetables_controller.rb
@@ -23,6 +23,9 @@ class MyTimetablesController < ApplicationController
                     .joins(:stage_performance)
                     .where(stage_performances: { festival_day_id: @selected_day.id })
                     .pluck(:stage_performance_id)
+
+    @performances_without_stage =
+      @performances.select { |performance| performance.stage_id.blank? }
   end
 
   def create
@@ -131,10 +134,6 @@ class MyTimetablesController < ApplicationController
       @performances
         .reject { |performance| performance.stage_id.blank? }
         .group_by(&:stage_id)
-
-    @performances_without_stage =
-      @performances
-        .select { |performance| performance.stage_id.blank? }
 
     timeline_context = TimelineContextBuilder.build(
       festival: @festival,

--- a/app/views/my_timetables/show.html.erb
+++ b/app/views/my_timetables/show.html.erb
@@ -79,27 +79,6 @@
         </div>
       <% end %>
 
-      <% if @performances_without_stage.present? %>
-        <section class="rounded-3xl border border-dashed border-slate-300 bg-white/80 p-4 shadow-sm">
-          <h2 class="text-sm font-bold text-slate-700">ステージ未設定の出演</h2>
-          <div class="mt-3 space-y-2">
-            <% @performances_without_stage.each do |performance| %>
-              <% selected = @selected_performance_ids.include?(performance.id) %>
-              <div class="rounded-2xl border px-4 py-3 shadow-sm <%= selected ? 'border-indigo-200 bg-indigo-500 text-white' : 'border-slate-200 bg-slate-100 text-slate-700' %>">
-                <div class="text-sm font-semibold"><%= performance.artist.name %></div>
-                <div class="mt-1 text-xs font-mono <%= selected ? 'text-indigo-100' : 'text-slate-500' %>">
-                  <%= performance.starts_at&.in_time_zone(@timezone)&.strftime("%H:%M") %> - <%= performance.ends_at&.in_time_zone(@timezone)&.strftime("%H:%M") %>
-                </div>
-                <% if selected %>
-                  <div class="mt-2 inline-flex items-center rounded-full border border-white/70 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-white/90">
-                    選択中
-                  </div>
-                <% end %>
-              </div>
-            <% end %>
-          </div>
-        </section>
-      <% end %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
## 概要
- ステージ未設定の出演をマイタイムテーブル表示から除外し、不要な UI とデータ取得を削除。
## 実施内容
- app/views/my_timetables/show.html.erb から「ステージ未設定の出演」セクションを丸ごと削除し、公開ページに表示しないようにした。
- app/controllers/my_timetables_controller.rb で @performances_without_stage の算出を build アクション専用に移動し、show では取得しないように整理。
## 対応Issue
- #165 
## 関連Issue
なし
## 特記事項