### PR TITLE
[add]Artistモデルの名前を重複不可に変更

### DIFF
--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -1,7 +1,7 @@
 require "securerandom"
 
 class Artist < ApplicationRecord
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: true
 
   has_many :stage_performances, dependent: :destroy
   has_many :festival_days, through: :stage_performances

--- a/db/migrate/20251125083646_add_unique_index_to_artists_name.rb
+++ b/db/migrate/20251125083646_add_unique_index_to_artists_name.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexToArtistsName < ActiveRecord::Migration[8.0]
+  def change
+    remove_index :artists, :name if index_exists?(:artists, :name)
+    add_index :artists, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_11_24_012926) do
+ActiveRecord::Schema[8.0].define(version: 2025_11_25_083646) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "pg_catalog.plpgsql"
@@ -23,7 +23,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_24_012926) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "uuid", null: false
-    t.index ["name"], name: "index_artists_on_name"
+    t.index ["name"], name: "index_artists_on_name", unique: true
     t.index ["spotify_artist_id"], name: "index_artists_on_spotify_artist_id_unique_when_present", unique: true, where: "(spotify_artist_id IS NOT NULL)"
     t.index ["uuid"], name: "index_artists_on_uuid", unique: true
   end
@@ -131,7 +131,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_24_012926) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
+    t.uuid "uuid", null: false
     t.string "provider"
     t.string "uid"
     t.index ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
## 概要
- アーティスト名の重複登録を防ぐため、アプリとDBの両方でユニーク制約を追加。
## 実施内容
- app/models/artist.rb: name に uniqueness: true を追加し、モデル層で重複をバリデーション。
- db/migrate/20251125083646_add_unique_index_to_artists_name.rb: 既存のnameインデックスを削除してからユニークインデックスを作成するよう修正（DBレベルで重複禁止）。
## 対応Issue
- close #241 
## 関連Issue
なし
## 特記事項