### PR TITLE
[refactor]indexアクション内のメソッド化

### DIFF
--- a/app/controllers/festivals/artists_controller.rb
+++ b/app/controllers/festivals/artists_controller.rb
@@ -1,10 +1,8 @@
 class Festivals::ArtistsController < ApplicationController
   before_action :set_festival
+  before_action :set_festival_days
 
   def index
-    @festival_days = @festival.festival_days.order(:date)
-    @selected_festival_day = @festival_days.find_by(id: params[:festival_day_id]) || @festival_days.first
-
     artists_scope = @festival.artists_for_day(@selected_festival_day)
 
     @q     = artists_scope.ransack(params[:q])
@@ -19,5 +17,10 @@ class Festivals::ArtistsController < ApplicationController
 
   def set_festival
     @festival = Festival.find_by_slug!(params[:festival_id])
+  end
+
+  def set_festival_days
+    @festival_days = @festival.festival_days.order(:date)
+    @selected_festival_day = @festival_days.find_by(id: params[:festival_day_id]) || @festival_days.first
   end
 end


### PR DESCRIPTION
## 概要
- アーティスト別フェス一覧ページのコントローラ内で、フェス日程のセット処理を共通化しコードの見通しを改善。
## 実施内容
- Festivals::ArtistsController#index から @festival_days と @selected_festival_day の算出処理を before_action :set_festival_days に切り出し、private メソッドとして定義
## 対応Issue
- #165 
## 関連Issue
なし
## 特記事項