### PR TITLE
[add]モデル追加に伴うコード追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,8 @@ class User < ApplicationRecord
 
   has_many :user_timetable_entries, dependent: :destroy
   has_many :my_stage_performances, through: :user_timetable_entries, source: :stage_performance
+  has_many :user_festival_favorites, dependent: :destroy
+  has_many :favorite_festivals, through: :user_festival_favorites, source: :festival
 
   before_create :ensure_uuid!
 

--- a/app/models/user_festival_favorite.rb
+++ b/app/models/user_festival_favorite.rb
@@ -1,0 +1,6 @@
+class UserFestivalFavorite < ApplicationRecord
+  belongs_to :user
+  belongs_to :festival
+
+  validates :user_id, uniqueness: { scope: :festival_id }
+end

--- a/db/migrate/20251122092002_create_user_festival_favorites.rb
+++ b/db/migrate/20251122092002_create_user_festival_favorites.rb
@@ -1,0 +1,12 @@
+class CreateUserFestivalFavorites < ActiveRecord::Migration[8.0]
+  def change
+    create_table :user_festival_favorites do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :festival, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :user_festival_favorites, [ :user_id, :festival_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_11_19_055428) do
+ActiveRecord::Schema[8.0].define(version: 2025_11_22_092002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "pg_catalog.plpgsql"
@@ -91,6 +91,16 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_19_055428) do
     t.index ["festival_id"], name: "index_stages_on_festival_id"
   end
 
+  create_table "user_festival_favorites", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "festival_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["festival_id"], name: "index_user_festival_favorites_on_festival_id"
+    t.index ["user_id", "festival_id"], name: "index_user_festival_favorites_on_user_id_and_festival_id", unique: true
+    t.index ["user_id"], name: "index_user_festival_favorites_on_user_id"
+  end
+
   create_table "user_timetable_entries", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "stage_performance_id", null: false
@@ -111,7 +121,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_19_055428) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
+    t.uuid "uuid", null: false
     t.string "provider"
     t.string "uid"
     t.index ["email"], name: "index_users_on_email", unique: true
@@ -125,6 +135,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_19_055428) do
   add_foreign_key "stage_performances", "festival_days"
   add_foreign_key "stage_performances", "stages"
   add_foreign_key "stages", "festivals"
+  add_foreign_key "user_festival_favorites", "festivals"
+  add_foreign_key "user_festival_favorites", "users"
   add_foreign_key "user_timetable_entries", "stage_performances"
   add_foreign_key "user_timetable_entries", "users"
 end


### PR DESCRIPTION
## 概要
- ログインユーザーがフェスをお気に入り登録できる「お気に入りフェス機能」実装の準備として、中間モデルと関連付けを追加。
- 将来的にフェス一覧・詳細画面でハートボタンを使い、非同期でお気に入り登録／解除できるようにするための基盤を整備。
- また、マイページで「お気に入りフェス一覧」を表示できるようにするため、User ↔ Festival の関連構造を作成。
## 実施内容
- UserFestivalFavorite モデルを新規作成
- user_festival_favorites テーブルを作成（user_id / festival_id の外部キー + ユニーク制約）
- User モデルに「お気に入りフェス」関連を追加
- Festival モデルに「お気に入りユーザー」関連と favorited_by? メソッドを追加
- 中間モデルに重複登録防止のバリデーションを追加
## 対応Issue
- #183 
## 関連Issue
なし
## 特記事項