### PR TITLE
[refacror]stage_performances_forメソッドのコード修正

### DIFF
--- a/app/controllers/my_timetables_controller.rb
+++ b/app/controllers/my_timetables_controller.rb
@@ -101,7 +101,7 @@ class MyTimetablesController < ApplicationController
 
     @performances =
       @festival
-        .stage_performances_for(@selected_day)
+        .stage_performances_on(@selected_day)
         .scheduled
         .includes(:stage, :artist)
 

--- a/app/controllers/timetables_controller.rb
+++ b/app/controllers/timetables_controller.rb
@@ -78,7 +78,7 @@ class TimetablesController < ApplicationController
   def performances_by_stage
     @performances_by_stage ||=
       @festival
-        .stage_performances_for(@selected_day)
+        .stage_performances_on(@selected_day)
         .scheduled
         .where.not(stage_id: nil)
         .includes(:stage, :artist)

--- a/app/models/festival.rb
+++ b/app/models/festival.rb
@@ -62,11 +62,13 @@ class Festival < ApplicationRecord
     festival_days.order(:date)
   end
 
-  def stage_performances_for(day_or_date)
-    day = day_or_date.is_a?(FestivalDay) ? day_or_date : festival_days.find_by!(date: day_or_date)
-    day.stage_performances
-       .includes(:stage, :artist)
-       .order(:starts_at)
+  def stage_performances_on(festival_day)
+    return StagePerformance.none if festival_day.blank?
+    raise ArgumentError, "festival_day must belong to festival" if festival_day.festival_id != id
+
+    festival_day.stage_performances
+                .includes(:stage, :artist)
+                .order(:starts_at)
   end
 
   def artists_for_day(festival_day)


### PR DESCRIPTION
## 概要
- Festival の「この日の出演を取る」API を stage_performances_on(FestivalDay) に一本化し、引数の「日付orDay」 の曖昧さを解消しました。
- これに合わせてタイムテーブル関連のコントローラも新 API を利用するよう調整しています。
## 実施内容
- Festival#stage_performances_on を新設し、引数が同一フェスの FestivalDay であることを明確化（不正な day を渡した場合は例外）。
- タイムテーブル画面およびマイタイムテーブル画面で出演情報を取得する際に、新メソッドを呼ぶよう更新 (app/controllers/timetables_controller.rb, app/controllers/my_timetables_controller.rb)。
## 対応Issue
- #165
## 関連Issue
なし
## 特記事項