### PR TITLE
[update]モバイル端末におけるフッターの余白

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -40,6 +40,16 @@ h1, h2, h3, h4 {
     @apply -translate-y-0.5 shadow-md;
   }
 
+  .footer-nav-inner {
+    padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 0.5rem);
+  }
+
+  @media (hover: none) and (pointer: coarse) {
+    .footer-nav-inner {
+      padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 1.5rem);
+    }
+  }
+
   @screen sm {
     .interactive-lift {
       @apply hover:-translate-y-1 hover:shadow-lg active:-translate-y-1 active:shadow-lg;

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -4,8 +4,7 @@ focus-visible:outline-offset-2 focus-visible:outline-white" %>
 
 <nav class="fixed inset-x-0 bottom-0 z-40 bg-[#F95858] text-white shadow-[0_-8px_24px_rgba(0,0,0,0.2)]">
   <div
-    class="mx-auto flex w-full max-w-screen-md items-end justify-between gap-2 px-4 pt-2
-          pb-[calc(env(safe-area-inset-bottom,0px)+0.5rem)]"
+    class="mx-auto flex w-full max-w-screen-md items-end justify-between gap-2 px-4 pt-2 footer-nav-inner"
   >
     <%= link_to festivals_path, class: nav_link_classes, data: { controller: "tap-feedback" } do %>
       <%= icon 'fes' %>


### PR DESCRIPTION
## 概要
- モバイル端末でフッターの各ボタンがホームバーに重なる問題を解消しつつ、PC表示のレイアウトは従来のまま維持するため、フッター内コンテナの下余白の扱いを見直しました。
## 実施内容
- フッター内ラッパーに footer-nav-inner クラスを付与し、Tailwindユーティリティではなく専用クラスで余白を制御できるように変更。
- Tailwindのコンポーネントレイヤーに .footer-nav-inner を新設し、通常は +0.5rem、タッチデバイス（hover: none かつ pointer: coarse）では +1.5rem のパディングを与えるメディアクエリを定義することで、モバイルのみ余白を拡大。
## 対応Issue
- close #218 
## 関連Issue
なし
## 特記事項