### PR TITLE
[fix]@performances_without_stagの部分を完全削除

### DIFF
--- a/app/controllers/my_timetables_controller.rb
+++ b/app/controllers/my_timetables_controller.rb
@@ -23,9 +23,6 @@ class MyTimetablesController < ApplicationController
                     .joins(:stage_performance)
                     .where(stage_performances: { festival_day_id: @selected_day.id })
                     .pluck(:stage_performance_id)
-
-    @performances_without_stage =
-      @performances.select { |performance| performance.stage_id.blank? }
   end
 
   def create
@@ -132,7 +129,6 @@ class MyTimetablesController < ApplicationController
 
     @performances_by_stage =
       @performances
-        .reject { |performance| performance.stage_id.blank? }
         .group_by(&:stage_id)
 
     timeline_context = TimelineContextBuilder.build(

--- a/app/views/my_timetables/build.html.erb
+++ b/app/views/my_timetables/build.html.erb
@@ -33,42 +33,6 @@
                stage_renderer: stage_renderer
              ) %>
 
-      <% if @performances_without_stage.present? %>
-        <section class="rounded-3xl border border-dashed border-slate-300 bg-white/80 p-4 shadow-sm">
-          <h2 class="text-sm font-bold text-slate-700">ステージ未設定の出演</h2>
-          <p class="mt-2 text-xs text-slate-500">以下の出演はステージが未設定のため、リスト形式で選択できます。</p>
-          <div class="mt-4 space-y-3">
-            <% @performances_without_stage.each do |performance| %>
-              <% checkbox_id = "stage-performance-#{performance.id}" %>
-              <div class="rounded-2xl border border-slate-200 bg-white p-3 shadow-sm">
-                <%= check_box_tag "stage_performance_ids[]",
-                                   performance.id,
-                                   @picked_ids.include?(performance.id),
-                                   id: checkbox_id,
-                                   class: "peer sr-only" %>
-                <label for="<%= checkbox_id %>"
-                       class="block w-full rounded-xl border border-transparent px-3 py-2 transition interactive-lift peer-checked:border-rose-500 peer-checked:bg-rose-50 peer-checked:shadow-md"
-                       data-controller="tap-feedback">
-                  <div class="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
-                    <div>
-                      <div class="text-sm font-semibold text-slate-800">
-                        <%= performance.artist.name %>
-                      </div>
-                      <div class="text-xs font-mono text-slate-500">
-                        <%= performance.starts_at&.in_time_zone(@timezone)&.strftime("%H:%M") %> - <%= performance.ends_at&.in_time_zone(@timezone)&.strftime("%H:%M") %>
-                      </div>
-                    </div>
-                    <span class="mt-1 inline-flex items-center rounded-full border border-slate-300 px-3 py-1 text-xs font-semibold text-slate-600 transition peer-checked:border-rose-500 peer-checked:bg-rose-500 peer-checked:text-white sm:mt-0">
-                      <span class="hidden peer-checked:inline">選択中</span>
-                    </span>
-                  </div>
-                </label>
-              </div>
-            <% end %>
-          </div>
-        </section>
-      <% end %>
-
       <div class="flex justify-center">
         <%= submit_tag "保存する",
                        class: "inline-flex items-center justify-center rounded-2xl bg-indigo-500 px-6 py-3 text-sm font-bold text-white shadow-md interactive-lift hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500" %>


### PR DESCRIPTION
## 概要
- ステージ未設定の出演を UI/データ取得ともに廃止し、マイタイムテーブル作成・閲覧画面から関連処理を削除。
## 実施内容
- app/views/my_timetables/build.html.erb からステージ未設定出演のチェックボックス一覧を削除。
- app/controllers/my_timetables_controller.rb で @performances_without_stage の算出を撤廃し、@performances_by_stage へのフィルタリングも整理。
## 対応Issue
- close #165 
## 関連Issue
なし
## 特記事項