### PR TITLE
[add]パスワードリセット機能

### DIFF
--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,34 @@
+class Users::PasswordsController < Devise::PasswordsController
+  skip_before_action :require_no_authentication, only: [ :create, :edit, :update ]
+
+  def new
+    self.resource = resource_class.new
+    resource.email = current_user.email if user_signed_in?
+    respond_with(resource)
+  end
+
+  def create
+    self.resource = resource_class.send_reset_password_instructions(reset_password_params)
+    yield resource if block_given?
+
+    if successfully_sent?(resource)
+      respond_to do |format|
+        format.html do
+          redirect_path = user_signed_in? ? mypage_path : after_sending_reset_password_instructions_path_for(resource_name)
+          redirect_to redirect_path, notice: "パスワード再設定用メールを送信しました。"
+        end
+        format.all { head :ok }
+      end
+    else
+      respond_with(resource)
+    end
+  end
+
+  private
+
+  def reset_password_params
+    return { email: current_user.email } if user_signed_in?
+
+    params.require(resource_name).permit(:email)
+  end
+end

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,13 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= @resource.email %> 様</p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p>FESREADY にてパスワード再設定のリクエストを受け付けました。</p>
+<p>以下のリンクをクリックし、表示された画面で新しいパスワードを入力してください。</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p>
+  <%= link_to "パスワードを再設定する",
+        edit_password_url(@resource, reset_password_token: @token) %>
+</p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p>このメールに覚えがない場合は破棄してください。リンクを開いて新しいパスワードを保存するまで、現在のパスワードは変更されません。</p>
+
+<p>FESREADY サポート</p>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,25 +1,49 @@
-<h2>Change your password</h2>
+<div class="min-h-screen px-4 py-8">
+  <div class="mx-auto w-full max-w-3xl space-y-8">
+    <header class="space-y-2">
+      <h1 class="text-3xl font-bold text-slate-900">新しいパスワードを設定</h1>
+      <p class="text-sm text-slate-500">
+        メールで受け取ったリンクからこのページにアクセスしています。新しく設定したいパスワードを入力してください。
+      </p>
+    </header>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
+    <section class="rounded-3xl bg-white/90 p-6 shadow-2xl shadow-black/5 ring-1 ring-white/60 backdrop-blur space-y-6">
+      <%= form_with model: resource,
+            url: password_path(resource_name),
+            method: :put,
+            class: "space-y-6" do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
+        <%= f.hidden_field :reset_password_token %>
 
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
-    <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
+        <div class="space-y-2">
+          <%= f.label :password, "新しいパスワード", class: "block text-sm font-semibold text-slate-700" %>
+          <% if @minimum_password_length %>
+            <p class="text-xs text-slate-400">半角<%= @minimum_password_length %>文字以上で設定してください。</p>
+          <% end %>
+          <%= f.password_field :password,
+                class: "w-full rounded-xl border border-slate-200 px-4 py-3 text-base shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-200",
+                autofocus: true,
+                autocomplete: "new-password" %>
+        </div>
+
+        <div class="space-y-2">
+          <%= f.label :password_confirmation, "確認のため再入力", class: "block text-sm font-semibold text-slate-700" %>
+          <%= f.password_field :password_confirmation,
+                class: "w-full rounded-xl border border-slate-200 px-4 py-3 text-base shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-200",
+                autocomplete: "new-password" %>
+        </div>
+
+        <div class="pt-4">
+          <%= f.submit "パスワードを更新する",
+                class: "inline-flex w-full items-center justify-center rounded-full bg-slate-700 px-6 py-3 text-base font-semibold text-white shadow-sm interactive-lift hover:bg-slate-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-700" %>
+        </div>
+      <% end %>
+
+      <div class="text-center text-sm">
+        <%= link_to "ログインに戻る",
+              new_session_path(resource_name),
+              class: "font-semibold text-indigo-600 hover:text-indigo-500" %>
+      </div>
+    </section>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,43 @@
-<h2>Forgot your password?</h2>
+<div class="min-h-screen px-4 py-8">
+  <div class="mx-auto w-full max-w-3xl space-y-8">
+    <header class="space-y-2">
+      <h1 class="text-3xl font-bold text-slate-900">パスワードを再設定する</h1>
+      <p class="text-sm text-slate-500">
+        登録済みのメールアドレスを入力すると、パスワード再設定用のリンクをメールで送信します。
+      </p>
+      <% if current_user&.provider.present? %>
+        <p class="text-xs font-semibold text-indigo-600">
+          Googleログインのみで利用している場合は、この操作は不要です。メールアドレスとパスワードでもログインしたいときだけ再設定を行ってください。
+        </p>
+      <% end %>
+    </header>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+    <section class="rounded-3xl bg-white/90 p-6 shadow-2xl shadow-black/5 ring-1 ring-white/60 backdrop-blur space-y-6">
+      <%= form_with model: resource,
+            url: password_path(resource_name),
+            method: :post,
+            class: "space-y-6" do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+        <div class="space-y-2">
+          <%= f.label :email, "登録メールアドレス", class: "block text-sm font-semibold text-slate-700" %>
+          <%= f.email_field :email,
+                class: "w-full rounded-xl border border-slate-200 px-4 py-3 text-base shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-200",
+                autofocus: true,
+                autocomplete: "email" %>
+        </div>
+
+        <div class="pt-4">
+          <%= f.submit "再設定メールを送信する",
+                class: "inline-flex w-full items-center justify-center rounded-full bg-slate-700 px-6 py-3 text-base font-semibold text-white shadow-sm interactive-lift hover:bg-slate-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-700" %>
+        </div>
+      <% end %>
+
+      <div class="text-center text-sm">
+        <%= link_to "ログインに戻る",
+              new_session_path(resource_name),
+              class: "font-semibold text-indigo-600 hover:text-indigo-500" %>
+      </div>
+    </section>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -37,21 +37,28 @@
           <p class="text-xs text-slate-400">ニックネーム変更の確認に利用します。</p>
         </div>
 
-        <div class="space-y-2">
-          <label class="block text-sm font-semibold text-slate-700">パスワード変更</label>
-          <%= link_to "登録メールアドレスに変更URLを送信",
-                "#",
-                class: "inline-flex w-full items-center justify-center rounded-2xl bg-indigo-500 px-4 py-3 text-sm font-semibold text-white shadow-md interactive-lift hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500",
-                data: { controller: "tap-feedback" } %>
-          <p class="text-xs text-slate-400">登録メールアドレス宛にパスワード再設定用URLを送信します。</p>
-        </div>
-
         <div class="pt-6 text-center">
           <%= f.submit "変更を保存",
                 class: "inline-flex items-center justify-center gap-2 rounded-full bg-slate-600 px-6 py-3 text-base font-semibold text-white shadow-sm interactive-lift hover:bg-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-600",
                 data: { controller: "tap-feedback" } %>
         </div>
       <% end %>
+
+      <div class="space-y-2">
+        <label class="block text-sm font-semibold text-slate-700">パスワード変更</label>
+        <% if current_user&.provider.present? %>
+          <p class="text-xs font-semibold text-indigo-600 leading-relaxed">
+            Googleログインのみで利用している場合は、この操作は不要です。<br>
+            メールアドレスとパスワードでもログインしたいときのみ、再設定を行ってください。
+          </p>
+        <% end %>
+        <%= button_to "登録メールアドレスに変更URLを送信",
+              user_password_path,
+              method: :post,
+              class: "inline-flex w-full items-center justify-center rounded-2xl bg-indigo-500 px-4 py-3 text-sm font-semibold text-white shadow-md interactive-lift hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500",
+              data: { controller: "tap-feedback" } %>
+        <p class="text-xs text-slate-400">登録メールアドレス宛にパスワード再設定用URLを送信します。</p>
+      </div>
     </section>
   </div>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -34,7 +34,9 @@
     <% end %>
 
     <div class="mt-2 text-center">
-      <%= link_to "パスワードをお忘れの方はこちら", "#", class: "text-sm font-medium text-[#F95858] hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#F95858]" %>
+      <%= link_to "パスワードをお忘れの方はこちら",
+            new_user_password_path,
+            class: "text-sm font-medium text-[#F95858] hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#F95858]" %>
     </div>
 
     <div class="mt-4">

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -39,7 +39,16 @@ Rails.application.configure do
 
   # Set localhost to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
-
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: "smtp.gmail.com",
+    port: 587,
+    domain: "localhost",
+    user_name: ENV["MAILER_SENDER"],
+    password: ENV["MAILER_PASSWORD"],
+    authentication: "plain",
+    enable_starttls_auto: true
+  }
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,7 +60,16 @@ Rails.application.configure do
 
   # Set host to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: "fesready.com", protocol: "https" }
-
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address:              "smtp.gmail.com",
+    port:                 587,
+    domain:               "fesready.com",
+    user_name:            ENV["MAILER_SENDER"],
+    password:             ENV["MAILER_PASSWORD"],
+    authentication:       "plain",
+    enable_starttls_auto: true
+  }
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via rails credentials:edit.
   # config.action_mailer.smtp_settings = {
   #   user_name: Rails.application.credentials.dig(:smtp, :user_name),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {
     registrations: "users/registrations",
-    omniauth_callbacks: "users/omniauth_callbacks"
+    omniauth_callbacks: "users/omniauth_callbacks",
+    passwords: "users/passwords"
   }
 
   root "home#top"


### PR DESCRIPTION
## 概要
- パスワードリセット機能実装のためのコード・ファイル追加。
## 実施内容
- Users::PasswordsController で Devise 標準を拡張し、ログイン済みでも new/create/edit/update にアクセス可能・成功時は mypage_path へ戻る挙動に変更。
- デバイスのルーティング部分にパスワードリセット機能用のコントローラを追記。
- パスワード再設定画面 (app/views/devise/passwords/new.html.erb, edit.html.erb) を Tailwind UI で刷新し、Google 連携ユーザー向け注意文を条件表示。
- マイページ編集画面 (app/views/devise/registrations/edit.html.erb) に直接 POST /users/password するボタンと同注意文を追加。
- ログインページの「パスワードをお忘れの方はこちら」のリンク先を new_user_password_path に差し替え。
- リセットメール本文 (app/views/devise/mailer/reset_password_instructions.html.erb) を日本語に書き換え。
## 対応Issue
- close #27 
- close #28 
## 関連Issue
なし
## 特記事項
- メール関係の環境編集は本番環境に設定済み。