### PR TITLE
[add]マイアーティスト登録機能実装

### DIFF
--- a/app/controllers/artists/favorites_controller.rb
+++ b/app/controllers/artists/favorites_controller.rb
@@ -1,0 +1,44 @@
+module Artists
+  class FavoritesController < ApplicationController
+    before_action :authenticate_user!
+    before_action :set_artist
+
+    def create
+      favorite = current_user.user_artist_favorites.find_or_create_by!(artist: @artist)
+
+      respond_to do |format|
+        format.html { redirect_back fallback_location: artist_path(@artist), notice: "お気に入りに追加しました" }
+        format.json { render json: favorite_payload(favorited: true, favorite_id: favorite.id), status: :created }
+      end
+    rescue ActiveRecord::RecordInvalid => e
+      respond_to do |format|
+        format.html { redirect_back fallback_location: artist_path(@artist), alert: "お気に入り登録に失敗しました" }
+        format.json { render json: { error: e.record.errors.full_messages.to_sentence }, status: :unprocessable_entity }
+      end
+    end
+
+    def destroy
+      favorite = current_user.user_artist_favorites.find_by(artist: @artist)
+      favorite&.destroy
+
+      respond_to do |format|
+        format.html { redirect_back fallback_location: artist_path(@artist), notice: "お気に入りを解除しました" }
+        format.json { render json: favorite_payload(favorited: false), status: :ok }
+      end
+    end
+
+    private
+
+    def set_artist
+      @artist = Artist.find_by_identifier!(params[:artist_id])
+    end
+
+    def favorite_payload(favorited:, favorite_id: nil)
+      {
+        artist_id: @artist.id,
+        favorited: favorited,
+        favorite_id: favorite_id
+      }.compact
+    end
+  end
+end

--- a/app/controllers/mypage/favorite_artists_controller.rb
+++ b/app/controllers/mypage/favorite_artists_controller.rb
@@ -1,0 +1,10 @@
+module Mypage
+  class FavoriteArtistsController < ApplicationController
+    before_action :authenticate_user!
+
+    def index
+      favorites_scope = Artist.favorited_by(current_user)
+      @pagy, @artists = pagy(favorites_scope, items: 20)
+    end
+  end
+end

--- a/app/helpers/artist_favorites_helper.rb
+++ b/app/helpers/artist_favorites_helper.rb
@@ -1,0 +1,7 @@
+module ArtistFavoritesHelper
+  def artist_favorited?(artist)
+    return false unless current_user
+    @favorite_artist_ids ||= current_user.user_artist_favorites.pluck(:artist_id)
+    @favorite_artist_ids.include?(artist.id)
+  end
+end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -18,6 +18,12 @@ class Artist < ApplicationRecord
   def self.ransackable_attributes(_ = nil); %w[name]; end
   def self.ransackable_associations(_ = nil); []; end
 
+  scope :favorited_by, ->(user) {
+    joins(:user_artist_favorites)
+      .where(user_artist_favorites: { user_id: user.id })
+      .order(:name)
+  }
+
   # 空文字・前後空白を取り除いて nil 正規化
   normalizes :spotify_artist_id, with: ->(v) { v&.strip.presence }
 
@@ -31,6 +37,11 @@ class Artist < ApplicationRecord
 
   def to_param
     uuid
+  end
+
+  def favorited_by?(user)
+    return false unless user
+    user_artist_favorites.exists?(user_id: user.id)
   end
 
   private

--- a/app/views/mypage/favorite_artists/index.html.erb
+++ b/app/views/mypage/favorite_artists/index.html.erb
@@ -1,0 +1,24 @@
+<div class="min-h-screen px-4 pb-24 pt-6">
+  <div class="mx-auto max-w-6xl space-y-6">
+    <header class="space-y-2">
+      <p class="text-sm font-semibold uppercase tracking-wide text-slate-500">マイアーティスト</p>
+      <h1 class="text-3xl font-bold text-slate-900">お気に入りアーティスト</h1>
+      <p class="text-sm text-slate-600">ハートを外すと一覧から削除されます。</p>
+    </header>
+
+    <section>
+      <% if @artists.any? %>
+        <div class="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
+          <% @artists.each do |artist| %>
+            <%= render "shared/artist_card", artist: artist %>
+          <% end %>
+        </div>
+      <% else %>
+        <p class="rounded-3xl border border-dashed border-slate-300 bg-white px-6 py-16 text-center text-sm text-slate-500">
+          お気に入り登録したアーティストはまだありません
+        </p>
+      <% end %>
+    </section>
+  </div>
+  <%= render "shared/pagination", pagy: @pagy %>
+</div>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -23,7 +23,7 @@
                   url: mypage_favorite_festivals_path %>
         <%= render "shared/nav_stack_button",
                   label: "マイアーティスト",
-                  url: "#" %>
+                  url: mypage_favorite_artists_path %>
         <%= render "shared/nav_stack_button",
                   label: "マイタイムテーブル",
                   url: my_timetables_path %>       

--- a/app/views/shared/_artist_card.html.erb
+++ b/app/views/shared/_artist_card.html.erb
@@ -20,18 +20,29 @@
     </p>
   <% end %>
 
+  <% if user_signed_in? %>
+    <div class="absolute left-3 bottom-3 z-10 flex h-9 w-9 items-center justify-center">
+      <%= favorite_button_for(
+            favorited: artist_favorited?(artist),
+            toggle_url: artist_favorite_path(artist)
+          ) %>
+    </div>
+  <% end %>
+
   <% if artist.spotify_artist_id.present? %>
-    <%= link_to "https://open.spotify.com/artist/#{artist.spotify_artist_id}",
-                target: "_blank",
-                rel: "noopener",
-                class: "absolute bottom-3 right-3 z-10 inline-flex items-center justify-center rounded-full transition hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-400" do %>
-      <span class="sr-only"><%= "#{artist.name} をSpotifyで開く" %></span>
-      <%= image_tag "spotify_icon.png",
-                    alt: "",
-                    class: "h-6 w-6",
-                    width: 24,
-                    height: 24,
-                    loading: "lazy" %>
-    <% end %>
+    <div class="absolute bottom-3 right-3 z-10 flex h-9 w-9 items-center justify-center">
+      <%= link_to "https://open.spotify.com/artist/#{artist.spotify_artist_id}",
+                  target: "_blank",
+                  rel: "noopener",
+                  class: "inline-flex h-9 w-9 items-center justify-center rounded-full transition hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-400" do %>
+        <span class="sr-only"><%= "#{artist.name} をSpotifyで開く" %></span>
+        <%= image_tag "spotify_icon.png",
+                      alt: "",
+                      class: "h-6 w-6",
+                      width: 24,
+                      height: 24,
+                      loading: "lazy" %>
+      <% end %>
+    </div>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
 
   resources :artists, only: [ :index, :show ] do
     resources :festivals, only: [ :index ], module: :artists
+    resource :favorite, only: [ :create, :destroy ], module: :artists
   end
 
   resources :timetables, only: [ :index, :show ]
@@ -22,6 +23,7 @@ Rails.application.routes.draw do
   resource :mypage, only: [ :show ]
   namespace :mypage do
     resources :favorite_festivals, only: [ :index ], path: "festivals"
+    resources :favorite_artists, only: [ :index ], path: "artists"
   end
 
   resources :festivals, only: [ :index, :show ] do


### PR DESCRIPTION
## 概要
- フェスお気に入り機能を踏襲して「お気に入りアーティスト」を実装し、一覧/詳細のハート表示とマイページのマイアーティスト一覧を追加。
## 実施内容
- ルートにアーティストお気に入り（単数 resource）とマイページ配下の favorite_artists を追加。
- Artists::FavoritesController（create/destroy）と Mypage::FavoriteArtistsController#index を新設。
- Artist モデルにお気に入り判定メソッドと favorited_by スコープを追加。
- ヘルパ artist_favorited? でログインユーザーの登録済み判定を共通化。
- アーティストカードにハートボタンを表示（左下配置、Spotify アイコンと高さ揃え）、マイページのマイアーティスト一覧をカードグリッド表示に変更。
## 対応Issue
- close #182 
## 関連Issue
なし
## 特記事項