### PR TITLE
[refactor]timetableメソッドの移行

### DIFF
--- a/app/controllers/festivals_controller.rb
+++ b/app/controllers/festivals_controller.rb
@@ -1,6 +1,5 @@
 class FestivalsController < ApplicationController
-  before_action :set_festival, only: [ :show, :timetable ]
-  before_action :ensure_timetable_published!, only: :timetable
+  before_action :set_festival, only: :show
 
   def index
     @artist = nil
@@ -18,60 +17,10 @@ class FestivalsController < ApplicationController
   def show
   end
 
-  def timetable
-    @festival_days = @festival.timetable_days
-    raise ActiveRecord::RecordNotFound if @festival_days.blank?
-
-    @timetable_query_params =
-      params.permit(:from, :artist_id, :festival_id, :user_id).to_h
-
-    @selected_day =
-      if params[:date].present?
-        begin
-          date = Date.parse(params[:date])
-        rescue ArgumentError
-          raise ActiveRecord::RecordNotFound
-        end
-        @festival.festival_days.find_by!(date: date)
-      else
-        @festival_days.first
-      end
-
-    @timezone = ActiveSupport::TimeZone[@festival.timezone] || Time.zone
-
-    @stages = @festival.stages.order(:sort_order, :id)
-
-    @performances =
-      @festival
-        .stage_performances_for(@selected_day)
-        .scheduled
-        .includes(:stage, :artist)
-
-    @performances_by_stage =
-      @performances
-        .reject { |performance| performance.stage_id.blank? }
-        .group_by(&:stage_id)
-
-    timeline_context = TimelineContextBuilder.build(
-      festival: @festival,
-      selected_day: @selected_day,
-      timezone: @timezone
-    )
-
-    @timeline_start = timeline_context.timeline_start
-    @timeline_end   = timeline_context.timeline_end
-    @time_markers   = timeline_context.time_markers
-    @timeline_layout = timeline_context.timeline_layout
-  end
-
   private
 
   def set_festival
     relation = Festival.includes(:festival_days, :stages)
     @festival = Festival.find_by_slug!(params[:id], scope: relation)
-  end
-
-  def ensure_timetable_published!
-    raise ActiveRecord::RecordNotFound unless @festival.timetable_published?
   end
 end

--- a/app/controllers/timetables_controller.rb
+++ b/app/controllers/timetables_controller.rb
@@ -1,22 +1,91 @@
 class TimetablesController < ApplicationController
+  before_action :set_festival, only: :show
+  before_action :ensure_timetable_published!, only: :show
+  before_action :load_festival_days, only: :show
+
   def index
-    @status = params[:status]
-    @status = "upcoming" unless %w[upcoming past].include?(@status)
-    @status_labels = { "upcoming" => "開催前", "past" => "開催済み" }
+    @status = Festival.normalized_status(params[:status])
+    @status_labels = Festival.status_labels
 
-    today = Date.current
-    base  = Festival.with_published_timetable.ordered
-
-    scoped =
-      case @status
-      when "past" then base.merge(Festival.past(today))
-      else             base.merge(Festival.upcoming(today))
-      end
+    published_festivals = Festival.with_published_timetable
+    scoped = published_festivals.merge(Festival.for_status(@status))
 
     @q = scoped.ransack(params[:q])
     result = @q.result(distinct: true)
 
     pagy_params = request.query_parameters.merge(status: @status)
     @pagy, @festivals = pagy(result, items: 20, params: pagy_params)
+  end
+
+  def show
+    extract_timetable_params
+    resolve_selected_day
+    build_timeline_context
+
+    @stages = @festival.stages.order(:sort_order, :id)
+    @performances_by_stage = performances_by_stage
+  end
+
+  private
+
+  def set_festival
+    relation = Festival.includes(:festival_days, :stages)
+    @festival = Festival.find_by_slug!(params[:id], scope: relation)
+  end
+
+  def ensure_timetable_published!
+    raise ActiveRecord::RecordNotFound unless @festival.timetable_published?
+  end
+
+  def load_festival_days
+    @festival_days = @festival.timetable_days
+    raise ActiveRecord::RecordNotFound if @festival_days.blank?
+  end
+
+  def extract_timetable_params
+    @timetable_query_params = timetable_query_params
+  end
+
+  def resolve_selected_day
+    @selected_day =
+      if params[:date].present?
+        begin
+          parsed = Date.parse(params[:date])
+        rescue ArgumentError
+          raise ActiveRecord::RecordNotFound
+        end
+        @festival.festival_days.find_by!(date: parsed)
+      else
+        @festival_days.first
+      end
+  end
+
+  def build_timeline_context
+    @timezone = ActiveSupport::TimeZone[@festival.timezone] || Time.zone
+
+    timeline_context = TimelineContextBuilder.build(
+      festival: @festival,
+      selected_day: @selected_day,
+      timezone: @timezone
+    )
+
+    @timeline_start = timeline_context.timeline_start
+    @timeline_end   = timeline_context.timeline_end
+    @time_markers   = timeline_context.time_markers
+    @timeline_layout = timeline_context.timeline_layout
+  end
+
+  def performances_by_stage
+    @performances_by_stage ||=
+      @festival
+        .stage_performances_for(@selected_day)
+        .scheduled
+        .where.not(stage_id: nil)
+        .includes(:stage, :artist)
+        .group_by(&:stage_id)
+  end
+
+  def timetable_query_params
+    params.permit(:from, :artist_id, :festival_id, :user_id).to_h
   end
 end

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -77,7 +77,7 @@ module NavigationHelper
   def timetable_back_path
     options = {}
     options[:date] = params[:date] if params[:date].present?
-    timetable_festival_path(params[:festival_id], options)
+    timetable_path(params[:festival_id], options)
   end
 
   def my_timetable_back_path
@@ -96,7 +96,7 @@ module NavigationHelper
       my_timetables_path
     else
       identifier = params[:festival_id] || params[:id]
-      identifier.present? ? timetable_festival_path(identifier) : root_path
+      identifier.present? ? timetable_path(identifier) : root_path
     end
   end
 end

--- a/app/views/festivals/show.html.erb
+++ b/app/views/festivals/show.html.erb
@@ -64,7 +64,7 @@
           出演アーティスト一覧へ
         <% end %>
         <% if @festival.timetable_published? %>
-          <%= link_to timetable_festival_path(@festival),
+          <%= link_to timetable_path(@festival),
                       class: "block w-full rounded-2xl bg-indigo-500 py-3 text-center text-sm font-bold text-white shadow-md interactive-lift hover:bg-indigo-400",
                       data: { controller: "tap-feedback" } do %>
             タイムテーブルへ

--- a/app/views/timetables/index.html.erb
+++ b/app/views/timetables/index.html.erb
@@ -34,7 +34,7 @@
           <div class="w-full">
             <%= render "shared/nav_stack_button",
                        label: festival.name,
-                       url: timetable_festival_path(festival, from: "timetables") %>
+                       url: timetable_path(festival, from: "timetables") %>
           </div>
         <% end %>
       <% else %>

--- a/app/views/timetables/show.html.erb
+++ b/app/views/timetables/show.html.erb
@@ -14,7 +14,7 @@
               active_key: @selected_day.id,
               url_builder: ->(festival_day_id) do
                 day = day_lookup[festival_day_id]
-                timetable_festival_path(@festival, @timetable_query_params.merge("date" => day.date.to_s))
+                timetable_path(@festival, @timetable_query_params.merge("date" => day.date.to_s))
               end
             ) %>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,13 +13,12 @@ Rails.application.routes.draw do
     resources :festivals, only: [ :index ], module: :artists
   end
 
-  resources :timetables, only: [ :index ]
+  resources :timetables, only: [ :index, :show ]
   resources :my_timetables, only: [ :index ]
 
   resources :festivals, only: [ :index, :show ] do
     resources :artists, only: [ :index ], module: :festivals
     member do
-      get :timetable
       # マイタイムテーブル（作成→保存→表示）
       get  "my_timetable/build", to: "my_timetables#build",  as: :build_my_timetable
       post "my_timetable",       to: "my_timetables#create", as: :my_timetable


### PR DESCRIPTION
## 概要
- フェス詳細から切り離した RESTful な TimetablesController#show を新設し、タイムテーブル表示処理とビューを移管。
- タイムテーブル一覧の絞り込みロジックを Festival モデルのステータス API に統一し、公開済みフェスのみに限定。
## 実施内容
- FestivalsController#timetable を削除し、TimetablesController#show に load_festival_days・resolve_selected_day・build_timeline_context・performances_by_stage を実装。関連ビューを app/views/timetables/show.html.erb へ移動。
- ルーティングを resources :timetables, only: [:index, :show] に変更し、既存リンク・ヘルパ（timetable_path など）を更新。
- TimetablesController#index で Festival.normalized_status, Festival.status_labels, Festival.for_status を利用し、published_festivals（with_published_timetable）に限定した上で検索・ページネーションを実行。
## 対応Issue
- #165 
## 関連Issue
なし
## 特記事項