### PR TITLE
[fix]Googleログイン時のニックネームが上書きされる問題の修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,7 +21,7 @@ class User < ApplicationRecord
     user = find_by(provider: auth.provider, uid: auth.uid)
     user ||= find_by(email: auth.info.email)
 
-    nickname = sanitized_nickname(auth)
+    nickname = user&.nickname.presence || sanitized_nickname(auth)
 
     user ||= new(
       email: auth.info.email,


### PR DESCRIPTION
## 概要
- Googleログイン時にニックネームをGoogleアカウントの名前で上書きしてしまう問題の修正。
## 実施内容
- 既存ニックネームを保持するように User.from_omniauth を修正し、すでに保存済みならその値を優先する形にしました 。Google ログイン時に毎回 auth.info.name で上書きされなくなり、ニックネーム未設定のユーザーだけが Google 側の名前を初期値として取り込みます。
## 対応Issue
- close #246 
## 関連Issue
なし
## 特記事項