### PR TITLE
[add]テーブル・モデル追加

### DIFF
--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -6,6 +6,8 @@ class Artist < ApplicationRecord
   has_many :stage_performances, dependent: :destroy
   has_many :festival_days, through: :stage_performances
   has_many :festivals, -> { distinct }, through: :festival_days
+  has_many :user_artist_favorites, dependent: :destroy
+  has_many :favorited_users, through: :user_artist_favorites, source: :user
 
   before_create :ensure_uuid!
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,8 @@ class User < ApplicationRecord
   has_many :my_stage_performances, through: :user_timetable_entries, source: :stage_performance
   has_many :user_festival_favorites, dependent: :destroy
   has_many :favorite_festivals, through: :user_festival_favorites, source: :festival
+  has_many :user_artist_favorites, dependent: :destroy
+  has_many :favorite_artists, through: :user_artist_favorites, source: :artist
 
   before_create :ensure_uuid!
 

--- a/app/models/user_artist_favorite.rb
+++ b/app/models/user_artist_favorite.rb
@@ -1,0 +1,6 @@
+class UserArtistFavorite < ApplicationRecord
+  belongs_to :user
+  belongs_to :artist
+
+  validates :user_id, uniqueness: { scope: :artist_id }
+end

--- a/db/migrate/20251124012926_create_user_artist_favorites.rb
+++ b/db/migrate/20251124012926_create_user_artist_favorites.rb
@@ -1,0 +1,12 @@
+class CreateUserArtistFavorites < ActiveRecord::Migration[8.0]
+  def change
+    create_table :user_artist_favorites do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :artist, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :user_artist_favorites, [ :user_id, :artist_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_11_22_092002) do
+ActiveRecord::Schema[8.0].define(version: 2025_11_24_012926) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "pg_catalog.plpgsql"
@@ -91,6 +91,16 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_22_092002) do
     t.index ["festival_id"], name: "index_stages_on_festival_id"
   end
 
+  create_table "user_artist_favorites", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "artist_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["artist_id"], name: "index_user_artist_favorites_on_artist_id"
+    t.index ["user_id", "artist_id"], name: "index_user_artist_favorites_on_user_id_and_artist_id", unique: true
+    t.index ["user_id"], name: "index_user_artist_favorites_on_user_id"
+  end
+
   create_table "user_festival_favorites", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "festival_id", null: false
@@ -121,7 +131,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_22_092002) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
+    t.uuid "uuid", null: false
     t.string "provider"
     t.string "uid"
     t.index ["email"], name: "index_users_on_email", unique: true
@@ -135,6 +145,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_22_092002) do
   add_foreign_key "stage_performances", "festival_days"
   add_foreign_key "stage_performances", "stages"
   add_foreign_key "stages", "festivals"
+  add_foreign_key "user_artist_favorites", "artists"
+  add_foreign_key "user_artist_favorites", "users"
   add_foreign_key "user_festival_favorites", "festivals"
   add_foreign_key "user_festival_favorites", "users"
   add_foreign_key "user_timetable_entries", "stage_performances"


### PR DESCRIPTION
## 概要
- アーティスト詳細ページなどに「お気に入りボタン」を表示するための基盤となるモデル・関連付けを実装。

## 実施内容
- user_artist_favorites テーブルを追加（user_id・artist_id・ユニーク制約付き）
- UserArtistFavorite モデルを作成（重複登録を防ぐバリデーションを追加）
- User / Artist モデルにお気に入り関連の has_many を追加
## 対応Issue
- #182 
## 関連Issue
なし
## 特記事項