### PR TITLE
[refactor]マイタイムテーブル機能のリファクタ

### DIFF
--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -85,7 +85,7 @@ module NavigationHelper
     options = {}
     options[:date] = params[:date] if params[:date].present?
     options[:user_id] = params[:user_id] if params[:user_id].present?
-    my_timetable_festival_path(params[:festival_id], options)
+    festival_my_timetable_path(params[:festival_id], options)
   end
 
   def my_timetables_back_path

--- a/app/models/festival_day.rb
+++ b/app/models/festival_day.rb
@@ -4,4 +4,12 @@ class FestivalDay < ApplicationRecord
 
   validates :date, presence: true
   validates :date, uniqueness: { scope: :festival_id }
+
+  scope :for_user, ->(user) {
+    joins(:festival, stage_performances: :user_timetable_entries)
+      .where(user_timetable_entries: { user_id: user.id })
+      .includes(:festival)
+      .distinct
+      .order("festivals.start_date ASC", "festival_days.date ASC")
+  }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,13 @@ class User < ApplicationRecord
     user_timetable_entries.exists?(stage_performance_id: stage_performance.id)
   end
 
+  def stage_performance_ids_for_day(festival_day)
+    user_timetable_entries
+      .joins(:stage_performance)
+      .where(stage_performances: { festival_day_id: festival_day.id })
+      .pluck(:stage_performance_id)
+  end
+
   def to_param
     uuid
   end

--- a/app/services/my_timetables/updater.rb
+++ b/app/services/my_timetables/updater.rb
@@ -1,0 +1,38 @@
+module MyTimetables
+  class Updater
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(user:, festival_day:, stage_performance_ids:)
+      @user = user
+      @festival_day = festival_day
+      @stage_performance_ids = Array(stage_performance_ids).map(&:to_i)
+    end
+
+    def call
+      ActiveRecord::Base.transaction do
+        delete_existing_entries
+        filtered_ids.each do |stage_performance_id|
+          user.user_timetable_entries.create!(stage_performance_id: stage_performance_id)
+        end
+      end
+    end
+
+    private
+
+    attr_reader :user, :festival_day, :stage_performance_ids
+
+    def delete_existing_entries
+      user.user_timetable_entries
+          .joins(:stage_performance)
+          .where(stage_performances: { festival_day_id: festival_day.id })
+          .delete_all
+    end
+
+    def filtered_ids
+      allowed_ids = StagePerformance.where(festival_day_id: festival_day.id).pluck(:id)
+      (stage_performance_ids & allowed_ids).uniq
+    end
+  end
+end

--- a/app/views/my_timetables/edit.html.erb
+++ b/app/views/my_timetables/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="min-h-screen px-4 pb-24 pt-6">
   <div class="mx-auto flex max-w-6xl flex-col gap-6">
     <%= render Shared::TimetableHeaderComponent.new(
-                 title: "マイタイムテーブル作成",
+                 title: "マイタイムテーブル編集",
                  festival_name: @festival.name,
                  selected_day: @selected_day,
                  timezone: @timezone
@@ -11,8 +11,8 @@
       </p>
     <% end %>
 
-    <%= form_with url: my_timetable_festival_path(@festival, date: @selected_day.date.to_s, user_id: current_user.uuid),
-                  method: :post,
+    <%= form_with url: festival_my_timetable_path(@festival, date: @selected_day.date.to_s, user_id: current_user.uuid),
+                  method: :patch,
                   class: "flex flex-col gap-6" do %>
       <% stage_renderer = ->(stage) do
            render StageColumns::PickerComponent.new(

--- a/app/views/my_timetables/index.html.erb
+++ b/app/views/my_timetables/index.html.erb
@@ -5,7 +5,7 @@
       <p class="text-sm text-slate-600">作成したマイタイムテーブルを確認できます。</p>
     </header>
 
-    <% if @festival_days.present? %>
+    <% if @festival_day_groups.present? %>
       <section class="space-y-6">
         <% @festival_day_groups.each do |festival, days| %>
           <div class="grid gap-3 md:grid-cols-2 md:gap-4">
@@ -13,7 +13,7 @@
               <div class="w-full">
                 <%= render "shared/nav_stack_button",
                            label: "#{festival.name} - #{format_date_with_weekday(festival_day.date)}",
-                           url: my_timetable_festival_path(festival, date: festival_day.date.to_s) %>
+                           url: festival_my_timetable_path(festival, date: festival_day.date.to_s) %>
               </div>
             <% end %>
           </div>

--- a/app/views/my_timetables/show.html.erb
+++ b/app/views/my_timetables/show.html.erb
@@ -11,11 +11,11 @@
         <% if @timetable_owner == current_user %>
           <div class="flex items-center gap-3">
             <%= link_to "編集する",
-                        build_my_timetable_festival_path(@festival, date: @selected_day.date.to_s),
+                        edit_festival_my_timetable_path(@festival, date: @selected_day.date.to_s),
                         class: "inline-flex items-center justify-center rounded-2xl bg-indigo-500 px-5 py-2.5 text-sm font-bold text-white shadow-md interactive-lift hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500",
                         data: { controller: "tap-feedback" } %>
             <%= button_to "削除する",
-                          my_timetable_festival_path(@festival, date: @selected_day.date.to_s),
+                          festival_my_timetable_path(@festival, date: @selected_day.date.to_s),
                           method: :delete,
                           data: { controller: "tap-feedback", turbo_confirm: "このマイタイムテーブルを削除しますか？" },
                           class: "inline-flex items-center justify-center rounded-2xl bg-rose-500 px-5 py-2.5 text-sm font-bold text-white shadow-md interactive-lift hover:bg-rose-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500" %>
@@ -28,7 +28,7 @@
       <div class="rounded-3xl border border-dashed border-slate-300 bg-white/80 px-6 py-12 text-center text-sm text-slate-600 shadow-sm">
         この日に選択した出演がまだありません。<br class="hidden sm:block" />
         <%= link_to "マイタイムテーブルを作成する",
-                    build_my_timetable_festival_path(@festival, date: @selected_day.date.to_s),
+                    edit_festival_my_timetable_path(@festival, date: @selected_day.date.to_s),
                     class: "inline-flex items-center justify-center rounded-full bg-indigo-500 px-4 py-2 text-sm font-semibold text-white shadow-md interactive-lift hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 mt-4",
                     data: { controller: "tap-feedback" } %>
       </div>
@@ -64,7 +64,7 @@
 
       <% if @timetable_owner == current_user %>
         <% share_text = "FES READYで #{@festival.name} のマイタイムテーブルを作成しました！" %>
-        <% share_link = my_timetable_festival_url(@festival,
+        <% share_link = festival_my_timetable_url(@festival,
                                                   date: @selected_day.date.to_s,
                                                   user_id: current_user.uuid) %>
         <% share_href = "https://twitter.com/intent/tweet?text=#{ERB::Util.url_encode(share_text + "\n")}&url=#{ERB::Util.url_encode(share_link)}" %>

--- a/app/views/timetables/show.html.erb
+++ b/app/views/timetables/show.html.erb
@@ -20,8 +20,8 @@
       </div>
       <% if user_signed_in? %>
         <div class="mt-4 flex justify-center">
-          <%= link_to "この日程のマイタイムテーブルを作成",
-                      build_my_timetable_festival_path(@festival, date: @selected_day.date.to_s),
+          <%= link_to "この日程のマイタイムテーブルを編集",
+                      edit_festival_my_timetable_path(@festival, date: @selected_day.date.to_s),
                       class: "inline-flex items-center justify-center rounded-2xl bg-indigo-500 px-6 py-3 text-sm font-bold text-white shadow-md interactive-lift hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500",
                       data: { controller: "tap-feedback" } %>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,13 +18,7 @@ Rails.application.routes.draw do
 
   resources :festivals, only: [ :index, :show ] do
     resources :artists, only: [ :index ], module: :festivals
-    member do
-      # マイタイムテーブル（作成→保存→表示）
-      get  "my_timetable/build", to: "my_timetables#build",  as: :build_my_timetable
-      post "my_timetable",       to: "my_timetables#create", as: :my_timetable
-      get  "my_timetable",       to: "my_timetables#show"
-      delete "my_timetable",     to: "my_timetables#destroy"
-    end
+    resource :my_timetable, only: [ :show, :edit, :update, :destroy ], controller: :my_timetables
   end
 
   namespace :admin do


### PR DESCRIPTION
## 概要
- マイタイムテーブル機能を Rails の RESTful な形に整理し、ルート・画面・コントローラの命名や責務を統一しました。
- 取得／更新のロジックはモデルやサービスに切り出し、コントローラを薄くしました。
## 実施内容
- FestivalDay.for_user(user) スコープを追加し、MyTimetables#index でのフェス日程取得をモデルに移譲。
- User#stage_performance_ids_for_day を追加して選択済み出演 ID 抽出を共通化。
- MyTimetables::Updater サービスを新設し、許可 ID フィルタ・削除→再作成をまとめて担当させた。
- build/create を edit/update にリネームし、resource :my_timetable ルートへ置き換え、各ビュー・ヘルパーの URL/文言を新ルートに合わせて更新。
## 対応Issue
- #165 
## 関連Issue
なし
## 特記事項