### PR TITLE
[fix]ブラウザ・PWA のステータスバーの色を変更

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,7 @@
 
     <%= yield :head %>
 
-    <%= tag.meta name: "theme-color", content: "#0ea5e9" %>
+    <%= tag.meta name: "theme-color", content: "#F95858" %>
     <%= tag.link rel: "manifest", href: pwa_manifest_path %>
 
     <link rel="icon" type="image/png" sizes="32x32" href="<%= asset_path('fesready_favicon.png') %>">


### PR DESCRIPTION
## 概要
- ブラウザ・PWA のステータスバーの色を変更。

## 実施内容
- app/views/layouts/application.html.erb (line 21) の theme-color をヘッダーのベースカラー #F95858 に変更。
## 対応Issue
なし
## 関連Issue
なし
## 特記事項