### PR TITLE
[add]お気に入りフェス機能のビュー追加

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -87,6 +87,8 @@ h1, h2, h3, h4 {
   }
 }
 
+@import "./components/favorite.css";
+
 @keyframes flash-slide {
   0% {
     opacity: 0;

--- a/app/assets/stylesheets/components/favorite.css
+++ b/app/assets/stylesheets/components/favorite.css
@@ -1,0 +1,9 @@
+.favorite-pulse {
+  animation: favorite-pulse 220ms ease-out;
+}
+
+@keyframes favorite-pulse {
+  0%   { transform: scale(1); }
+  50%  { transform: scale(1.2); }
+  100% { transform: scale(1); }
+}

--- a/app/helpers/favorites_helper.rb
+++ b/app/helpers/favorites_helper.rb
@@ -1,0 +1,17 @@
+module FavoritesHelper
+  def favorite_button_for(favorited:, toggle_url:)
+    return unless user_signed_in?
+
+    render "shared/favorite_button",
+           favorited: !!favorited,
+           toggle_url: toggle_url,
+           icons: favorite_icons
+  end
+
+  def favorite_icons
+    {
+      empty:  asset_path("icons/heart.svg"),
+      filled: asset_path("icons/heart_filled.svg")
+    }
+  end
+end

--- a/app/helpers/festival_favorites_helper.rb
+++ b/app/helpers/festival_favorites_helper.rb
@@ -1,0 +1,6 @@
+module FestivalFavoritesHelper
+  def festival_favorited?(festival)
+    return false unless current_user
+    festival.favorited_by?(current_user)
+  end
+end

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -45,6 +45,8 @@ module NavigationHelper
       return artist_festivals_path(params[:artist_id]) if params[:artist_id].present?
     when "timetables"
       return timetables_path
+    when "mypage_favorites"
+      return mypage_favorite_festivals_path
     end
 
     return artist_path(params[:artist_id]) if params[:artist_id].present?

--- a/app/javascript/controllers/favorite_toggle_controller.js
+++ b/app/javascript/controllers/favorite_toggle_controller.js
@@ -1,0 +1,58 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [ "icon" ]
+  static values = {
+    url: String,
+    favorited: Boolean,
+    heartSrc: String,
+    heartFilledSrc: String
+  }
+
+  toggle(event) {
+    event.preventDefault()
+    const method = this.favoritedValue ? "DELETE" : "POST"
+    const csrfToken = document.querySelector("meta[name='csrf-token']")?.getAttribute("content")
+
+    fetch(this.urlValue, {
+      method,
+      headers: {
+        "X-CSRF-Token": csrfToken,
+        "Accept": "application/json"
+      },
+      credentials: "same-origin"
+    }).then(async (response) => {
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}))
+        throw new Error(body.error || "お気に入りの更新に失敗しました")
+      }
+      return response.json()
+    }).then((body) => {
+      this.favoritedValue = !!body.favorited
+      this.refreshIcon()
+      this.pulse()
+    }).catch((error) => {
+      // 簡易エラー表示（UIにトーストがあれば差し替え）
+      alert(error.message)
+    })
+  }
+
+  favoritedValueChanged() {
+    this.refreshIcon()
+  }
+
+  refreshIcon() {
+    if (!this.hasIconTarget) return
+    const src = this.favoritedValue ? this.heartFilledSrcValue : this.heartSrcValue
+    const alt = this.favoritedValue ? "お気に入り解除" : "お気に入り登録"
+    this.iconTarget.src = src
+    this.iconTarget.alt = alt
+  }
+
+  pulse() {
+    this.element.classList.remove("favorite-pulse")
+    // 再トリガのためのリフロー
+    void this.element.offsetWidth
+    this.element.classList.add("favorite-pulse")
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -21,3 +21,6 @@ application.register("stage-performance-form", StagePerformanceFormController)
 
 import TapFeedbackController from "./tap_feedback_controller"
 application.register("tap-feedback", TapFeedbackController)
+
+import FavoriteToggleController from "./favorite_toggle_controller"
+application.register("favorite-toggle", FavoriteToggleController)

--- a/app/views/festivals/index.html.erb
+++ b/app/views/festivals/index.html.erb
@@ -37,7 +37,11 @@
                end %>
             <%= render "shared/nav_stack_button",
                        label: festival.name,
-                       url: festival_url %>
+                       url: festival_url,
+                       trailing: favorite_button_for(
+                         favorited: festival_favorited?(festival),
+                         toggle_url: festival_favorite_path(festival)
+                       ) %>
           </div>
         <% end %>
       <% else %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
     <meta name="mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <meta name="turbo-cache-control" content="no-preview">
 
     <meta property="og:site_name" content="FES READY">
     <meta property="og:title" content="<%= content_for(:title) || 'FES READY' %>">

--- a/app/views/mypage/favorite_festivals/index.html.erb
+++ b/app/views/mypage/favorite_festivals/index.html.erb
@@ -1,0 +1,30 @@
+<div class="min-h-screen px-4 py-8">
+  <div class="mx-auto max-w-4xl space-y-6">
+    <header class="space-y-2">
+      <p class="text-sm font-semibold uppercase tracking-wide text-slate-500">マイフェス</p>
+      <h1 class="text-3xl font-bold text-slate-900">お気に入りフェス</h1>
+      <p class="text-sm text-slate-600">ハートを外すと一覧から削除されます。</p>
+    </header>
+
+    <section class="space-y-4">
+      <% if @festivals.any? %>
+        <% @festivals.each do |festival| %>
+          <div class="w-full">
+            <%= render "shared/nav_stack_button",
+                       label: festival.name,
+                       url: festival_path(festival, from: "mypage_favorites"),
+                       trailing: favorite_button_for(
+                         favorited: festival_favorited?(festival),
+                         toggle_url: festival_favorite_path(festival)
+                       ) %>
+          </div>
+        <% end %>
+      <% else %>
+        <p class="rounded-xl bg-white px-4 py-12 text-center text-sm text-slate-500 shadow">
+          お気に入り登録したフェスはまだありません
+        </p>
+      <% end %>
+    </section>
+  </div>
+  <%= render "shared/pagination", pagy: @pagy %>
+</div>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -20,7 +20,7 @@
       <div class="space-y-4">
         <%= render "shared/nav_stack_button",
                   label: "マイフェス",
-                  url: "#" %>
+                  url: mypage_favorite_festivals_path %>
         <%= render "shared/nav_stack_button",
                   label: "マイアーティスト",
                   url: "#" %>

--- a/app/views/shared/_favorite_button.html.erb
+++ b/app/views/shared/_favorite_button.html.erb
@@ -1,0 +1,13 @@
+<button type="button"
+        class="inline-flex h-9 w-9 items-center justify-center transition hover:scale-105"
+        data-controller="favorite-toggle"
+        data-action="click->favorite-toggle#toggle"
+        data-favorite-toggle-url-value="<%= toggle_url %>"
+        data-favorite-toggle-favorited-value="<%= favorited %>"
+        data-favorite-toggle-heart-src-value="<%= icons[:empty] %>"
+        data-favorite-toggle-heart-filled-src-value="<%= icons[:filled] %>">
+  <%= image_tag(favorited ? icons[:filled] : icons[:empty],
+                alt: favorited ? "お気に入り解除" : "お気に入り登録",
+                class: "h-5 w-5",
+                data: { favorite_toggle_target: "icon" }) %>
+</button>

--- a/app/views/shared/_nav_stack_button.html.erb
+++ b/app/views/shared/_nav_stack_button.html.erb
@@ -1,3 +1,8 @@
 <%= link_to url, class: "nav-stack-button interactive-lift", data: { controller: "tap-feedback" } do %>
-  <span><%= label %></span>
+  <span class="flex w-full items-center justify-between gap-3">
+    <span><%= label %></span>
+    <% if local_assigns[:trailing].present? %>
+      <span class="shrink-0"><%= trailing %></span>
+    <% end %>
+  </span>
 <% end %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -121,7 +121,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_22_092002) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "uuid", null: false
+    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.string "provider"
     t.string "uid"
     t.index ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
## 概要
- お気に入りハートのUI整備（アニメ付トグル、未ログイン非表示）、フェス一覧・マイフェスでの導線強化、戻る動作の改善。
## 実施内容
- 共通ハート部品: _favorite_button + favorite_button_for ヘルパーを追加し、フェス一覧/マイフェスで再利用。未ログイン時は表示しない仕様に変更。
- ハートトグル: Stimulus favorite_toggle_controller にスケールの弾むアニメを追加。対応CSSを components/favorite.css として読み込み。
- フェス一覧表示: フェス名右にハートを表示してお気に入り登録/解除を非同期で実行。
- マイフェス導線: マイページの「マイフェス」リンクをお気に入り一覧に接続。マイフェス一覧で詳細リンクに from: "mypage_favorites" を付与し、戻るボタンで一覧に戻るようナビゲーションを調整。
## 対応Issue
- close #183 
## 関連Issue
なし
## 特記事項