### PR TITLE
[fix]メソッド内の不要なコードの削除

### DIFF
--- a/app/models/festival.rb
+++ b/app/models/festival.rb
@@ -76,7 +76,6 @@ class Festival < ApplicationRecord
       .joins(stage_performances: :festival_day)
       .where(stage_performances: { festival_day_id: festival_day.id })
       .distinct
-      .includes(stage_performances: :festival_day)
       .order(:name)
   end
 


### PR DESCRIPTION
## 概要
- Festival#artists_for_dayの不要なコードを削除。
## 実施内容
- Festival#artists_for_day から includes(stage_performances: :festival_day) を削除し、使われていない関連の eager load をなくした。
## 対応Issue
- #165 
## 関連Issue
なし
## 特記事項