### PR TITLE
[add]モデル追加

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,0 +1,13 @@
+class Item < ApplicationRecord
+  belongs_to :user, optional: true
+
+  has_many :packing_list_items, dependent: :destroy
+  has_many :packing_lists, through: :packing_list_items
+
+  scope :templates, -> { where(template: true) }
+  scope :owned_by, ->(user) { where(user_id: user.id) }
+
+  validates :name, presence: true, length: { maximum: 100 }
+  validates :user_id, presence: true, unless: :template?
+  validates :template, inclusion: { in: [ true, false ] }
+end

--- a/app/models/packing_list.rb
+++ b/app/models/packing_list.rb
@@ -1,0 +1,13 @@
+class PackingList < ApplicationRecord
+  belongs_to :user, optional: true
+
+  has_many :packing_list_items, dependent: :destroy
+  has_many :items, through: :packing_list_items
+
+  scope :templates, -> { where(template: true) }
+  scope :owned_by, ->(user) { where(user_id: user.id) }
+
+  validates :title, presence: true, length: { maximum: 100 }
+  validates :user_id, presence: true, unless: :template?
+  validates :template, inclusion: { in: [ true, false ] }
+end

--- a/app/models/packing_list_item.rb
+++ b/app/models/packing_list_item.rb
@@ -1,0 +1,8 @@
+class PackingListItem < ApplicationRecord
+  belongs_to :packing_list
+  belongs_to :item
+
+  validates :item_id, uniqueness: { scope: :packing_list_id }
+  validates :checked, inclusion: { in: [ true, false ] }
+  validates :position, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+end

--- a/db/migrate/20251126090000_create_items.rb
+++ b/db/migrate/20251126090000_create_items.rb
@@ -1,0 +1,16 @@
+class CreateItems < ActiveRecord::Migration[8.0]
+  def change
+    create_table :items do |t|
+      t.references :user, null: true, foreign_key: true
+      t.string :name, null: false
+      t.text :description
+      t.string :category
+      t.boolean :template, null: false, default: false
+
+      t.timestamps null: false
+    end
+
+    add_index :items, :template
+    add_index :items, [ :user_id, :name ], unique: true, name: "index_items_on_user_and_name_when_owned", where: "user_id IS NOT NULL"
+  end
+end

--- a/db/migrate/20251126091000_create_packing_lists.rb
+++ b/db/migrate/20251126091000_create_packing_lists.rb
@@ -1,0 +1,15 @@
+class CreatePackingLists < ActiveRecord::Migration[8.0]
+  def change
+    create_table :packing_lists do |t|
+      t.references :user, null: true, foreign_key: true
+      t.string :title, null: false
+      t.boolean :template, null: false, default: false
+      t.string :template_name
+
+      t.timestamps null: false
+    end
+
+    add_index :packing_lists, :template
+    add_index :packing_lists, [ :user_id, :title ], unique: true, name: "index_packing_lists_on_user_and_title_when_owned", where: "user_id IS NOT NULL"
+  end
+end

--- a/db/migrate/20251126092000_create_packing_list_items.rb
+++ b/db/migrate/20251126092000_create_packing_list_items.rb
@@ -1,0 +1,16 @@
+class CreatePackingListItems < ActiveRecord::Migration[8.0]
+  def change
+    create_table :packing_list_items do |t|
+      t.references :packing_list, null: false, foreign_key: true
+      t.references :item, null: false, foreign_key: true
+      t.boolean :checked, null: false, default: false
+      t.integer :position, null: false, default: 0
+      t.string :note
+
+      t.timestamps null: false
+    end
+
+    add_index :packing_list_items, [ :packing_list_id, :item_id ], unique: true, name: "index_packing_list_items_on_list_and_item"
+    add_index :packing_list_items, [ :packing_list_id, :position ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_11_25_092105) do
+ActiveRecord::Schema[8.0].define(version: 2025_11_26_092000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "pg_catalog.plpgsql"
@@ -59,6 +59,45 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_25_092105) do
     t.index ["slug"], name: "index_festivals_on_slug", unique: true
     t.index ["start_date"], name: "index_festivals_on_start_date"
     t.index ["timetable_published"], name: "index_festivals_on_timetable_published"
+  end
+
+  create_table "items", force: :cascade do |t|
+    t.bigint "user_id"
+    t.string "name", null: false
+    t.text "description"
+    t.string "category"
+    t.boolean "template", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["template"], name: "index_items_on_template"
+    t.index ["user_id", "name"], name: "index_items_on_user_and_name_when_owned", unique: true, where: "(user_id IS NOT NULL)"
+    t.index ["user_id"], name: "index_items_on_user_id"
+  end
+
+  create_table "packing_list_items", force: :cascade do |t|
+    t.bigint "packing_list_id", null: false
+    t.bigint "item_id", null: false
+    t.boolean "checked", default: false, null: false
+    t.integer "position", default: 0, null: false
+    t.string "note"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_id"], name: "index_packing_list_items_on_item_id"
+    t.index ["packing_list_id", "item_id"], name: "index_packing_list_items_on_list_and_item", unique: true
+    t.index ["packing_list_id", "position"], name: "index_packing_list_items_on_packing_list_id_and_position"
+    t.index ["packing_list_id"], name: "index_packing_list_items_on_packing_list_id"
+  end
+
+  create_table "packing_lists", force: :cascade do |t|
+    t.bigint "user_id"
+    t.string "title", null: false
+    t.boolean "template", default: false, null: false
+    t.string "template_name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["template"], name: "index_packing_lists_on_template"
+    t.index ["user_id", "title"], name: "index_packing_lists_on_user_and_title_when_owned", unique: true, where: "(user_id IS NOT NULL)"
+    t.index ["user_id"], name: "index_packing_lists_on_user_id"
   end
 
   create_table "stage_performances", force: :cascade do |t|
@@ -133,7 +172,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_25_092105) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
+    t.uuid "uuid", null: false
     t.string "provider"
     t.string "uid"
     t.index ["email"], name: "index_users_on_email", unique: true
@@ -143,6 +182,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_25_092105) do
   end
 
   add_foreign_key "festival_days", "festivals"
+  add_foreign_key "items", "users"
+  add_foreign_key "packing_list_items", "items"
+  add_foreign_key "packing_list_items", "packing_lists"
+  add_foreign_key "packing_lists", "users"
   add_foreign_key "stage_performances", "artists"
   add_foreign_key "stage_performances", "festival_days"
   add_foreign_key "stage_performances", "stages"


### PR DESCRIPTION
## 概要
- 持ち物リスト機能用のモデルと中間テーブルを追加し、テンプレ運用とユーザー所有を切り分けられる土台を作成。
## 実施内容
- db/migrate/20251126090000_create_items.rb にアイテムテーブルを追加（user_id任意FK、name必須、テンプレ判定フラグ、部分ユニーク索引）。
- db/migrate/20251126091000_create_packing_lists.rb に持ち物リストテーブルを追加（user_id任意FK、title必須、テンプレ判定/名前、部分ユニーク索引）。
- db/migrate/20251126092000_create_packing_list_items.rb にリストとアイテムを結ぶ中間テーブルを追加（checked/position/note、ユニーク制約と並び順索引）。
- モデル app/models/item.rb, packing_list.rb, packing_list_item.rb を追加し、関連・スコープ・バリデーションを定義。
## 対応Issue
- #170 
## 関連Issue
なし
## 特記事項