### PR TITLE
[add]利用規約ページを作成

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,7 @@
 class HomeController < ApplicationController
   def top
   end
+
+  def terms
+  end
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -39,7 +39,7 @@
       </div>
 
       <p class="text-xs text-center text-slate-600">
-        <%= link_to "利用規約", "#", class: "text-[#F95858] hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#F95858]" %>
+        <%= link_to "利用規約", terms_path, class: "text-[#F95858] hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#F95858]" %>
         と
         <%= link_to "プライバシーポリシー", "#", class: "text-[#F95858] hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#F95858]" %>
         <br>

--- a/app/views/home/terms.html.erb
+++ b/app/views/home/terms.html.erb
@@ -1,0 +1,130 @@
+<% content_for :title, "利用規約 | FES READY" %>
+
+<main
+  class="box-border flex items-center justify-center px-4 py-6 md:py-8"
+  style="height: calc(100vh - var(--header-offset) - var(--footer-offset));"
+>
+  <div class="box-border flex h-full w-full max-w-4xl flex-col rounded-3xl bg-white/95 p-6 shadow-xl ring-1 ring-slate-200 backdrop-blur lg:p-8">
+    <header class="space-y-2 text-center shrink-0">
+      <h1 class="text-2xl font-black text-slate-900">FES READY 利用規約</h1>
+    </header>
+
+    <div class="mt-6 h-px w-full bg-gradient-to-r from-transparent via-[#F95858]/40 to-transparent"></div>
+
+    <div class="mt-6 flex-1 space-y-10 overflow-y-auto pr-2 text-sm leading-relaxed text-slate-700 md:text-base">
+      <section class="space-y-3" id="scope">
+        <h2 class="text-lg font-semibold text-slate-900">1. 規約の適用</h2>
+        <p>
+          本規約は、FES READY（以下「当サービス」）を利用するすべての方（登録ユーザー・未登録ユーザー・管理者を含む）に
+          適用されます。利用者は本規約に同意したうえで、フェス情報の閲覧やマイタイムテーブル作成など全ての機能を利用するものとします。
+        </p>
+      </section>
+
+      <section class="space-y-3" id="overview">
+        <h2 class="text-lg font-semibold text-slate-900">2. サービスの概要</h2>
+        <p>当サービスは音楽フェスの準備体験をワンストップで支援することを目的とし、主に以下の機能を提供します。</p>
+        <ul class="list-disc space-y-2 pl-5">
+          <li>フェスの基本情報（日程・会場・出演アーティスト・タイムテーブル）の検索と閲覧</li>
+          <li>出演アーティスト詳細および Spotify 連携による試聴・予習サポート（順次拡張予定）</li>
+          <li>過去セットリストをもとにした頻出曲ランキングと予習セットリストの提示（順次拡張予定）</li>
+          <li>マイタイムテーブルの作成・保存・SNS 共有機能</li>
+          <li>天気情報と連動した持ち物チェックリストやテンプレートの提供（順次拡張予定）</li>
+        </ul>
+        <p>サービス内容は今後も改善・追加される場合があり、最新情報はアプリ内および公式SNSアカウント等で告知します。</p>
+      </section>
+
+      <section class="space-y-3" id="account">
+        <h2 class="text-lg font-semibold text-slate-900">3. アカウント登録と管理</h2>
+        <ul class="list-disc space-y-2 pl-5">
+          <li>会員登録にはニックネーム、メールアドレス、パスワードが必要です。Googleアカウント連携は任意です。</li>
+          <li>登録情報に虚偽・不備がある場合、または第三者の権利を侵害していると判断した場合、登録を拒否または停止することがあります。</li>
+          <li>ユーザーはログイン情報の管理責任を負い、第三者に譲渡・貸与してはなりません。</li>
+          <li>未成年者は保護者の同意を得たうえで本サービスをご利用ください。</li>
+        </ul>
+      </section>
+
+      <section class="space-y-3" id="responsibility">
+        <h2 class="text-lg font-semibold text-slate-900">4. 利用者の責務</h2>
+        <p>利用者は以下の事項を遵守するものとします。</p>
+        <ul class="list-disc space-y-2 pl-5">
+          <li>提供される情報（タイムテーブル、持ち物リスト等）を自己の責任で参照し、必要に応じて公式情報と照合すること</li>
+          <li>登録したマイタイムテーブルや投稿内容に、第三者の著作権・肖像権・プライバシーを侵害する情報を含めないこと</li>
+          <li>フェス会場および各主催者の規約や感染症対策ガイドラインを順守すること</li>
+        </ul>
+      </section>
+
+      <section class="space-y-3" id="prohibited">
+        <h2 class="text-lg font-semibold text-slate-900">5. 禁止事項</h2>
+        <p>当サービスでは、以下の行為を禁止します。</p>
+        <ul class="list-disc space-y-2 pl-5">
+          <li>法令または公序良俗に違反する行為、犯罪に結びつく行為</li>
+          <li>当サービスまたは第三者の知的財産・肖像・プライバシーを侵害する行為</li>
+          <li>システムへ過度な負荷をかけるアクセスや、脆弱性を探る行為</li>
+          <li>当サービスが提供するデータを無断で転載・複製・販売する行為</li>
+          <li>他のユーザーになりすます、または虚偽の情報で登録する行為</li>
+          <li>Spotify・Open-Meteo 等の外部 API 利用規約に違反する行為</li>
+        </ul>
+      </section>
+
+      <section class="space-y-3" id="data">
+        <h2 class="text-lg font-semibold text-slate-900">6. 情報の取り扱い</h2>
+        <ul class="list-disc space-y-2 pl-5">
+          <li>フェス情報・セットリスト等のデータは運営チームが調査・登録した内容であり、最新性・正確性を完全に保証するものではありません。</li>
+          <li>ユーザーが登録したマイタイムテーブルやお気に入り情報は、サービス改善・分析のために匿名加工した上で利用する場合があります。</li>
+          <li>個人情報の取り扱いは別途定めるプライバシーポリシーに従います。</li>
+        </ul>
+      </section>
+
+      <section class="space-y-3" id="external">
+        <h2 class="text-lg font-semibold text-slate-900">7. 外部サービスとの連携</h2>
+        <p>
+          当サービスは Spotify API および Open-Meteo API 等の外部サービスと連携し、楽曲の試聴リンクや天気情報を取得します。
+          連携先の障害や仕様変更により一部機能が利用できない場合がありますが、当サービスはそれによって生じた損害について責任を負いません。
+        </p>
+      </section>
+
+      <section class="space-y-3" id="disclaimer">
+        <h2 class="text-lg font-semibold text-slate-900">8. 免責事項</h2>
+        <ul class="list-disc space-y-2 pl-5">
+          <li>フェス主催者や出演アーティストの公式発表と当サービスの情報が異なる場合でも、当サービスはその差異によって生じた損害に責任を負いません。</li>
+          <li>ユーザー間または第三者とのトラブルは、当事者間で解決するものとし、当サービスは関与いたしません。</li>
+          <li>通信環境・端末環境・ブラウザ設定等により当サービスを利用できない場合があっても、当サービスは責任を負いません。</li>
+        </ul>
+      </section>
+
+      <section class="space-y-3" id="suspension">
+        <h2 class="text-lg font-semibold text-slate-900">9. サービスの変更・中断・終了</h2>
+        <p>
+          運営は、機能追加や品質向上のためにサービス内容を変更・一時停止・終了する場合があります。
+          緊急メンテナンスや災害、外部 API 停止等により事前告知ができないこともあります。重大な変更がある場合は、公式サイト・SNS 等で周知します。
+        </p>
+      </section>
+
+      <section class="space-y-3" id="termination">
+        <h2 class="text-lg font-semibold text-slate-900">10. 利用停止・退会</h2>
+        <p>
+          利用者が本規約に違反した場合、運営は事前の通知なくアカウント停止・削除等の措置を講じることがあります。
+          退会を希望する場合は、アカウント設定またはお問い合わせフォームから手続きを行ってください。
+        </p>
+      </section>
+
+      <section class="space-y-3" id="revision">
+        <h2 class="text-lg font-semibold text-slate-900">11. 規約の改定</h2>
+        <p>
+          本規約の内容は必要に応じて改定されることがあります。改定後に当サービスを利用した場合、改定内容に同意したものとみなします。
+        </p>
+      </section>
+
+      <section class="space-y-3" id="law">
+        <h2 class="text-lg font-semibold text-slate-900">12. 準拠法・裁判管轄</h2>
+        <p>
+          本規約は日本法に準拠します。当サービスを巡って紛争が生じた場合、運営所在地を管轄する裁判所を第一審の専属的合意管轄裁判所とします。
+        </p>
+      </section>
+    </div>
+
+    <p class="mt-6 text-right text-xs text-slate-500">
+      制定日：<%= Date.current.strftime("%Y年%-m月%-d日") %>（最新版）
+    </p>
+  </div>
+</main>

--- a/app/views/shared/_side_menu.html.erb
+++ b/app/views/shared/_side_menu.html.erb
@@ -6,7 +6,7 @@
   { label: "ログイン", href: new_user_session_path }
 ] %>
 <% secondary_links = [
-  { label: "利用規約", href: "#" },
+  { label: "利用規約", href: terms_path },
   { label: "プライバシーポリシー", href: "#" }
 ] %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,10 +2,12 @@ Rails.application.routes.draw do
   devise_for :users
 
   root "home#top"
+  get "/terms", to: "home#terms", as: :terms
+
   get "up" => "rails/health#show", as: :rails_health_check
   get "/service-worker.js", to: "rails/pwa#service_worker", defaults: { format: :js }, as: :pwa_service_worker
   get "/manifest.webmanifest", to: "rails/pwa#manifest", defaults: { format: :json }, as: :pwa_manifest
-
+  
   resources :artists, only: [ :index, :show ] do
     resources :festivals, only: [ :index ], controller: :festivals
   end


### PR DESCRIPTION
## 概要
- 利用規約ページを追加。

## 実施内容
- 利用規約ページ用のルート (/terms) と HomeController#terms を追加し、新しいビュー app/views/home/terms.html.erb で 12 章構成の規約本文を実装しました。README のサービス方針を踏まえて条文化しています。
- 既存リンク（app/views/devise/registrations/new.html.erb と app/views/shared/_side_menu.html.erb）の「利用規約」を terms_path に差し替え、新規登録ページとサイドバーから規約ページへ遷移できるようにしました。

## 対応Issue
- close #155 
## 関連Issue
なし
## 特記事項