### PR TITLE
[fix]タイムテーブル表示の高さを調整

### DIFF
--- a/app/presenters/timeline_layout_presenter.rb
+++ b/app/presenters/timeline_layout_presenter.rb
@@ -22,7 +22,7 @@ class TimelineLayoutPresenter
 
   attr_reader :timeline_start, :timeline_end, :timezone, :hour_height_px
 
-  def initialize(timeline_start:, timeline_end:, timezone:, hour_height_px: 90)
+  def initialize(timeline_start:, timeline_end:, timezone:, hour_height_px: 120)
     @timeline_start = timeline_start
     @timeline_end   = timeline_end
     @timezone       = timezone


### PR DESCRIPTION
## 概要
- タイムテーブルの縦スケールを広げ、短いアクトでも情報が収まりやすいように調整。
## 実施内容
- app/presenters/timeline_layout_presenter.rb: 1時間あたりの高さを90px→120pxに拡大し、最小ブロック高さを24pxに戻して時間比率を維持。
## 対応Issue
- close #258 
## 関連Issue
なし
## 特記事項