### PR TITLE
[fix]使い方のカードのタイトルを中央揃え

### DIFF
--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -33,7 +33,7 @@
             style="aspect-ratio: 1 / 1;"
             data-reveal-on-scroll-target="item"
           >
-            <p class="text-lg font-semibold text-slate-900">フェス情報の閲覧</p>
+            <p class="text-lg font-semibold text-slate-900 text-center">フェス情報の閲覧</p>
             <div class="flex flex-1 items-center justify-center">
               <%= image_tag("usage_singer.png", alt: "フェス情報の閲覧", class: "h-30 w-30 object-contain") %>
             </div>
@@ -47,7 +47,7 @@
             style="aspect-ratio: 1 / 1;"
             data-reveal-on-scroll-target="item"
           >
-            <p class="text-lg font-semibold text-slate-900">マイタイムテーブルの作成</p>
+            <p class="text-lg font-semibold text-slate-900 text-center">マイタイムテーブルの作成</p>
             <div class="flex flex-1 items-center justify-center">
               <%= image_tag("usage_timer.png", alt: "マイタイムテーブルの作成", class: "h-30 w-30 object-contain") %>
             </div>
@@ -61,7 +61,7 @@
             style="aspect-ratio: 1 / 1;"
             data-reveal-on-scroll-target="item"
           >
-            <p class="text-lg font-semibold text-slate-900">オリジナル予習プレイリスト</p>
+            <p class="text-lg font-semibold text-slate-900 text-center">オリジナル予習プレイリスト</p>
             <div class="flex flex-1 items-center justify-center">
               <%= image_tag("usage_music.png", alt: "オリジナル予習プレイリスト", class: "h-30 w-30 object-contain") %>
             </div>
@@ -75,7 +75,7 @@
             style="aspect-ratio: 1 / 1;"
             data-reveal-on-scroll-target="item"
           >
-            <p class="text-lg font-semibold text-slate-900">持ち物リストの管理</p>
+            <p class="text-lg font-semibold text-slate-900 text-center">持ち物リストの管理</p>
             <div class="flex flex-1 items-center justify-center">
               <%= image_tag("usage_bag.png", alt: "持ち物リストの管理", class: "h-30 w-30 object-contain") %>
             </div>


### PR DESCRIPTION
## 概要
- トップページの使い方のカード内のタイトル部分を中央揃えに変更。
## 実施内容
- app/views/home/top.html.erb の各カード見出しに text-center を付与。
## 対応Issue
- #75 
## 関連Issue
なし
## 特記事項