### PR TITLE
[add]アーティストテーブルに公開/非公開のカラムを追加

### DIFF
--- a/app/components/stage_columns/festival_component.rb
+++ b/app/components/stage_columns/festival_component.rb
@@ -11,6 +11,14 @@ module StageColumns
     attr_reader :festival, :selected_day
 
     def render_block(performance, block)
+      block_body = default_block_content(block, block.artist_name)
+      block_style_rules = block_style(block, background_color: stage_color, text_color: stage_text_color)
+
+      return content_tag(:div,
+                         block_body,
+                         class: default_block_classes,
+                         style: block_style_rules) unless performance.artist.published?
+
       params = {
         from: "festival_timetable",
         festival_id: festival.slug,
@@ -20,8 +28,8 @@ module StageColumns
       link_to(helpers.artist_path(performance.artist, params),
               class: default_block_classes,
               data: { controller: "tap-feedback" },
-              style: block_style(block, background_color: stage_color, text_color: stage_text_color)) do
-        default_block_content(block, block.artist_name)
+              style: block_style_rules) do
+        block_body
       end
     end
   end

--- a/app/components/stage_columns/show_component.rb
+++ b/app/components/stage_columns/show_component.rb
@@ -18,6 +18,16 @@ module StageColumns
       text_color = selected ? stage_text_color : unselected_text_color
       border_color = selected ? "rgba(255,255,255,0.7)" : "rgba(148,163,184,0.7)"
       classes = [ default_block_classes, (selected ? nil : "opacity-80") ].compact.join(" ")
+      block_body = default_block_content(block, block.artist_name)
+      block_style_rules = block_style(block,
+                                      background_color: background_color,
+                                      text_color: text_color,
+                                      border: "1px solid #{border_color}")
+
+      return content_tag(:div,
+                         block_body,
+                         class: classes,
+                         style: block_style_rules) unless performance.artist.published?
 
       params = {
         from: "my_timetable",
@@ -29,12 +39,9 @@ module StageColumns
       link_to(helpers.artist_path(performance.artist, params),
               class: classes,
               data: { controller: "tap-feedback" },
-              style: block_style(block,
-                                background_color: background_color,
-                                text_color: text_color,
-                                border: "1px solid #{border_color}")
+              style: block_style_rules
               ) do
-        default_block_content(block, block.artist_name)
+        block_body
       end
     end
 

--- a/app/controllers/admin/artists_controller.rb
+++ b/app/controllers/admin/artists_controller.rb
@@ -39,7 +39,7 @@ class Admin::ArtistsController < Admin::BaseController
   end
 
   def artist_params
-    params.require(:artist).permit(:name, :spotify_artist_id, :image_url).tap do |p|
+    params.require(:artist).permit(:name, :spotify_artist_id, :image_url, :published).tap do |p|
       p[:spotify_artist_id] = p[:spotify_artist_id].presence
     end
   end

--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -4,7 +4,7 @@ class ArtistsController < ApplicationController
     @festival_days = []
     @selected_festival_day = nil
 
-    artists_scope = Artist.order(:name)
+    artists_scope = Artist.published.order(:name)
     @q     = artists_scope.ransack(params[:q])
     result = @q.result(distinct: true)
 
@@ -12,6 +12,6 @@ class ArtistsController < ApplicationController
   end
 
   def show
-    @artist = Artist.find_by_identifier!(params[:id])
+    @artist = Artist.find_published!(params[:id])
   end
 end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -3,6 +3,8 @@ require "securerandom"
 class Artist < ApplicationRecord
   validates :name, presence: true, uniqueness: true
 
+  scope :published, -> { where(published: true) }
+
   has_many :stage_performances, dependent: :destroy
   has_many :festival_days, through: :stage_performances
   has_many :festivals, -> { distinct }, through: :festival_days
@@ -13,6 +15,10 @@ class Artist < ApplicationRecord
 
   def self.find_by_identifier!(identifier)
     find_by(uuid: identifier) || find(identifier)
+  end
+
+  def self.find_published!(identifier)
+    published.find_by(uuid: identifier) || published.find(identifier)
   end
 
   def self.ransackable_attributes(_ = nil); %w[name]; end

--- a/app/models/festival.rb
+++ b/app/models/festival.rb
@@ -84,6 +84,7 @@ class Festival < ApplicationRecord
     Artist
       .joins(stage_performances: :festival_day)
       .where(stage_performances: { festival_day_id: festival_day.id })
+      .merge(Artist.published)
       .distinct
       .order(:name)
   end

--- a/app/views/admin/artists/_form.html.erb
+++ b/app/views/admin/artists/_form.html.erb
@@ -42,6 +42,11 @@
     </div>
   </div>
 
+  <div class="flex items-center gap-2">
+    <%= f.check_box :published, class: "h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500" %>
+    <%= f.label :published, "公開する", class: "text-sm font-semibold text-slate-800" %>
+  </div>
+
   <div class="pt-4">
     <%= f.submit "登録する", class: "px-4 py-2 rounded bg-[#F95858] text-white shadow-sm interactive-lift hover:bg-[#e14f4f] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#F95858]", data: { controller: "tap-feedback" } %>
   </div>

--- a/db/migrate/20251125092105_add_published_to_artists.rb
+++ b/db/migrate/20251125092105_add_published_to_artists.rb
@@ -1,0 +1,6 @@
+class AddPublishedToArtists < ActiveRecord::Migration[8.0]
+  def change
+    add_column :artists, :published, :boolean, default: true, null: false
+    add_index :artists, :published
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_11_25_083646) do
+ActiveRecord::Schema[8.0].define(version: 2025_11_25_092105) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "pg_catalog.plpgsql"
@@ -23,7 +23,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_25_083646) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "uuid", null: false
+    t.boolean "published", default: true, null: false
     t.index ["name"], name: "index_artists_on_name", unique: true
+    t.index ["published"], name: "index_artists_on_published"
     t.index ["spotify_artist_id"], name: "index_artists_on_spotify_artist_id_unique_when_present", unique: true, where: "(spotify_artist_id IS NOT NULL)"
     t.index ["uuid"], name: "index_artists_on_uuid", unique: true
   end
@@ -131,7 +133,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_25_083646) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "uuid", null: false
+    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.string "provider"
     t.string "uid"
     t.index ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
## 概要
- アーティストに公開フラグを追加し、一般公開のアーティスト一覧画面は公開分のみ表示・非公開はリンクしないように変更。
- フェス出演一覧やタイムテーブル表示も公開フラグに従うように変更。
## 実施内容
- db/migrate/20251125092105_add_published_to_artists.rb: published:boolean（default: true, null: false）とインデックスを追加。
- app/models/artist.rb: published スコープと find_published! を追加、name のユニークバリデーションを維持。
- app/controllers/artists_controller.rb: 一覧・詳細とも公開アーティストに限定。
- app/views/admin/artists/_form.html.erb, app/controllers/admin/artists_controller.rb: 管理画面で公開/非公開をチェックボックスで設定・保存可能に。
- app/models/festival.rb: フェス出演一覧で公開アーティストのみを返すように変更。
- app/components/stage_columns/festival_component.rb, show_component.rb: タイムテーブル上は非公開でも表示するがリンクは外し、遷移しないように調整。
## 対応Issue
- close #257 
## 関連Issue
なし
## 特記事項
- タイムテーブルには表示したいが、アーティスト一覧画面への表示やアーティスト詳細画面は不要なフェスアクトへの対応。
（例）京都大作戦「鞍馬の間」のようなバスケットボールアクト