### PR TITLE
[fix]マイページの戻るボタンの挙動修正

### DIFF
--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -12,6 +12,10 @@ module NavigationHelper
       artists_back_path
     when "my_timetables"
       my_timetables_back_path
+    when "mypages"
+      root_path
+    when "mypage/favorite_festivals", "mypage/favorite_artists"
+      mypage_back_path
     else
       root_path
     end
@@ -65,6 +69,8 @@ module NavigationHelper
       return timetable_back_path if params[:festival_id].present?
     when "my_timetable"
       return my_timetable_back_path
+    when "mypage_favorites"
+      return mypage_favorite_artists_path
     end
 
     return festival_path(params[:festival_id]) if params[:festival_id].present?
@@ -100,5 +106,9 @@ module NavigationHelper
       identifier = params[:festival_id] || params[:id]
       identifier.present? ? timetable_path(identifier) : root_path
     end
+  end
+
+  def mypage_back_path
+    mypage_path
   end
 end

--- a/app/views/mypage/favorite_artists/index.html.erb
+++ b/app/views/mypage/favorite_artists/index.html.erb
@@ -10,7 +10,7 @@
       <% if @artists.any? %>
         <div class="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
           <% @artists.each do |artist| %>
-            <%= render "shared/artist_card", artist: artist %>
+            <%= render "shared/artist_card", artist: artist, from: "mypage_favorites" %>
           <% end %>
         </div>
       <% else %>

--- a/app/views/shared/_artist_card.html.erb
+++ b/app/views/shared/_artist_card.html.erb
@@ -1,5 +1,7 @@
 <div class="relative h-full">
-  <%= link_to artist_path(artist),
+  <% link_params = {} %>
+  <% link_params[:from] = local_assigns[:from] if local_assigns[:from].present? %>
+  <%= link_to artist_path(artist, link_params),
               class: "flex h-full w-full flex-col items-center rounded-3xl border border-slate-200 bg-white p-4 pb-12 shadow-sm interactive-lift focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-400",
               data: { controller: "tap-feedback" } do %>
     <div class="aspect-square w-full overflow-hidden rounded-2xl border border-slate-200 bg-slate-50">


### PR DESCRIPTION
## 概要
- 戻る矢印の挙動を調整し、マイページ配下やマイアーティスト一覧→詳細→戻るの遷移先を修正。
## 実施内容
- NavigationHelper に mypages→ホーム、mypage/favorite_festivals/mypage/favorite_artists→マイページ、アーティスト詳細で from: "mypage_favorites" 時はマイアーティスト一覧へ戻るロジックを追加（app/helpers/navigation_helper.rb）。
- マイアーティスト一覧でアーティスト詳細へのリンクに from: "mypage_favorites" を付与し、カードリンクも受け取った from をパスに渡すよう変更（app/views/mypage/favorite_artists/index.html.erb, app/views/shared/_artist_card.html.erb）。
## 対応Issue
なし
## 関連Issue
なし
## 特記事項