### PR TITLE
[add]ルーティング・コントローラーの追加

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,0 +1,36 @@
+class ItemsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_item, only: :destroy
+
+  def index
+    @items = Item.templates.or(Item.owned_by(current_user)).order(:name)
+  end
+
+  def new
+    @item = current_user.items.build
+  end
+
+  def create
+    @item = current_user.items.build(item_params)
+    if @item.save
+      redirect_to items_path, notice: "持ち物を追加しました"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @item.destroy!
+    redirect_to items_path, notice: "持ち物を削除しました"
+  end
+
+  private
+
+  def set_item
+    @item = current_user.items.find(params[:id])
+  end
+
+  def item_params
+    params.require(:item).permit(:name, :description, :category)
+  end
+end

--- a/app/controllers/packing_list_items_controller.rb
+++ b/app/controllers/packing_list_items_controller.rb
@@ -1,0 +1,46 @@
+class PackingListItemsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_packing_list
+  before_action :set_packing_list_item, only: [ :update, :destroy, :toggle ]
+
+  def create
+    @packing_list_item = @packing_list.packing_list_items.build(packing_list_item_params)
+    if @packing_list_item.save
+      redirect_to @packing_list, notice: "持ち物を追加しました"
+    else
+      redirect_to @packing_list, alert: "追加に失敗しました"
+    end
+  end
+
+  def update
+    if @packing_list_item.update(packing_list_item_params)
+      redirect_to @packing_list, notice: "持ち物を更新しました"
+    else
+      redirect_to @packing_list, alert: "更新に失敗しました"
+    end
+  end
+
+  def destroy
+    @packing_list_item.destroy!
+    redirect_to @packing_list, notice: "持ち物を削除しました"
+  end
+
+  def toggle
+    @packing_list_item.update!(checked: !@packing_list_item.checked)
+    redirect_to @packing_list, notice: "チェックを更新しました"
+  end
+
+  private
+
+  def set_packing_list
+    @packing_list = current_user.packing_lists.find(params[:packing_list_id])
+  end
+
+  def set_packing_list_item
+    @packing_list_item = @packing_list.packing_list_items.find(params[:id])
+  end
+
+  def packing_list_item_params
+    params.require(:packing_list_item).permit(:item_id, :note, :position)
+  end
+end

--- a/app/controllers/packing_lists_controller.rb
+++ b/app/controllers/packing_lists_controller.rb
@@ -1,0 +1,83 @@
+class PackingListsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_packing_list, only: [ :show, :edit, :update, :destroy, :duplicate_from_template ]
+  before_action :set_owned_packing_list, only: [ :edit, :update, :destroy ]
+
+  def index
+    @template_lists = PackingList.templates.order(:title)
+    @packing_lists = current_user.packing_lists.order(created_at: :desc)
+  end
+
+  def show
+    @packing_list_items = @packing_list.packing_list_items.includes(:item).order(:position, :id)
+  end
+
+  def new
+    @packing_list = current_user.packing_lists.build
+    @template_lists = PackingList.templates.order(:title)
+  end
+
+  def create
+    @packing_list = current_user.packing_lists.build(packing_list_params)
+    if @packing_list.save
+      redirect_to @packing_list, notice: "持ち物リストを作成しました"
+    else
+      @template_lists = PackingList.templates.order(:title)
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    @template_lists = PackingList.templates.order(:title)
+  end
+
+  def update
+    if @packing_list.update(packing_list_params)
+      redirect_to @packing_list, notice: "持ち物リストを更新しました"
+    else
+      @template_lists = PackingList.templates.order(:title)
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @packing_list.destroy!
+    redirect_to packing_lists_path, notice: "持ち物リストを削除しました"
+  end
+
+  def duplicate_from_template
+    unless @packing_list.template?
+      redirect_to packing_lists_path, alert: "テンプレートのみ複製できます" and return
+    end
+
+    new_list = current_user.packing_lists.build(title: @packing_list.title)
+    ActiveRecord::Base.transaction do
+      new_list.save!
+      @packing_list.packing_list_items.find_each do |pli|
+        new_list.packing_list_items.create!(
+          item_id: pli.item_id,
+          position: pli.position,
+          note: pli.note
+        )
+      end
+    end
+
+    redirect_to new_list, notice: "テンプレートからリストを作成しました"
+  rescue ActiveRecord::RecordInvalid
+    redirect_to packing_lists_path, alert: "複製に失敗しました"
+  end
+
+  private
+
+  def set_packing_list
+    @packing_list = PackingList.templates.or(PackingList.owned_by(current_user)).find(params[:id])
+  end
+
+  def set_owned_packing_list
+    @packing_list = current_user.packing_lists.find(params[:id])
+  end
+
+  def packing_list_params
+    params.require(:packing_list).permit(:title)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,8 @@ class User < ApplicationRecord
   has_many :favorite_festivals, through: :user_festival_favorites, source: :festival
   has_many :user_artist_favorites, dependent: :destroy
   has_many :favorite_artists, through: :user_artist_favorites, source: :artist
+  has_many :items, dependent: :destroy
+  has_many :packing_lists, dependent: :destroy
 
   before_create :ensure_uuid!
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,18 @@ Rails.application.routes.draw do
     resource :favorite, only: [ :create, :destroy ], module: :festivals
   end
 
+  resources :items, only: [ :index, :new, :create, :destroy ]
+  resources :packing_lists do
+    resources :packing_list_items, only: [ :create, :update, :destroy ] do
+      member do
+        patch :toggle
+      end
+    end
+    member do
+      post :duplicate_from_template
+    end
+  end
+
   namespace :admin do
     root "home#top"
     get "spotify/search", to: "spotify#search"


### PR DESCRIPTION
## 概要
- ルーティングに対応したコントローラとユーザーの関連を追加しました。
## 実施内容
- app/controllers/items_controller.rb：テンプレ＋自分のアイテム一覧、新規作成、削除（current_user.items を利用）。
- app/controllers/packing_lists_controller.rb：一覧（テンプレと自分）、詳細、新規/編集/削除、テンプレ複製。複製ではテンプレのアイテムを位置/メモごとコピーします。
- app/controllers/packing_list_items_controller.rb：リスト内アイテムの追加・更新・削除・チェックトグル（リストは自分のもののみ操作可能）。
- app/models/user.rb：has_many :items, has_many :packing_lists を追加。
## 対応Issue
- #170 
## 関連Issue
なし
## 特記事項