### PR TITLE
[update]日付を跨ぐフェス日程への対応

### DIFF
--- a/app/components/shared/timetable_board_component.rb
+++ b/app/components/shared/timetable_board_component.rb
@@ -60,7 +60,7 @@ module Shared
       elements = labels.map do |label|
         content_tag(:div,
                     content_tag(:span,
-                                label.formatted_time(timezone),
+                                label.label_text,
                                 class: "inline-block rounded bg-white/90 px-[3px] py-0.5 font-mono text-[9px] text-slate-700 shadow-sm sm:px-1 sm:text-[10px]"),
                     class: [ base_classes, label.css_translation_class ].join(" "),
                     style: "top: #{label.top_percent}%")


### PR DESCRIPTION
## 概要
- タイムテーブルの時間計算と表示を見直し、24 時を超えるフェス日程でも「25:00」などの表記で自然に表示されるようにしました。
- 開場～終演の優先順位を崩さずに深夜対応を加え、UI も同じフォーマットで統一しています。
## 実施内容
- TimelineContextBuilder を拡張し、深夜終了を許容する開始/終了判定・出演時間からの補助計算・終演時刻の自動翌日補正を追加。従来どおり doors_at → start_at → performance_start → デフォルト 9:00 の優先順位で開始、終了も end_at 優先に戻しています (app/services/timeline_context_builder.rb)。
- TimelineLayoutPresenter でマーカーや出演ブロックの時刻ラベル生成を一元化し、タイムライン開始日の 0:00 を基準に「00:00 / 25:00」形式で出力。MarkerLabel へ label_text を追加し、align_time_to_day の日付固定を廃止して深夜データをそのまま扱えるようにしました (app/presenters/timeline_layout_presenter.rb)。
- タイムテーブル UI は label.label_text を表示するだけで 24h 超表記が伝播するため、マーカー表示を新ラベルに切り替えました (app/components/shared/timetable_board_component.rb)。
## 対応Issue
- close #207
## 関連Issue
なし
## 特記事項