### PR TITLE
[add]トップページにアプリのインストールガイドを追加

### DIFF
--- a/app/javascript/controllers/reveal_on_scroll_controller.js
+++ b/app/javascript/controllers/reveal_on_scroll_controller.js
@@ -26,7 +26,7 @@ export default class extends Controller {
 
       const element = entry.target
       element.classList.remove("opacity-0", "translate-y-6")
-      element.classList.add("opacity-100", "translate-y-0")
+      element.classList.add("opacity-100")
 
       this.observer.unobserve(element)
     })

--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -1,29 +1,42 @@
-<main class="min-h-screen pb-32 text-center">
+<main class="min-h-screen pb-6 text-center">
   <!-- メインビジュアル -->
-  <div class="relative w-full min-h-[60vh] md:min-h-[50vh] lg:min-h-[75vh] -mt-16 lg:-mt-28">
+  <div class="relative w-full min-h-[60vh] md:min-h-[50vh] lg:min-h-[75vh] -mt-16 lg:-mt-28" data-controller="reveal-on-scroll">
     <%= image_tag(
       "fes.png",
       alt: "FES READY ステージ",
-      class: "absolute inset-0 h-full w-full object-cover"
+      class: "absolute inset-0 h-full w-full object-cover opacity-0 transition duration-700 ease-out",
+      data: { reveal_on_scroll_target: "item" }
     ) %>
-    <h1 class="absolute left-1/2 top-[35%] -translate-x-1/2 -translate-y-1/2 text-4xl md:text-6xl font-black tracking-tight text-black drop-shadow-[0_4px_12px_rgba(255,255,255,0.8)]">
+    <h1
+      class="absolute left-1/2 top-[35%] -translate-x-1/2 -translate-y-1/2 text-4xl md:text-6xl font-black tracking-tight text-black drop-shadow-[0_4px_12px_rgba(255,255,255,0.8)] opacity-0 translate-y-6 transition duration-700 ease-out"
+      data-reveal-on-scroll-target="item"
+    >
       FES READY
     </h1>
   </div>
 
   <!-- 説明ブロック -->
-  <section class="mx-auto w-full max-w-screen-xl px-6 py-12">
-    <p class="text-sm md:text-base leading-relaxed text-slate-900">
+  <section class="mx-auto w-full max-w-screen-xl px-6 py-12" data-controller="reveal-on-scroll">
+    <p
+      class="text-sm md:text-base leading-relaxed text-slate-900 opacity-0 translate-y-6 transition duration-700 ease-out"
+      data-reveal-on-scroll-target="item"
+    >
       最高のフェス体験を、これ１つで。
     </p>
 
     <!-- 使い方（下向き矢印） -->
-    <div class="mt-14">
-      <p class="text-base font-semibold text-slate-900">FES READY でできること</p>
+    <div class="mt-24 md:mt-14" data-controller="reveal-on-scroll">
+      <p
+        class="text-base font-semibold text-slate-900 opacity-0 translate-y-6 transition duration-700 ease-out"
+        data-reveal-on-scroll-target="item"
+      >
+        FES READY でできること
+      </p>
 
       <%= icon 'chevron-down',
-          class_name: 'size-10 mx-auto mt-4 text-slate-700 animate-bounce motion-reduce:animate-none',
-          aria: { label: '下へ' } %>
+          class_name: 'size-10 mx-auto mt-4 text-slate-700 animate-bounce motion-reduce:animate-none opacity-0 translate-y-6 transition duration-700 ease-out',
+          aria: { label: '下へ' },
+          data: { reveal_on_scroll_target: 'item' } %>
 
       <!-- 使い方カード -->
       <div class="mx-auto mt-8 w-full px-2 sm:px-4" data-controller="reveal-on-scroll">
@@ -80,10 +93,67 @@
               <%= image_tag("usage_bag.png", alt: "持ち物リストの管理", class: "h-30 w-30 object-contain") %>
             </div>
             <p class="text-xs md:text-sm leading-relaxed text-slate-700">
-              当日の気温や天気によって最適な持ち物リストを提案したり、自分の持ち物リストを作成できます。
+              当日の気温や天気によって最適な持ち物リストを提案し、自分の持ち物リストを作成できます。
             </p>
           </div>
         </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- アプリのインストールガイド -->
+  <section class="relative px-6 py-12 md:px-10 md:py-16" data-controller="reveal-on-scroll">
+    <div
+      class="relative mx-auto max-w-5xl rounded-[32px] border border-slate-200/80 bg-white/80 p-8 shadow-[0_32px_70px_rgba(15,23,42,0.16)] backdrop-blur-md md:p-12 transition duration-700 ease-out opacity-0 translate-y-6 hover:-translate-y-2 hover:shadow-[0_36px_80px_rgba(15,23,42,0.18)]"
+      data-reveal-on-scroll-target="item"
+    >
+      <div class="text-center">
+        <p class="mt-3 text-2xl font-semibold text-slate-900 md:text-3xl">アプリをホーム画面に追加しよう</p>
+        <p class="mt-3 text-sm leading-relaxed text-slate-700 md:text-base">
+          オフラインでもすぐに開けるため、<span class="md:hidden"><br></span><span class="hidden md:inline"> </span>ホーム画面への追加を推奨しています。
+        </p>
+      </div>
+
+      <div class="mt-10 grid gap-6 md:grid-cols-2">
+        <details class="group rounded-3xl border border-slate-200 bg-slate-50/60 p-6 shadow-[0_20px_45px_rgba(15,23,42,0.12)] transition hover:-translate-y-1 hover:shadow-[0_28px_55px_rgba(15,23,42,0.16)]">
+          <summary class="flex items-center gap-3 text-lg font-semibold text-slate-900 transition group-open:text-sky-700 cursor-pointer">
+            <svg class="size-7 text-sky-600" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+              <path stroke="none" d="M0 0h24v24H0z"/><line x1="3" y1="10" x2="3" y2="16" /><line x1="21" y1="10" x2="21" y2="16" /><path d="M7 9h10v8a1 1 0 0 1 -1 1h-8a1 1 0 0 1 -1 -1v-8a5 5 0 0 1 10 0" /><line x1="8" y1="3" x2="9" y2="5" /><line x1="16" y1="3" x2="15" y2="5" /><line x1="9" y1="18" x2="9" y2="21" /><line x1="15" y1="18" x2="15" y2="21" />
+            </svg>
+            <span class="text-base font-semibold tracking-wide text-slate-900 group-open:text-sky-700">Android（Chrome）</span>
+          </summary>
+          <section class="mt-4 space-y-4 border-t border-slate-200 pt-4 text-sm leading-relaxed text-slate-700 md:text-base">
+            <p>1. 右上のメニュー「︙」をタップします。</p>
+            <%#= image_tag "tutorial/tutorial_1_1.png", class: "mx-auto mb-2 w-full max-w-[220px] rounded-xl shadow-[0_12px_30px_rgba(15,23,42,0.12)]" %>
+            <p>2. 表示されたメニューから「ホーム画面に追加」をタップします。</p>
+            <%#= image_tag "tutorial/tutorial_1_2.png", class: "mx-auto w-full max-w-[220px] rounded-xl shadow-[0_12px_30px_rgba(15,23,42,0.12)]" %>
+          </section>
+        </details>
+
+        <details class="group rounded-3xl border border-slate-200 bg-slate-50/60 p-6 shadow-[0_20px_45px_rgba(15,23,42,0.12)] transition hover:-translate-y-1 hover:shadow-[0_28px_55px_rgba(15,23,42,0.16)]">
+          <summary class="flex items-center gap-3 text-lg font-semibold text-slate-900 transition group-open:text-sky-700 cursor-pointer">
+            <svg class="size-7 text-sky-600" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+              <path stroke="none" d="M0 0h24v24H0z"/><path d="M9 7c-3 0-4 3-4 5.5 0 3 2 7.5 4 7.5 1.088-.046 1.679-.5 3-.5 1.312 0 1.5.5 3 .5s4-3 4-5c-.028-.01-2.472-.403-2.5-3-.019-2.17 2.416-2.954 2.5-3-1.023-1.492-2.951-1.963-3.5-2-1.433-.111-2.83 1-3.5 1-.68 0-1.9-1-3-1z" /><path d="M12 4a2 2 0 0 0 2 -2a2 2 0 0 0 -2 2" />
+            </svg>
+            <span class="text-base font-semibold tracking-wide text-slate-900 group-open:text-sky-700">iOS（Safari）</span>
+          </summary>
+          <section class="mt-4 space-y-4 border-t border-slate-200 pt-4 text-sm leading-relaxed text-slate-700 md:text-base">
+            <p>
+              1. 画面下部の共有メニュー
+              <svg class="inline align-middle size-5 text-sky-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8" /><polyline points="16 6 12 2 8 6" /><line x1="12" y1="2" x2="12" y2="15" />
+              </svg>
+              をタップします。
+            </p>
+            <%#= image_tag "tutorial/tutorial_1_3.png", class: "mx-auto mb-2 w-full max-w-[220px] rounded-xl shadow-[0_12px_30px_rgba(15,23,42,0.12)]" %>
+            <p>2. 「ホーム画面に追加」をタップします。</p>
+            <%#= image_tag "tutorial/tutorial_1_4.png", class: "mx-auto w-full max-w-[220px] rounded-xl shadow-[0_12px_30px_rgba(15,23,42,0.12)]" %>
+          </section>
+        </details>
+      </div>
+
+      <div class="mt-12 space-y-3 text-center text-sm leading-relaxed text-slate-700 md:text-base">
+        <p>ホーム画面に追加できない場合は、ブラウザキャッシュの削除や最新版ブラウザをご確認ください。</p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## 概要
- トップページ下部に「アプリのインストールガイド」を追加し、Android/iOS向けのホーム画面追加手順を掲載。
- スクロールイン時の表示と、カードのホバー浮き上がりも付与。
## 実施内容
- app/views/home/top.html.erb: インストールガイドセクション（Android/iOS向けの details/summary 手順、チュートリアル画像参照、通知設定の案内）を実装。
- セクション全体にスクロールリビールを適用。
- カードにホバー時のリフトアップアニメーションを付与。
## 対応Issue
- close #75 
## 関連Issue
なし
## 特記事項
issueはcloseとするが、今後スクリーンショット画像を追加し、よりわかりやすく改善予定。