### PR TITLE
[update]ユーザー情報編集ページを改善

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,43 +1,57 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<div class="min-h-screen px-4 py-8">
+  <div class="mx-auto w-full max-w-3xl space-y-8">
+    <header class="space-y-2">
+      <h1 class="text-3xl font-bold text-slate-900">ユーザー情報の設定</h1>
+      <p class="text-sm text-slate-500">ニックネームを更新したい場合は、現在のパスワードを入力してください。</p>
+    </header>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+    <section class="rounded-3xl bg-white/90 p-6 shadow-2xl shadow-black/5 ring-1 ring-white/60 backdrop-blur space-y-6">
+      <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+      <%= form_with model: resource,
+            url: registration_path(resource_name),
+            method: :put,
+            class: "space-y-6" do |f| %>
+        <div class="space-y-2">
+          <%= f.label :nickname, "ニックネーム", class: "block text-sm font-semibold text-slate-700" %>
+          <%= f.text_field :nickname,
+                class: "w-full rounded-xl border border-slate-200 px-4 py-3 text-base shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-200",
+                autofocus: true,
+                autocomplete: "nickname" %>
+        </div>
+
+        <div class="space-y-2">
+          <label class="block text-sm font-semibold text-slate-700">登録メールアドレス</label>
+          <input type="text"
+                 class="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-base text-slate-500"
+                 value="<%= resource.email %>"
+                 readonly>
+          <p class="text-xs text-slate-400">メールアドレスの変更は現在サポートされていません。</p>
+        </div>
+
+        <div class="space-y-2">
+          <%= f.label :current_password, "パスワード確認", class: "block text-sm font-semibold text-slate-700" %>
+          <%= f.password_field :current_password,
+                class: "w-full rounded-xl border border-slate-200 px-4 py-3 text-base shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-200",
+                autocomplete: "current-password" %>
+          <p class="text-xs text-slate-400">ニックネーム変更の確認に利用します。</p>
+        </div>
+
+        <div class="space-y-2">
+          <label class="block text-sm font-semibold text-slate-700">パスワード変更</label>
+          <%= link_to "登録メールアドレスに変更URLを送信",
+                "#",
+                class: "inline-flex w-full items-center justify-center rounded-2xl bg-indigo-500 px-4 py-3 text-sm font-semibold text-white shadow-md interactive-lift hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500",
+                data: { controller: "tap-feedback" } %>
+          <p class="text-xs text-slate-400">登録メールアドレス宛にパスワード再設定用URLを送信します。</p>
+        </div>
+
+        <div class="pt-6 text-center">
+          <%= f.submit "変更を保存",
+                class: "inline-flex items-center justify-center gap-2 rounded-full bg-slate-600 px-6 py-3 text-base font-semibold text-white shadow-sm interactive-lift hover:bg-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-600",
+                data: { controller: "tap-feedback" } %>
+        </div>
+      <% end %>
+    </section>
   </div>
-
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
-
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
-    <% end %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
-
-<%= link_to "Back", :back %>
+</div>


### PR DESCRIPTION
## 概要
- Devise のユーザー設定画面をマイページと同系統のシンプルなデザインに刷新し、ニックネーム更新＋メール閲覧＋パスワード再設定導線のみの画面へ整理しました。
## 実施内容
- ニックネーム入力、登録メールアドレスの表示、現在のパスワード確認欄をカードレイアウトで実装。
- 「登録メールアドレスに変更URLを送信」のボタンとラベルを追加し、パスワードリセット機能実装時に対応。
## 対応Issue
- close #25 
## 関連Issue
- #28 
## 特記事項