### PR TITLE
[fix]brakemanによる警告部分の修正

### DIFF
--- a/app/views/packing_lists/edit.html.erb
+++ b/app/views/packing_lists/edit.html.erb
@@ -1,5 +1,3 @@
-<% content_for :title, "持ち物リスト編集" %>
-
 <div class="min-h-screen px-4 pb-24 pt-6">
   <div class="mx-auto max-w-3xl space-y-6">
     <header class="space-y-2">


### PR DESCRIPTION
## 概要
- Strong Parameters を全面 permit! に頼らず、安全にネストされた持ち物パラメータを通すように修正。新規持ち物の追加が動き、Brakeman の警告も回避できる構造にした。
-  app/views/packing_lists/edit.html.erb のタイトル部分を削除。
## 実施内容
- PackingListsController#packing_list_params を改修し、親の title は通常の permit、ネストされた packing_list_items_attributes は自前のサニタイズメソッドで必要なキーだけ抽出（id/item_id/note/position/_destroy と item_attributes の id/name/description/category）してセット。
- sanitize_packing_list_items を追加し、動的キー付きのネストをハッシュ化→不要なキーを除去→空の item_attributes は付けない形で整形。
- これにより、フォームから送られた持ち物リストの子要素が強制的にフィルタされ、permit! を使わずに新規持ち物の追加・既存アイテムの保持が動作するようにした。
## 対応Issue
- #170 
- close #274 
## 関連Issue
なし
## 特記事項