### PR TITLE
[fix]変数名のリネーム

### DIFF
--- a/app/controllers/artists/festivals_controller.rb
+++ b/app/controllers/artists/festivals_controller.rb
@@ -5,8 +5,8 @@ class Artists::FestivalsController < ApplicationController
     @status = Festival.normalized_status(params[:status])
     @status_labels = Festival.status_labels
 
-    base = @artist.festivals.merge(Festival.for_status(@status))
-    @q   = base.ransack(params[:q])
+    festival_scope = @artist.festivals.merge(Festival.for_status(@status))
+    @q   = festival_scope.ransack(params[:q])
     result = @q.result(distinct: true)
 
     pagy_params = request.query_parameters.merge(status: @status)

--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -4,8 +4,8 @@ class ArtistsController < ApplicationController
     @festival_days = []
     @selected_festival_day = nil
 
-    scope = Artist.order(:name)
-    @q     = scope.ransack(params[:q])
+    artists_scope = Artist.order(:name)
+    @q     = artists_scope.ransack(params[:q])
     result = @q.result(distinct: true)
 
     @pagy, @artists = pagy(result, params: request.query_parameters)

--- a/app/controllers/festivals_controller.rb
+++ b/app/controllers/festivals_controller.rb
@@ -6,8 +6,8 @@ class FestivalsController < ApplicationController
     @status = Festival.normalized_status(params[:status])
     @status_labels = Festival.status_labels
 
-    base   = Festival.for_status(@status)
-    @q     = base.ransack(params[:q])
+    festival_scope = Festival.for_status(@status)
+    @q     = festival_scope.ransack(params[:q])
     result = @q.result(distinct: true)
 
     pagy_params = request.query_parameters.merge(status: @status)
@@ -20,7 +20,7 @@ class FestivalsController < ApplicationController
   private
 
   def set_festival
-    relation = Festival.includes(:festival_days, :stages)
-    @festival = Festival.find_by_slug!(params[:id], scope: relation)
+    festival_relation = Festival.includes(:festival_days, :stages)
+    @festival = Festival.find_by_slug!(params[:id], scope: festival_relation)
   end
 end

--- a/app/controllers/timetables_controller.rb
+++ b/app/controllers/timetables_controller.rb
@@ -29,8 +29,8 @@ class TimetablesController < ApplicationController
   private
 
   def set_festival
-    relation = Festival.includes(:festival_days, :stages)
-    @festival = Festival.find_by_slug!(params[:id], scope: relation)
+    festival_relation = Festival.includes(:festival_days, :stages)
+    @festival = Festival.find_by_slug!(params[:id], scope: festival_relation)
   end
 
   def ensure_timetable_published!


### PR DESCRIPTION
## 概要
- フェス関連コントローラ内の変数名をわかりやすくしました。
## 実施内容
- Artists::FestivalsController#index と FestivalsController#index の一時変数を festival_scope にリネームし、処理内容がわかりやすい名前に変更。
- ArtistsController#index の検索対象変数を artists_scope にリネームし、他コントローラと命名を統一。
- FestivalsController#set_festival と TimetablesController#set_festival の relation を festival_relation にリネームし、どの Relation を扱うか明示。
## 対応Issue
なし
## 関連Issue
なし
## 特記事項