### PR TITLE
[refactor]ネストされたルーティングの変更に伴うコード整理

### DIFF
--- a/app/controllers/admin/artists_controller.rb
+++ b/app/controllers/admin/artists_controller.rb
@@ -35,16 +35,12 @@ class Admin::ArtistsController < Admin::BaseController
 
   private
   def set_artist
-    @artist = find_artist_by_identifier!(params[:id])
+    @artist = Artist.find_by_identifier!(params[:id])
   end
 
   def artist_params
     params.require(:artist).permit(:name, :spotify_artist_id, :image_url).tap do |p|
       p[:spotify_artist_id] = p[:spotify_artist_id].presence
     end
-  end
-
-  def find_artist_by_identifier!(identifier)
-    Artist.find_by(uuid: identifier) || Artist.find(identifier)
   end
 end

--- a/app/controllers/admin/festivals_controller.rb
+++ b/app/controllers/admin/festivals_controller.rb
@@ -55,7 +55,7 @@ class Admin::FestivalsController < Admin::BaseController
   private
 
   def set_festival
-    @festival = Festival.find_by!(slug: params[:id])
+    @festival = Festival.find_by_slug!(params[:id])
   end
 
   # 1ページ目（基本情報のみ）

--- a/app/controllers/artists/festivals_controller.rb
+++ b/app/controllers/artists/festivals_controller.rb
@@ -1,0 +1,23 @@
+class Artists::FestivalsController < ApplicationController
+  before_action :set_artist
+
+  def index
+    @status = Festival.normalized_status(params[:status])
+    @status_labels = Festival.status_labels
+
+    base = @artist.festivals.merge(Festival.for_status(@status))
+    @q   = base.ransack(params[:q])
+    result = @q.result(distinct: true)
+
+    pagy_params = request.query_parameters.merge(status: @status)
+    @pagy, @festivals = pagy(result, items: 20, params: pagy_params)
+
+    render "festivals/index"
+  end
+
+  private
+
+  def set_artist
+    @artist = Artist.find_by_identifier!(params[:artist_id])
+  end
+end

--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -1,45 +1,17 @@
 class ArtistsController < ApplicationController
   def index
-    @festival = Festival.find_by(slug: params[:festival_id])
+    @festival = nil
+    @festival_days = []
+    @selected_festival_day = nil
 
-    base =
-    if @festival
-      @festival_days = @festival.festival_days.order(:date)
-      @selected_festival_day = if params[:festival_day_id].present?
-        @festival_days.find_by(id: params[:festival_day_id])
-      end
-      @selected_festival_day ||= @festival_days.first
-
-      if @selected_festival_day
-        Artist
-          .joins(stage_performances: :festival_day)
-          .where(stage_performances: { festival_day_id: @selected_festival_day.id })
-          .distinct
-          .includes(stage_performances: :festival_day)
-      else
-        Artist.none
-      end
-    else
-      @festival_days = []
-      @selected_festival_day = nil
-      Artist.all
-    end
-
-    base = base.order(:name)
-
-    @q     = base.ransack(params[:q])
+    scope = Artist.order(:name)
+    @q     = scope.ransack(params[:q])
     result = @q.result(distinct: true)
 
     @pagy, @artists = pagy(result, params: request.query_parameters)
   end
 
   def show
-    @artist = find_artist_by_identifier!(params[:id])
-  end
-
-  private
-
-  def find_artist_by_identifier!(identifier)
-    Artist.find_by(uuid: identifier) || Artist.find(identifier)
+    @artist = Artist.find_by_identifier!(params[:id])
   end
 end

--- a/app/controllers/festivals/artists_controller.rb
+++ b/app/controllers/festivals/artists_controller.rb
@@ -1,0 +1,23 @@
+class Festivals::ArtistsController < ApplicationController
+  before_action :set_festival
+
+  def index
+    @festival_days = @festival.festival_days.order(:date)
+    @selected_festival_day = @festival_days.find_by(id: params[:festival_day_id]) || @festival_days.first
+
+    artists_scope = @festival.artists_for_day(@selected_festival_day)
+
+    @q     = artists_scope.ransack(params[:q])
+    result = @q.result(distinct: true)
+
+    @pagy, @artists = pagy(result, params: request.query_parameters)
+
+    render "artists/index"
+  end
+
+  private
+
+  def set_festival
+    @festival = Festival.find_by_slug!(params[:festival_id])
+  end
+end

--- a/app/controllers/my_timetables_controller.rb
+++ b/app/controllers/my_timetables_controller.rb
@@ -71,7 +71,7 @@ class MyTimetablesController < ApplicationController
 
   def set_festival!
     slug = params[:festival_id] || params[:id]
-    @festival = Festival.find_by!(slug: slug)
+    @festival = Festival.find_by_slug!(slug)
   end
 
   def set_selected_day!

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -6,9 +6,9 @@ module NavigationHelper
     case controller_path
     when "home"
       home_back_path
-    when "festivals"
+    when "festivals", "festivals/artists"
       festivals_back_path
-    when "artists"
+    when "artists", "artists/festivals"
       artists_back_path
     when "my_timetables"
       my_timetables_back_path

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -9,6 +9,10 @@ class Artist < ApplicationRecord
 
   before_create :ensure_uuid!
 
+  def self.find_by_identifier!(identifier)
+    find_by(uuid: identifier) || find(identifier)
+  end
+
   def self.ransackable_attributes(_ = nil); %w[name]; end
   def self.ransackable_associations(_ = nil); []; end
 

--- a/app/models/festival.rb
+++ b/app/models/festival.rb
@@ -1,4 +1,7 @@
 class Festival < ApplicationRecord
+  attribute :status_filter, :string
+  enum :status_filter, { upcoming: "upcoming", past: "past" }, scopes: false
+
   has_many :festival_days, dependent: :destroy, inverse_of: :festival
   has_many :stages,        dependent: :destroy, inverse_of: :festival
 
@@ -28,20 +31,53 @@ class Festival < ApplicationRecord
     slug.presence || super
   end
 
+  scope :with_slug, ->(slug) { where(slug: slug) }
+
+  def self.status_labels
+    status_filters.keys.index_with do |key|
+      I18n.t("enums.festival.status_filter.#{key}", default: key.humanize)
+    end
+  end
+
+  def self.default_status
+    status_filters.keys.first
+  end
+
+  def self.normalized_status(value)
+    candidate = value.to_s
+    status_filters.key?(candidate) ? candidate : default_status
+  end
+
+  def self.for_status(status, reference_date: Date.current)
+    normalized = normalized_status(status)
+    relation = normalized == "past" ? past(reference_date) : upcoming(reference_date)
+    relation.merge(ordered)
+  end
+
+  def self.find_by_slug!(slug, scope: all)
+    scope.find_by!(slug: slug)
+  end
+
   def timetable_days
     festival_days.order(:date)
   end
 
   def stage_performances_for(day_or_date)
-    day =
-      if day_or_date.is_a?(FestivalDay)
-        day_or_date
-      else
-        festival_days.find_by!(date: day_or_date)
-      end
+    day = day_or_date.is_a?(FestivalDay) ? day_or_date : festival_days.find_by!(date: day_or_date)
     day.stage_performances
        .includes(:stage, :artist)
        .order(:starts_at)
+  end
+
+  def artists_for_day(festival_day)
+    return Artist.none if festival_day.blank? || festival_day.festival_id != id
+
+    Artist
+      .joins(stage_performances: :festival_day)
+      .where(stage_performances: { festival_day_id: festival_day.id })
+      .distinct
+      .includes(stage_performances: :festival_day)
+      .order(:name)
   end
 
   private

--- a/config/locales/activerecord.ja.yml
+++ b/config/locales/activerecord.ja.yml
@@ -13,3 +13,7 @@ ja:
       role:
         general: 一般
         admin: 管理者
+    festival:
+      status_filter:
+        upcoming: 開催前
+        past: 開催済み

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,3 +29,8 @@
 
 en:
   hello: "Hello world"
+  enums:
+    festival:
+      status_filter:
+        upcoming: Upcoming
+        past: Past

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,14 +10,14 @@ Rails.application.routes.draw do
   get "/manifest.webmanifest", to: "rails/pwa#manifest", defaults: { format: :json }, as: :pwa_manifest
 
   resources :artists, only: [ :index, :show ] do
-    resources :festivals, only: [ :index ], controller: :festivals
+    resources :festivals, only: [ :index ], module: :artists
   end
 
   resources :timetables, only: [ :index ]
   resources :my_timetables, only: [ :index ]
 
   resources :festivals, only: [ :index, :show ] do
-    resources :artists, only: [ :index ], controller: :artists
+    resources :artists, only: [ :index ], module: :festivals
     member do
       get :timetable
       # マイタイムテーブル（作成→保存→表示）


### PR DESCRIPTION
## 概要
- フェスとアーティストのネストルートを名前空間付きコントローラーへ分離し、戻るボタン含めたルーティング挙動の整合性と再利用可能なモデルロジックを整備しました。
## 実施内容
- config/routes.rb を更新し、/artists/:artist_id/festivals は Artists::FestivalsController、/festivals/:festival_id/artists は Festivals::ArtistsController に対応させるよう module 指定を追加。
- app/controllers/artists/festivals_controller.rb と app/controllers/festivals/artists_controller.rb を新設し、親リソースのロード・検-索・Pagy を名前空間側で完結させたうえで既存ビューを render で再利用。
- Festival モデルに status_filter enum（仮想属性）、status_labels/normalized_status/for_status/find_by_slug!/artists_for_day などのヘルパーを実装し、開催前後フィルタや関連アーティスト取得をモデル側へ集約。Artist モデルにも find_by_identifier! を追加。
- すべての関連コントローラー（FestivalsController, Artists::FestivalsController, Festivals::ArtistsController, Admin::FestivalsController, MyTimetablesController）で新ヘルパーを利用するようリファクタリングし、Festival.for_status などでフィルタ処理を統一。
- app/helpers/navigation_helper.rb の header_back_path を更新し、新しい名前空間付きコントローラー (festivals/artists, artists/festivals) からの戻る動作も従来どおり動くように調整。
- config/locales/activerecord.ja.yml / config/locales/en.yml に enums.festival.status_filter を追加し、開催前／開催済みタブのラベルを I18n 管理に変更。
- 補助的に Festival#stage_performances_for を三項演算子で簡潔化し、ArtistsController／FestivalsController 本体はトップレベルの一覧機能に専念できるよう整理しました。
## 対応Issue
- #165
## 関連Issue
なし
## 特記事項