### PR TITLE
[fix]利用規約ページからの戻るボタンの挙動修正

### DIFF
--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -4,6 +4,8 @@ module NavigationHelper
     return @header_back_path if defined?(@header_back_path) && @header_back_path.present?
 
     case controller_path
+    when "home"
+      home_back_path
     when "festivals"
       festivals_back_path
     when "artists"
@@ -16,6 +18,26 @@ module NavigationHelper
   end
 
   private
+
+  def home_back_path
+    return safe_referer_path || root_path if action_name == "terms"
+
+    root_path
+  end
+
+  def safe_referer_path
+    return if request.referer.blank?
+
+    uri = URI.parse(request.referer)
+    return if uri.host.present? && uri.host != request.host
+
+    path = uri.path.presence || root_path
+    query = uri.query.present? ? "?#{uri.query}" : ""
+    fragment = uri.fragment.present? ? "##{uri.fragment}" : ""
+    "#{path}#{query}#{fragment}"
+  rescue URI::InvalidURIError
+    nil
+  end
 
   def festivals_back_path
     case params[:from]


### PR DESCRIPTION
## 概要
- 利用規約ページを開いたときに、ヘッダーの戻るボタンで元の画面へ戻れない問題を解消するため、戻り先判定ロジックをヘルパー側へ集約。
## 実施内容
- HomeController からリファラ処理を削除し、戻り先の決定責務を NavigationHelper#header_back_path に一本化。
- header_back_path の分岐に when "home" を追加し、home_back_path で terms アクションの戻り先を制御。
- home_back_path と safe_referer_path を NavigationHelper に実装し、同一ホストのリファラのみを安全に復元して戻り先に利用、無効時は root_path へフォールバック。
## 対応Issue
なし 
## 関連Issue
- #155 
## 特記事項