### PR TITLE
[add]持ち物リストのテーブルにuuidを追加するマイグレーション作成

### DIFF
--- a/db/migrate/20251129052829_add_uuid_to_packing_lists.rb
+++ b/db/migrate/20251129052829_add_uuid_to_packing_lists.rb
@@ -1,0 +1,6 @@
+class AddUuidToPackingLists < ActiveRecord::Migration[8.0]
+  def change
+    add_column :packing_lists, :uuid, :string
+    add_index  :packing_lists, :uuid, unique: true
+  end
+end

--- a/db/migrate/20251129053104_backfill_and_enforce_uuid_on_packing_lists.rb
+++ b/db/migrate/20251129053104_backfill_and_enforce_uuid_on_packing_lists.rb
@@ -1,0 +1,18 @@
+class BackfillAndEnforceUuidOnPackingLists < ActiveRecord::Migration[8.0]
+  def up
+    enable_extension "pgcrypto" unless extension_enabled?("pgcrypto")
+
+    PackingList.where(uuid: [ nil, "" ]).find_in_batches(batch_size: 1000) do |batch|
+      batch.each { |pl| pl.update_columns(uuid: SecureRandom.uuid) }
+    end
+
+    change_column_default :packing_lists, :uuid, -> { "gen_random_uuid()" }
+    change_column_null :packing_lists, :uuid, false
+  end
+
+  def down
+    change_column_null :packing_lists, :uuid, true
+    change_column_default :packing_lists, :uuid, nil
+    # バックフィル分は戻さない想定
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_11_26_092000) do
+ActiveRecord::Schema[8.0].define(version: 2025_11_29_053104) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "pg_catalog.plpgsql"
@@ -95,9 +95,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_26_092000) do
     t.string "template_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.index ["template"], name: "index_packing_lists_on_template"
     t.index ["user_id", "title"], name: "index_packing_lists_on_user_and_title_when_owned", unique: true, where: "(user_id IS NOT NULL)"
     t.index ["user_id"], name: "index_packing_lists_on_user_id"
+    t.index ["uuid"], name: "index_packing_lists_on_uuid", unique: true
   end
 
   create_table "stage_performances", force: :cascade do |t|
@@ -172,7 +174,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_26_092000) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
+    t.uuid "uuid", null: false
     t.string "provider"
     t.string "uid"
     t.index ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
## 概要
- PackingListにUUIDを導入するための2本のマイグレーションを追加し、今後の新規作成で自動付与し、既存データにもUUIDを埋めた上でNOT NULL制約を付与。
## 実施内容
- 20251129052829_add_uuid_to_packing_lists.rbでpacking_listsにuuidカラム追加＋ユニークインデックスを作成。
- 20251129053104_backfill_and_enforce_uuid_on_packing_lists.rbでpgcrypto有効化、既存レコードへUUIDバックフィル、以降のデフォルトをgen_random_uuid()に設定、uuidをNOT NULL制約に変更。
## 対応Issue
- #271 
## 関連Issue
なし
## 特記事項
- 現時点でURLには未反映。