### PR TITLE
[add]adminの持ち物テンプレート管理機能の追加

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -1,0 +1,45 @@
+class Admin::ItemsController < Admin::BaseController
+  before_action :set_item, only: [ :edit, :update, :destroy ]
+
+  def index
+    @pagy, @items = pagy(Item.templates.order(:name), limit: 30)
+  end
+
+  def new
+    @item = Item.new(template: true)
+  end
+
+  def create
+    @item = Item.new(item_params.merge(template: true, user: nil))
+    if @item.save
+      redirect_to admin_items_path, notice: "持ち物を作成しました"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit; end
+
+  def update
+    if @item.update(item_params.merge(template: true, user: nil))
+      redirect_to admin_items_path, notice: "持ち物を更新しました"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @item.destroy!
+    redirect_to admin_items_path, notice: "持ち物を削除しました"
+  end
+
+  private
+
+  def set_item
+    @item = Item.templates.find(params[:id])
+  end
+
+  def item_params
+    params.require(:item).permit(:name, :description, :category)
+  end
+end

--- a/app/controllers/admin/packing_lists_controller.rb
+++ b/app/controllers/admin/packing_lists_controller.rb
@@ -1,0 +1,78 @@
+class Admin::PackingListsController < Admin::BaseController
+  helper PackingListsHelper
+
+  before_action :set_packing_list, only: [ :edit, :update, :destroy ]
+  before_action :set_available_items, only: [ :new, :create, :edit, :update ]
+
+  def index
+    @pagy, @packing_lists = pagy(PackingList.templates.includes(:packing_list_items).order(:title), limit: 20)
+  end
+
+  def new
+    @packing_list = PackingList.new(template: true)
+    prepare_form_data
+  end
+
+  def create
+    @packing_list = PackingList.new(packing_list_params.merge(template: true, user: nil))
+    if @packing_list.save
+      redirect_to admin_packing_lists_path, notice: "テンプレート持ち物リストを作成しました"
+    else
+      prepare_form_data
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    prepare_form_data
+  end
+
+  def update
+    if @packing_list.update(packing_list_params.merge(template: true, user: nil))
+      redirect_to admin_packing_lists_path, notice: "テンプレート持ち物リストを更新しました"
+    else
+      prepare_form_data
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @packing_list.destroy!
+    redirect_to admin_packing_lists_path, notice: "テンプレート持ち物リストを削除しました"
+  end
+
+  private
+
+  def set_packing_list
+    @packing_list = PackingList.templates.find(params[:id])
+  end
+
+  def set_available_items
+    @available_items = Item.templates.order(:name)
+  end
+
+  def prepare_form_data
+    @sorted_items = @packing_list.packing_list_items.includes(:item).sort_by { |pli| [ pli.position || 0, pli.id || 0 ] }
+    @next_position_value = (@sorted_items.map { |pli| pli.position || 0 }.max || -1) + 1
+  end
+
+  def packing_list_params
+    raw = params.require(:packing_list)
+
+    safe = raw.permit(:title).to_h
+    safe[:packing_list_items_attributes] = sanitize_packing_list_items(raw[:packing_list_items_attributes])
+    safe
+  end
+
+  # 動的キー付きのネストを手動でサニタイズ
+  def sanitize_packing_list_items(raw_items)
+    return [] if raw_items.blank?
+
+    raw_items.to_unsafe_h.map do |_, attrs|
+      attrs = attrs.to_unsafe_h if attrs.respond_to?(:to_unsafe_h)
+      next unless attrs.is_a?(Hash)
+
+      attrs.slice("id", "item_id", "note", "position", "_destroy")
+    end.compact
+  end
+end

--- a/app/views/admin/home/top.html.erb
+++ b/app/views/admin/home/top.html.erb
@@ -7,6 +7,8 @@
     <%= render "shared/nav_stack_button", label: "フェス管理", url: admin_festivals_path %>
     <%= render "shared/nav_stack_button", label: "アーティスト管理", url: admin_artists_path %>
     <%= render "shared/nav_stack_button", label: "出演枠管理", url: admin_stage_performances_path %>
+    <%= render "shared/nav_stack_button", label: "持ち物管理", url: admin_items_path %>
+    <%= render "shared/nav_stack_button", label: "持ち物リスト管理", url: admin_packing_lists_path %>
     <%= render "shared/nav_stack_button", label: "セットリスト管理", url: "#" %>
   </nav>
 </div>

--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -1,0 +1,28 @@
+<%= form_with model: [:admin, @item], class: "space-y-6" do |f| %>
+  <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm space-y-6">
+    <div>
+      <%= f.label :name, "持ち物名", class: "block text-sm font-semibold text-slate-700" %>
+      <%= f.text_field :name,
+                       class: "mt-2 w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200",
+                       required: true %>
+    </div>
+
+    <div>
+      <%= f.label :category, "カテゴリ（任意）", class: "block text-sm font-semibold text-slate-700" %>
+      <%= f.text_field :category,
+                       placeholder: "例）基本セット、雨対策など",
+                       class: "mt-2 w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200" %>
+    </div>
+
+    <div>
+      <%= f.label :description, "メモ（任意）", class: "block text-sm font-semibold text-slate-700" %>
+      <%= f.text_area :description,
+                      rows: 3,
+                      class: "mt-2 w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200" %>
+    </div>
+  </div>
+
+  <div class="pt-2">
+    <%= f.submit class: "inline-flex items-center rounded bg-[#F95858] px-5 py-2 text-sm font-semibold text-white shadow transition hover:bg-[#e04f4f]" %>
+  </div>
+<% end %>

--- a/app/views/admin/items/edit.html.erb
+++ b/app/views/admin/items/edit.html.erb
@@ -1,0 +1,15 @@
+<div class="mx-auto max-w-3xl px-4 py-10 min-h-[calc(100vh-var(--header-offset,4.5rem)-var(--footer-offset,6rem))]">
+  <div class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+    <div>
+      <h1 class="text-2xl font-bold text-slate-900">持ち物を編集</h1>
+      <p class="mt-1 text-sm text-slate-600">テンプレートに表示される内容を更新します。</p>
+    </div>
+    <%= link_to "一覧に戻る",
+          admin_items_path,
+          class: "inline-flex items-center justify-center rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50" %>
+  </div>
+
+  <div class="mt-8">
+    <%= render "form" %>
+  </div>
+</div>

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -1,0 +1,48 @@
+<div class="mx-auto max-w-5xl px-4 py-10 min-h-[calc(100vh-var(--header-offset,4.5rem)-var(--footer-offset,6rem))]">
+  <div class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+    <div>
+      <h1 class="text-2xl font-bold">持ち物管理</h1>
+      <p class="mt-2 text-slate-600">テンプレートとして登録する持ち物を管理できます。</p>
+    </div>
+    <%= link_to "新規作成",
+                new_admin_item_path,
+                class: "inline-flex items-center justify-center rounded-lg bg-[#F95858] px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-[#e04f4f]" %>
+  </div>
+
+  <div class="mt-8 overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm">
+    <table class="min-w-full divide-y divide-slate-200 text-sm">
+      <thead class="bg-slate-50">
+        <tr class="text-left text-xs font-semibold uppercase tracking-wider text-slate-600">
+          <th class="px-4 py-3">ID</th>
+          <th class="px-4 py-3">名前</th>
+          <th class="px-4 py-3">カテゴリ</th>
+          <th class="px-4 py-3">メモ</th>
+          <th class="px-4 py-3"></th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-slate-100 text-slate-800">
+        <% @items.each do |item| %>
+          <tr class="hover:bg-slate-50">
+            <td class="px-4 py-3 font-mono text-xs text-slate-500"><%= item.id %></td>
+            <td class="px-4 py-3 font-semibold"><%= item.name %></td>
+            <td class="px-4 py-3 text-xs text-slate-600"><%= item.category.presence || "-" %></td>
+            <td class="px-4 py-3 text-sm text-slate-700">
+              <% if item.description.present? %>
+                <span class="line-clamp-2"><%= item.description %></span>
+              <% else %>
+                <span class="text-slate-400">-</span>
+              <% end %>
+            </td>
+            <td class="px-4 py-3">
+              <div class="flex items-center gap-3 text-sm font-semibold">
+                <%= link_to "編集", edit_admin_item_path(item), class: "text-blue-600 transition hover:text-blue-700" %>
+                <%= link_to "削除", admin_item_path(item), data: { turbo_method: :delete, turbo_confirm: "削除しますか？" }, class: "text-red-600 transition hover:text-red-700" %>
+              </div>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+  <%= render "shared/pagination", pagy: @pagy %>
+</div>

--- a/app/views/admin/items/new.html.erb
+++ b/app/views/admin/items/new.html.erb
@@ -1,0 +1,15 @@
+<div class="mx-auto max-w-3xl px-4 py-10 min-h-[calc(100vh-var(--header-offset,4.5rem)-var(--footer-offset,6rem))]">
+  <div class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+    <div>
+      <h1 class="text-2xl font-bold text-slate-900">持ち物を追加</h1>
+      <p class="mt-1 text-sm text-slate-600">テンプレートとして使える持ち物を登録します。</p>
+    </div>
+    <%= link_to "一覧に戻る",
+          admin_items_path,
+          class: "inline-flex items-center justify-center rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50" %>
+  </div>
+
+  <div class="mt-8">
+    <%= render "form" %>
+  </div>
+</div>

--- a/app/views/admin/packing_lists/_form.html.erb
+++ b/app/views/admin/packing_lists/_form.html.erb
@@ -1,0 +1,116 @@
+<%= form_with model: [:admin, @packing_list], class: "space-y-6" do |f| %>
+  <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm space-y-6">
+    <div>
+      <%= f.label :title, "リスト名", class: "block text-sm font-semibold text-slate-700" %>
+      <%= f.text_field :title,
+                       placeholder: "例）夏フェス持ち物テンプレート",
+                       class: "mt-2 w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200",
+                       required: true %>
+    </div>
+
+    <div class="border-t border-slate-100 pt-4"
+         data-controller="packing-list-form"
+         data-packing-list-form-next-position-value="<%= @next_position_value || 0 %>">
+      <div class="flex items-center justify-between gap-3">
+        <h2 class="text-base font-bold text-slate-900">テンプレートの持ち物</h2>
+        <button type="button"
+                class="inline-flex items-center gap-1 rounded-lg bg-indigo-500 px-3 py-2 text-xs font-bold text-white shadow-sm interactive-lift hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+                data-controller="tap-feedback"
+                data-action="click->packing-list-form#openModal">
+          <span class="text-base leading-none">＋</span>
+          <span>持ち物を追加</span>
+        </button>
+      </div>
+
+      <div class="mt-4 space-y-3" data-packing-list-form-target="itemsContainer">
+        <p class="rounded-xl border border-dashed border-slate-300 bg-slate-50 px-4 py-6 text-center text-sm text-slate-600 <%= "hidden" if @sorted_items&.any? %>"
+           data-packing-list-form-target="emptyState">
+          追加した持ち物がここに並びます。「持ち物を追加」から登録してください。
+        </p>
+
+        <% (@sorted_items || []).each do |pli| %>
+          <%= f.fields_for :packing_list_items, pli do |pli_fields| %>
+            <%= render "packing_lists/item_fields", f: pli_fields %>
+          <% end %>
+        <% end %>
+      </div>
+
+      <div data-packing-list-form-target="modal"
+           class="fixed inset-0 z-50 hidden flex items-center justify-center bg-slate-900/60 px-3 py-6 md:px-4"
+           data-action="click->packing-list-form#closeModal">
+        <div class="w-full max-w-lg rounded-3xl bg-white shadow-2xl shadow-slate-900/20"
+             data-action="click->packing-list-form#stopPropagation">
+          <header class="flex items-center justify-between border-b border-slate-100 px-5 py-4">
+            <h3 class="text-base font-bold text-slate-900">テンプレートから追加</h3>
+            <button type="button"
+                    class="rounded-full p-1 text-slate-500 hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-400"
+                    data-action="click->packing-list-form#closeModal">
+              ✕
+            </button>
+          </header>
+
+          <div class="space-y-5 px-5 py-4">
+            <div class="space-y-3">
+              <p class="text-sm font-semibold text-slate-800">登録済みの持ち物</p>
+              <div class="max-h-72 space-y-2 overflow-y-auto rounded-2xl border border-slate-200 bg-slate-50 px-3 py-3">
+                <% if @available_items.any? %>
+                  <% @available_items.each do |item| %>
+                    <%= button_tag type: "button",
+                                   class: "flex w-full items-start justify-between gap-3 rounded-xl bg-white px-4 py-3 text-left text-sm font-semibold text-slate-900 shadow-sm ring-1 ring-slate-200 hover:bg-slate-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500",
+                                   data: {
+                                     action: "click->packing-list-form#addExistingItem",
+                                     item_id: item.id,
+                                     item_name: item.name,
+                                     item_description: item.description
+                                   } do %>
+                      <span class="min-w-0 break-words">
+                        <span class="block font-bold"><%= item.name %></span>
+                        <% if item.description.present? %>
+                          <span class="block text-xs font-normal text-slate-600"><%= truncate(item.description, length: 80) %></span>
+                        <% end %>
+                      </span>
+                      <span class="shrink-0 rounded-full bg-indigo-100 px-3 py-1 text-xs font-bold text-indigo-600">追加</span>
+                    <% end %>
+                  <% end %>
+                <% else %>
+                  <p class="text-center text-xs text-slate-500">テンプレート登録されている持ち物がありません。</p>
+                <% end %>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <template data-packing-list-form-target="existingItemTemplate">
+        <div class="rounded-2xl border border-slate-200 bg-white px-4 py-3 shadow-sm"
+             data-nested-form-wrapper
+             data-item-id="__ITEM_ID__">
+          <input type="hidden" name="packing_list[packing_list_items_attributes][__INDEX__][_destroy]" value="0" data-destroy-field="true" />
+          <input type="hidden" name="packing_list[packing_list_items_attributes][__INDEX__][item_id]" value="__ITEM_ID__" />
+          <input type="hidden" name="packing_list[packing_list_items_attributes][__INDEX__][position]" value="__POSITION__" data-position-field="true" />
+
+          <div class="flex items-start justify-between gap-3">
+            <div class="min-w-0 space-y-1">
+              <p class="break-words text-sm font-bold text-slate-900">__ITEM_NAME__</p>
+              <p class="break-words text-xs text-slate-600">__ITEM_DESCRIPTION__</p>
+              <input type="text"
+                     name="packing_list[packing_list_items_attributes][__INDEX__][note]"
+                     placeholder="メモを追加 (任意)"
+                     value="__ITEM_NOTE__"
+                     class="mt-2 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-800 placeholder:text-slate-400 focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-200" />
+            </div>
+            <button type="button"
+                    class="shrink-0 rounded-lg bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700 hover:bg-slate-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-400"
+                    data-action="click->packing-list-form#removeItem">
+              削除
+            </button>
+          </div>
+        </div>
+      </template>
+    </div>
+  </div>
+
+  <div class="pt-2">
+    <%= f.submit class: "inline-flex items-center rounded bg-[#F95858] px-5 py-2 text-sm font-semibold text-white shadow transition hover:bg-[#e04f4f]" %>
+  </div>
+<% end %>

--- a/app/views/admin/packing_lists/edit.html.erb
+++ b/app/views/admin/packing_lists/edit.html.erb
@@ -1,0 +1,15 @@
+<div class="mx-auto max-w-4xl px-4 py-10 min-h-[calc(100vh-var(--header-offset,4.5rem)-var(--footer-offset,6rem))]">
+  <div class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+    <div>
+      <h1 class="text-2xl font-bold text-slate-900">持ち物リストを編集</h1>
+      <p class="mt-1 text-sm text-slate-600">テンプレートに含める持ち物やメモを更新します。</p>
+    </div>
+    <%= link_to "一覧に戻る",
+          admin_packing_lists_path,
+          class: "inline-flex items-center justify-center rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50" %>
+  </div>
+
+  <div class="mt-8">
+    <%= render "form" %>
+  </div>
+</div>

--- a/app/views/admin/packing_lists/index.html.erb
+++ b/app/views/admin/packing_lists/index.html.erb
@@ -1,0 +1,44 @@
+<div class="mx-auto max-w-5xl px-4 py-10 min-h-[calc(100vh-var(--header-offset,4.5rem)-var(--footer-offset,6rem))]">
+  <div class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+    <div>
+      <h1 class="text-2xl font-bold">持ち物リスト管理</h1>
+      <p class="mt-2 text-slate-600">テンプレートとして配布する持ち物リストを組み立てます。</p>
+    </div>
+    <%= link_to "新規作成",
+                new_admin_packing_list_path,
+                class: "inline-flex items-center justify-center rounded-lg bg-[#F95858] px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-[#e04f4f]" %>
+  </div>
+
+  <div class="mt-8 overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm">
+    <table class="min-w-full divide-y divide-slate-200 text-sm">
+      <thead class="bg-slate-50">
+        <tr class="text-left text-xs font-semibold uppercase tracking-wider text-slate-600">
+          <th class="px-4 py-3">ID</th>
+          <th class="px-4 py-3">リスト名</th>
+          <th class="px-4 py-3">持ち物数</th>
+          <th class="px-4 py-3">更新日</th>
+          <th class="px-4 py-3"></th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-slate-100 text-slate-800">
+        <% @packing_lists.each do |list| %>
+          <tr class="hover:bg-slate-50">
+            <td class="px-4 py-3 font-mono text-xs text-slate-500"><%= list.id %></td>
+            <td class="px-4 py-3 font-semibold"><%= list.title %></td>
+            <td class="px-4 py-3 text-xs font-semibold text-slate-700">
+              <span class="inline-flex min-w-[3rem] items-center justify-center rounded-full bg-slate-100 px-2 py-1"><%= list.packing_list_items.size %> 件</span>
+            </td>
+            <td class="px-4 py-3 text-xs text-slate-600"><%= l(list.updated_at, format: :short) %></td>
+            <td class="px-4 py-3">
+              <div class="flex items-center gap-3 text-sm font-semibold">
+                <%= link_to "編集", edit_admin_packing_list_path(list), class: "text-blue-600 transition hover:text-blue-700" %>
+                <%= link_to "削除", admin_packing_list_path(list), data: { turbo_method: :delete, turbo_confirm: "削除しますか？" }, class: "text-red-600 transition hover:text-red-700" %>
+              </div>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+  <%= render "shared/pagination", pagy: @pagy %>
+</div>

--- a/app/views/admin/packing_lists/new.html.erb
+++ b/app/views/admin/packing_lists/new.html.erb
@@ -1,0 +1,15 @@
+<div class="mx-auto max-w-4xl px-4 py-10 min-h-[calc(100vh-var(--header-offset,4.5rem)-var(--footer-offset,6rem))]">
+  <div class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+    <div>
+      <h1 class="text-2xl font-bold text-slate-900">持ち物リストを追加</h1>
+      <p class="mt-1 text-sm text-slate-600">テンプレートの持ち物からリストを組み立てます。</p>
+    </div>
+    <%= link_to "一覧に戻る",
+          admin_packing_lists_path,
+          class: "inline-flex items-center justify-center rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50" %>
+  </div>
+
+  <div class="mt-8">
+    <%= render "form" %>
+  </div>
+</div>

--- a/app/views/packing_lists/index.html.erb
+++ b/app/views/packing_lists/index.html.erb
@@ -60,11 +60,10 @@
                 <div class="min-w-0">
                   <p class="break-words text-sm font-bold text-slate-900"><%= template.title %></p>
                 </div>
-                <%= button_to "複製",
-                              duplicate_from_template_packing_list_path(template),
-                              method: :post,
-                              class: "shrink-0 rounded-xl bg-indigo-500 px-3 py-1.5 text-xs font-bold text-white shadow-sm interactive-lift hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500",
-                              data: { controller: "tap-feedback" } %>
+                <%= link_to "複製",
+                            new_packing_list_path(template_id: template.id),
+                            class: "shrink-0 rounded-xl bg-indigo-500 px-3 py-1.5 text-xs font-bold text-white shadow-sm interactive-lift hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500",
+                            data: { controller: "tap-feedback" } %>
               </div>
             </div>
           <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,5 +55,7 @@ Rails.application.routes.draw do
         patch :apply
       end
     end
+    resources :items, only: [ :index, :new, :create, :edit, :update, :destroy ]
+    resources :packing_lists, only: [ :index, :new, :create, :edit, :update, :destroy ]
   end
 end


### PR DESCRIPTION
## 概要
- 管理画面に「持ち物管理」「持ち物リスト管理」を追加し、テンプレート持ち物とテンプレート持ち物リストのCRUDを実装。
- ユーザー向けテンプレ複製フローを改善し、新規作成画面にテンプレ内容を事前投入できるように変更。
## 実施内容
- ルーティングに admin/items, packing_lists を追加し、メニューから遷移できるようにリンクを追加（config/routes.rb, app/views/admin/home/top.html.erb）。
- 管理用コントローラを追加: テンプレ持ち物のCRUD（app/controllers/admin/items_controller.rb）と、テンプレ持ち物リストのCRUD＋ネストパラメータサニタイズ（app/controllers/admin/packing_lists_controller.rb）。
- 管理用の一覧・新規・編集ビューを作成し、持ち物リスト編集ではモーダルでテンプレ持ち物を選択して並べられるUIを実装（app/views/admin/items/*, app/views/admin/packing_lists/*）。
- 通常ユーザー側: テンプレ複製ボタンを新規作成リンクに変更し、template_id指定でタイトル・持ち物を初期投入（app/views/packing_lists/index.html.erb, packing_lists_controller#apply_template_if_present）。
- 持ち物リスト登録におけるタイトル重複エラーのメッセージを固定化。
## 対応Issue
- close #170 
## 関連Issue
なし
## 特記事項
- 通常ユーザー側のテンプレート持ち物の選択と、テンプレートの持ち物リストの複製機能の動作確認済。