### PR TITLE
[refactor]SegmentedTabsComponentのAPI名称とドキュメント変更

### DIFF
--- a/app/components/shared/segmented_tabs_component.rb
+++ b/app/components/shared/segmented_tabs_component.rb
@@ -1,23 +1,24 @@
 module Shared
   class SegmentedTabsComponent < ViewComponent::Base
-    def initialize(items:, active_key:, url_builder:)
-      @items = items
-      @active_key = active_key
+    # tabs: { タブのキー => 表示ラベル } を想定したハッシュ
+    def initialize(tabs:, active_tab_key:, url_builder:)
+      @tabs = tabs
+      @active_tab_key = active_tab_key
       @url_builder = url_builder
     end
 
     def call
       content_tag(:div, class: "inline-flex rounded-xl bg-white p-1 shadow-md") do
-        safe_join(items.map { |key, label| tab_link(key, label) })
+        safe_join(tabs.map { |key, label| tab_link(key, label) })
       end
     end
 
     private
 
-    attr_reader :items, :active_key, :url_builder
+    attr_reader :tabs, :active_tab_key, :url_builder
 
     def tab_link(key, label)
-      active = key == active_key
+      active = key == active_tab_key
       classes = [
         "rounded-lg px-4 py-2 text-sm font-semibold transition",
         active ? "bg-rose-500 text-white shadow-sm" : "text-slate-500 hover:text-rose-500"

--- a/app/views/artists/index.html.erb
+++ b/app/views/artists/index.html.erb
@@ -10,8 +10,8 @@
         <% tab_items = @festival_days.map { |festival_day| [ festival_day.id, format_date_with_weekday(festival_day.date) ] }.to_h %>
         <div class="flex justify-center">
           <%= render Shared::SegmentedTabsComponent.new(
-                items: tab_items,
-                active_key: @selected_festival_day&.id,
+                tabs: tab_items,
+                active_tab_key: @selected_festival_day&.id,
                 url_builder: ->(festival_day_id) {
                   festival_artists_path(@festival, preserved_query.merge(festival_day_id: festival_day_id))
                 }

--- a/app/views/festivals/index.html.erb
+++ b/app/views/festivals/index.html.erb
@@ -7,8 +7,8 @@
       <% preserved_query = request.query_parameters.except(:page, :status) %>
       <div class="flex justify-center">
         <%= render Shared::SegmentedTabsComponent.new(
-              items: @status_labels,
-              active_key: @status,
+              tabs: @status_labels,
+              active_tab_key: @status,
               url_builder: ->(key) do
                 path_options = preserved_query.merge(status: key)
                 @artist ? artist_festivals_path(@artist, path_options) : festivals_path(path_options)

--- a/app/views/timetables/index.html.erb
+++ b/app/views/timetables/index.html.erb
@@ -14,8 +14,8 @@
       <% preserved_query = request.query_parameters.except(:page, :status) %>
       <div class="flex justify-center">
         <%= render Shared::SegmentedTabsComponent.new(
-              items: @status_labels,
-              active_key: @status,
+              tabs: @status_labels,
+              active_tab_key: @status,
               url_builder: ->(key) { timetables_path(preserved_query.merge(status: key)) }
             ) %>
       </div>

--- a/app/views/timetables/show.html.erb
+++ b/app/views/timetables/show.html.erb
@@ -10,8 +10,8 @@
       <% tab_items = day_lookup.transform_values { |day| day.date.strftime("%-m/%-d") } %>
       <div class="mt-6 flex justify-center">
         <%= render Shared::SegmentedTabsComponent.new(
-              items: tab_items,
-              active_key: @selected_day.id,
+              tabs: tab_items,
+              active_tab_key: @selected_day.id,
               url_builder: ->(festival_day_id) do
                 day = day_lookup[festival_day_id]
                 timetable_path(@festival, @timetable_query_params.merge("date" => day.date.to_s))


### PR DESCRIPTION
## 概要
- SegmentedTabsComponent の API 名称とドキュメントを整理し、タブ用途であることがひと目で分かる形にしました。
## 実施内容
- コンポーネントの引数を tabs, active_tab_key にリネームし、tabs が {タブのキー => 表示ラベル} のハッシュを想定する旨をコメントで明記 (app/components/shared/segmented_tabs_component.rb)。
- 当コンポーネントを利用している Artists/Timetables/Festivals 各ビューで、新しい引数名に追随 (app/views/artists/index.html.erb, app/views/timetables/index.html.erb, app/views/timetables/show.html.erb, app/views/festivals/index.html.erb)。
## 対応Issue
- #165
## 関連Issue
なし
## 特記事項