### PR TITLE
[fix]admin用のアーティスト一覧表示の改善

### DIFF
--- a/app/controllers/admin/artists_controller.rb
+++ b/app/controllers/admin/artists_controller.rb
@@ -2,7 +2,7 @@ class Admin::ArtistsController < Admin::BaseController
   before_action :set_artist, only: [ :edit, :update, :destroy ]
 
   def index
-    @pagy, @artists = pagy(Artist.order(:id), limit: 5)
+    @pagy, @artists = pagy(Artist.order(:name), limit: 20)
   end
 
   def new


### PR DESCRIPTION
## 概要
- 管理画面のアーティスト一覧で1ページあたりの件数を20件に変更。
- 管理画面のアーティスト一覧を名前順で表示するように変更。
## 実施内容
- app/controllers/admin/artists_controller.rb の pagy 引数 limit: 5 → limit: 20に変更。
- app/controllers/admin/artists_controller.rb の並び順を order(:name) に変更。
## 対応Issue
- close #242 
## 関連Issue
なし
## 特記事項