### PR TITLE
[add]Google認証に必要なGemとカラムを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,9 @@ gem "devise-i18n"
 gem "pagy"
 # 検索機能
 gem "ransack"
+# Googleログイン
+gem "omniauth-google-oauth2"
+gem "omniauth-rails_csrf_protection"
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,11 +127,18 @@ GEM
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo
+    faraday (2.14.0)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
     fugit (1.11.2)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    hashie (5.0.0)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     inline_svg (1.10.0)
@@ -148,6 +155,8 @@ GEM
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.15.0)
+    jwt (3.1.2)
+      base64
     kamal (2.7.0)
       activesupport (>= 7.0)
       base64 (~> 0.2)
@@ -175,6 +184,10 @@ GEM
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.8.0)
+    multi_xml (0.7.2)
+      bigdecimal (~> 3.1)
+    net-http (0.8.0)
+      uri (>= 0.11.1)
     net-imap (0.5.11)
       date
       net-protocol
@@ -206,6 +219,30 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.10-x86_64-linux-musl)
       racc (~> 1.4)
+    oauth2 (2.0.18)
+      faraday (>= 0.17.3, < 4.0)
+      jwt (>= 1.0, < 4.0)
+      logger (~> 1.2)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 4)
+      snaky_hash (~> 2.0, >= 2.0.3)
+      version_gem (~> 1.1, >= 1.1.9)
+    omniauth (2.1.4)
+      hashie (>= 3.4.6)
+      logger
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-google-oauth2 (1.2.1)
+      jwt (>= 2.9.2)
+      oauth2 (~> 2.0)
+      omniauth (~> 2.0)
+      omniauth-oauth2 (~> 1.8)
+    omniauth-oauth2 (1.8.0)
+      oauth2 (>= 1.4, < 3)
+      omniauth (~> 2.0)
+    omniauth-rails_csrf_protection (1.0.2)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
     orm_adapter (0.5.0)
     ostruct (0.6.3)
     pagy (9.4.0)
@@ -237,6 +274,10 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.1)
+    rack-protection (4.2.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -330,6 +371,9 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    snaky_hash (2.0.3)
+      hashie (>= 0.1.0, < 6)
+      version_gem (>= 1.1.8, < 3)
     solid_cable (3.0.12)
       actioncable (>= 7.2)
       activejob (>= 7.2)
@@ -374,6 +418,7 @@ GEM
     unicode-emoji (4.1.0)
     uri (1.0.3)
     useragent (0.16.11)
+    version_gem (1.1.9)
     view_component (4.1.1)
       actionview (>= 7.1.0, < 8.2)
       activesupport (>= 7.1.0, < 8.2)
@@ -420,6 +465,8 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails
   kamal
+  omniauth-google-oauth2
+  omniauth-rails_csrf_protection
   pagy
   pg (~> 1.1)
   propshaft

--- a/db/migrate/20251119055428_add_omniauth_to_users.rb
+++ b/db/migrate/20251119055428_add_omniauth_to_users.rb
@@ -1,0 +1,8 @@
+class AddOmniauthToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :provider, :string
+    add_column :users, :uid, :string
+
+    add_index :users, [ :provider, :uid ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_11_10_072932) do
+ActiveRecord::Schema[8.0].define(version: 2025_11_19_055428) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "pg_catalog.plpgsql"
@@ -111,8 +111,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_10_072932) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
+    t.uuid "uuid", null: false
+    t.string "provider"
+    t.string "uid"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["uuid"], name: "index_users_on_uuid", unique: true
   end


### PR DESCRIPTION
## 概要
- Gemfileに "omniauth-google-oauth2" と "omniauth-rails_csrf_protection" を追加し、Devise で Google 認証を扱える下準備を整備。
- db/migrate/20251119055428_add_omniauth_to_users.rb を新規作成し、users テーブルへ provider/uid を追加するマイグレーションを用意、実行済みのため db/schema.rbに反映。
## 実施内容
- Bundle に OmniAuth 関連 gem を追加し、bundle install 済みなので Gemfile.lock も更新。
- AddOmniauthToUsers マイグレーションで users に provider・uid カラムと複合ユニークインデックスを追加し、以降の Google ログイン実装でアカウントを一意に紐づけられる土台を作成。
## 対応Issue
- #22 
## 関連Issue
なし
## 特記事項