### PR TITLE
[add]Googleログイン機能の追加

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,26 @@
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  skip_before_action :verify_authenticity_token, only: :google_oauth2
+
+  def google_oauth2
+    handle_callback(:google_oauth2, "Google")
+  end
+
+  def failure
+    redirect_to root_path
+  end
+
+  private
+
+  def handle_callback(provider_key, provider_name)
+    @user = User.from_omniauth(request.env["omniauth.auth"])
+
+    if @user.persisted?
+      sign_in_and_redirect @user, event: :authentication
+      set_flash_message(:notice, :success, kind: provider_name) if is_navigational_format?
+    else
+      session["devise.#{provider_key}_data"] = request.env["omniauth.auth"].except(:extra)
+      flash[:alert] = "#{provider_name}ログインに失敗しました。もう一度お試しください。"
+      redirect_to new_user_registration_url
+    end
+  end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,12 @@
+class Users::RegistrationsController < Devise::RegistrationsController
+  def build_resource(hash = {})
+    hash[:uid] = User.create_unique_string
+    super
+  end
+
+  def update_resource(resource, params)
+    return super if params["password"].present?
+
+    resource.update_without_password(params.except("current_password"))
+  end
+end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -52,17 +52,18 @@
     <% end %>
 
     <div class="mt-4">
-      <%= link_to "#",
+      <%= button_to user_google_oauth2_omniauth_authorize_path,
+            method: :post,
             class: "flex w-full items-center justify-center gap-2 rounded-full bg-slate-600 px-4 py-2 text-base font-semibold text-white shadow-sm interactive-lift hover:bg-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-600",
-            role: "button",
-            data: { controller: "tap-feedback" } do %>
+            data: { controller: "tap-feedback" },
+            form: { data: { turbo: false } } do %>
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 533.5 544.3" class="h-5 w-5" aria-hidden="true">
           <path fill="#4285f4" d="M533.5 278.4c0-17.4-1.6-34.1-4.7-50.2H272.1v95.0h146.9c-6.3 34.0-25.2 62.9-53.5 82.1v68.2h86.6c50.7-46.7 81.4-115.4 81.4-195.1Z"/>
           <path fill="#34a853" d="M272.1 544.3c72.6 0 133.6-24.0 178.2-65.8l-86.6-68.2c-24.0 16.1-54.7 25.7-91.6 25.7-70.5 0-130.2-47.6-151.6-111.6H32.9v70.2c44.7 88.3 136.6 149.7 239.2 149.7Z"/>
           <path fill="#fbbc04" d="M120.5 324.4c-10.2-30.7-10.2-63.7 0-94.4V159.8H32.9c-38.7 77.4-38.7 168.0 0 245.4l87.6-70.8Z"/>
           <path fill="#ea4335" d="M272.1 107.7c38.7-.6 75.7 13.6 103.9 39.6l77.4-77.4C404.5 24.4 343.6 0 272.1 0 169.5 0 77.6 61.4 32.9 149.7l87.6 70.8C141.9 155.6 201.6 108.0 272.1 107.7Z"/>
         </svg>
-        Googleアカウントで登録する
+        <span>Googleアカウントで登録する</span>
       <% end %>
     </div>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -38,17 +38,18 @@
     </div>
 
     <div class="mt-4">
-      <%= link_to "#",
+      <%= button_to user_google_oauth2_omniauth_authorize_path,
+            method: :post,
             class: "flex w-full items-center justify-center gap-2 rounded-full bg-slate-600 px-4 py-2 text-base font-semibold text-white shadow-sm interactive-lift hover:bg-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-600",
-            role: "button",
-            data: { controller: "tap-feedback" } do %>
+            data: { controller: "tap-feedback" },
+            form: { data: { turbo: false } } do %>
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 533.5 544.3" class="h-5 w-5" aria-hidden="true">
           <path fill="#4285f4" d="M533.5 278.4c0-17.4-1.6-34.1-4.7-50.2H272.1v95.0h146.9c-6.3 34.0-25.2 62.9-53.5 82.1v68.2h86.6c50.7-46.7 81.4-115.4 81.4-195.1Z"/>
           <path fill="#34a853" d="M272.1 544.3c72.6 0 133.6-24.0 178.2-65.8l-86.6-68.2c-24.0 16.1-54.7 25.7-91.6 25.7-70.5 0-130.2-47.6-151.6-111.6H32.9v70.2c44.7 88.3 136.6 149.7 239.2 149.7Z"/>
           <path fill="#fbbc04" d="M120.5 324.4c-10.2-30.7-10.2-63.7 0-94.4V159.8H32.9c-38.7 77.4-38.7 168.0 0 245.4l87.6-70.8Z"/>
           <path fill="#ea4335" d="M272.1 107.7c38.7-.6 75.7 13.6 103.9 39.6l77.4-77.4C404.5 24.4 343.6 0 272.1 0 169.5 0 77.6 61.4 32.9 149.7l87.6 70.8C141.9 155.6 201.6 108.0 272.1 107.7Z"/>
         </svg>
-        Googleでログイン
+        <span>Googleでログイン</span>
       <% end %>
     </div>
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -31,7 +31,7 @@ Devise.setup do |config|
 
   # Configure the parent class responsible to send e-mails.
   # config.parent_mailer = 'ActionMailer::Base'
-
+  config.omniauth :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"]
   # ==> ORM configuration
   # Load and configure the ORM. Supports :active_record (default) and
   # :mongoid (bson_ext recommended) by default. Other ORMs may be

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,8 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: {
+    registrations: "users/registrations",
+    omniauth_callbacks: "users/omniauth_callbacks"
+  }
 
   root "home#top"
   get "/terms", to: "home#terms", as: :terms

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -111,7 +111,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_19_055428) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "uuid", null: false
+    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.string "provider"
     t.string "uid"
     t.index ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
## 概要
- Google認証によるユーザー登録・ログインを可能にする。
## 実施内容
- User.from_omniauth(app/models/user.rb (lines 20-37)) を実装し、既存メールの紐付け・ニックネーム 10 文字制限対応 (sanitized_nickname クラスメソッド) を行う。
- app/controllers/users/registrations_controller.rb を新設し、build_resource で UID を付与、update_resource でパスワード無し更新を許可。
- app/controllers/users/omniauth_callbacks_controller.rb では handle_callback を用意して Google 成功/失敗時の処理と flash[:alert] を実装。
- Users::OmniauthCallbacksControllerで共通ハンドラを用意し、失敗時に flash[:alert] を設定して登録画面へ遷移。
- config/routes.rb (lines 2-5) の devise_for に registrations/omniauth_callbacks を明示。
- ログイン/新規登録ビューのGoogleログインボタンに導線を構築 。
## 対応Issue
- close #22 
## 関連Issue
なし
## 特記事項