### PR TITLE
[add]マイページを作成

### DIFF
--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -1,0 +1,7 @@
+class MypagesController < ApplicationController
+  before_action :authenticate_user!
+
+  def show
+    @user = current_user
+  end
+end

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -1,0 +1,33 @@
+<div class="min-h-screen px-4 py-8">
+  <div class="mx-auto w-full max-w-4xl space-y-6">
+    <h1 class="mt-1 text-3xl font-bold text-slate-900">マイページ</h1>
+    <section class="rounded-3xl bg-white/90 p-6 shadow-2xl shadow-black/5 ring-1 ring-white/60 backdrop-blur">
+      <% display_name = @user.nickname.presence || @user.email %>
+      <div class="mt-1 flex flex-col gap-3 items-start md:flex-row md:items-center md:justify-between">
+        <h1 class="text-3xl font-bold text-slate-900"><%= display_name %> さん</h1>
+        <%= link_to edit_user_registration_path,
+              class: "inline-flex items-center justify-center rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold text-white shadow-md transition hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900" do %>
+          ユーザー情報を編集
+        <% end %>
+      </div>
+    </section>
+
+    <section class="space-y-6">
+      <header>
+        <h2 class="text-2xl font-bold text-slate-900">マイコンテンツ一覧</h2>
+      </header>
+
+      <div class="space-y-4">
+        <%= render "shared/nav_stack_button",
+                  label: "マイフェス",
+                  url: "#" %>
+        <%= render "shared/nav_stack_button",
+                  label: "マイアーティスト",
+                  url: "#" %>
+        <%= render "shared/nav_stack_button",
+                  label: "マイタイムテーブル",
+                  url: my_timetables_path %>       
+      </div>
+    </section>
+  </div>
+</div>

--- a/app/views/shared/_side_menu.html.erb
+++ b/app/views/shared/_side_menu.html.erb
@@ -1,6 +1,6 @@
 <% is_signed_in = defined?(user_signed_in?) && user_signed_in? %>
 <% primary_links = is_signed_in ? [
-  { label: "マイページ", href: "#" },
+  { label: "マイページ", href: mypage_path },
   { label: "ログアウト", href: destroy_user_session_path, method: :delete }
 ] : [
   { label: "ログイン", href: new_user_session_path }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
 
   resources :timetables, only: [ :index, :show ]
   resources :my_timetables, only: [ :index ]
+  resource :mypage, only: [ :show ]
 
   resources :festivals, only: [ :index, :show ] do
     resources :artists, only: [ :index ], module: :festivals


### PR DESCRIPTION
## 概要
- サインイン済みユーザー専用のマイページを追加し、ニックネーム表示や主要リンクの導線をまとめました。
- 既存ナビゲーションからマイページへ遷移できるようサイドメニューを更新しました。
## 実施内容
- config/routes.rb に resource :mypage, only: :show を追加し、アクセス用ルートを定義。
- app/controllers/mypages_controller.rb を新設して before_action :authenticate_user! 付きの show を実装。
- app/views/mypages/show.html.erb でニックネーム表示とボタンレイアウトを調整し、/shared/nav_stack_button を使ってマイタイムテーブル・ユーザー情報などの導線を配置。
- app/views/shared/_side_menu.html.erb のサインイン時リンクを mypage_path 指定に変更し、メニュー経由でマイページを開けるようにした。
## 対応Issue
- close #23 
## 関連Issue
なし
## 特記事項