### PR TITLE
[add]ヘッダー・フッターのタップ/クリック時のUI追加

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -44,9 +44,35 @@ h1, h2, h3, h4 {
     padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 0.5rem);
   }
 
+  .footer-nav-touch-active {
+    @apply transition duration-150 ease-out;
+  }
+
+  .header-button-touch-active {
+    @apply transition duration-150 ease-out;
+  }
+
+  .header-logo-touch-active {
+    @apply transition duration-150 ease-out;
+  }
+
   @media (hover: none) and (pointer: coarse) {
     .footer-nav-inner {
       padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 1.5rem);
+    }
+
+    .footer-nav-touch-active {
+      @apply -translate-y-0.5 shadow-md;
+      background-color: rgba(234, 74, 74, 0.6);
+    }
+
+    .header-button-touch-active {
+      @apply -translate-y-0.5 shadow-md;
+      background-color: rgba(234, 74, 74, 0.5);
+    }
+
+    .header-logo-touch-active {
+      opacity: 0.75;
     }
   }
 

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,32 +1,33 @@
 <% nav_link_classes = "flex flex-1 flex-col items-center gap-1 rounded-xl py-2 text-[11px] md:text-[13px] 
 font-bold tracking-tight shadow-sm interactive-lift hover:bg-[#ea4a4a]/60 focus-visible:outline focus-visible:outline-2 
 focus-visible:outline-offset-2 focus-visible:outline-white" %>
+<% nav_link_data = { controller: "tap-feedback", tap_feedback_active_class_value: "footer-nav-touch-active" } %>
 
 <nav class="fixed inset-x-0 bottom-0 z-40 bg-[#F95858] text-white shadow-[0_-8px_24px_rgba(0,0,0,0.2)]">
   <div
     class="mx-auto flex w-full max-w-screen-md items-end justify-between gap-2 px-4 pt-2 footer-nav-inner"
   >
-    <%= link_to festivals_path, class: nav_link_classes, data: { controller: "tap-feedback" } do %>
+    <%= link_to festivals_path, class: nav_link_classes, data: nav_link_data do %>
       <%= icon 'fes' %>
       <span class="whitespace-nowrap">フェス</span>
     <% end %>
 
-    <%= link_to artists_path, class: nav_link_classes, data: { controller: "tap-feedback" } do %>
+    <%= link_to artists_path, class: nav_link_classes, data: nav_link_data do %>
       <%= icon 'artists' %>
       <span class="whitespace-nowrap">アーティスト</span>
     <% end %>
 
-    <%= link_to timetables_path, class: nav_link_classes, data: { controller: "tap-feedback" } do %>
+    <%= link_to timetables_path, class: nav_link_classes, data: nav_link_data do %>
       <%= icon 'timetable' %>
       <span class="whitespace-nowrap">タイムテーブル</span>
     <% end %>
 
-    <%= link_to '#', class: nav_link_classes, data: { controller: "tap-feedback" } do %>
+    <%= link_to '#', class: nav_link_classes, data: nav_link_data do %>
       <%= icon 'practice' %>
       <span class="whitespace-nowrap">予習</span>
     <% end %>
 
-    <%= link_to '#', class: nav_link_classes, data: { controller: "tap-feedback" } do %>
+    <%= link_to '#', class: nav_link_classes, data: nav_link_data do %>
       <%= icon 'checklist' %>
       <span class="whitespace-nowrap">持ち物</span>
     <% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,10 +1,12 @@
 <header class="fixed inset-x-0 top-0 z-50 bg-[#F95858] text-white h-16">
   <div class="h-full mx-auto flex w-full max-w-screen-xl items-center gap-4 px-4">
     <% back_path = header_back_path %>
+    <% header_button_classes = "flex h-10 w-10 items-center justify-center rounded-full shadow-sm interactive-lift hover:bg-[#ea4a4a]/50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white" %>
+    <% header_button_data = { controller: "tap-feedback", tap_feedback_active_class_value: "header-button-touch-active" } %>
     <% if back_path.present? %>
       <%= link_to back_path,
-          class: "flex h-10 w-10 items-center justify-center rounded-full shadow-sm interactive-lift hover:bg-[#ea4a4a]/50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white",
-          data: { controller: "tap-feedback" },
+          class: header_button_classes,
+          data: header_button_data,
           aria: { label: "前の画面に戻る" } do %>
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="h-6 w-6">
           <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
@@ -22,20 +24,23 @@
     <% end %>
 
     <div class="flex-1 text-center">
-      <%= link_to root_path, class: "inline-block text-xl font-black tracking-tight text-white transition hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white" do %>
+      <%= link_to root_path,
+                  class: "inline-block text-xl font-black tracking-tight text-white transition hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white",
+                  data: { controller: "tap-feedback", tap_feedback_active_class_value: "header-logo-touch-active" } do %>
         FES READY
       <% end %>
     </div>
 
     <button
       type="button"
-      class="flex h-10 w-10 items-center justify-center rounded-full shadow-sm interactive-lift hover:bg-[#ea4a4a]/50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+      class="<%= header_button_classes %>"
       aria-label="メニューを開く"
       data-action="click->side-menu#toggle"
       data-side-menu-target="button"
       aria-controls="app-side-menu"
       aria-expanded="false"
       data-controller="tap-feedback"
+      data-tap-feedback-active-class-value="header-button-touch-active"
     >
       <span class="sr-only">メニュー</span>
       <span class="relative flex h-5 w-6 flex-col items-center justify-between">


### PR DESCRIPTION
## 概要
- フッター/ヘッダーのボタン＋ロゴに、タッチ端末だけタップ時にホバーと同等のアクション（浮き上がりや色変化、ロゴの薄化など）が走るよう調整しました。
## 実施内容
- フッター内ラッパーおよび各リンクに専用クラス/データを導入し、タッチデバイスのみ余白拡張＋タップ時の色変化/浮き上がりを適用。
- ヘッダーの戻る/メニュー/ロゴに tap-feedback の activeClass を設定し、タッチ端末のタップ中だけ浮き上がりやロゴの透過を行う処理を追加。PCホバー時は既存挙動を維持。
## 対応Issue
- close #234 
## 関連Issue
なし
## 特記事項