### PR TITLE
[fix]マイグレーションファイルの修正

### DIFF
--- a/db/migrate/20251129055631_backfill_and_enforce_uuid_on_packing_lists.rb
+++ b/db/migrate/20251129055631_backfill_and_enforce_uuid_on_packing_lists.rb
@@ -2,9 +2,16 @@ class BackfillAndEnforceUuidOnPackingLists < ActiveRecord::Migration[8.0]
   def up
     enable_extension "pgcrypto" unless extension_enabled?("pgcrypto")
 
-    PackingList.where(uuid: [ nil, "" ]).find_in_batches(batch_size: 1000) do |batch|
-      batch.each { |pl| pl.update_columns(uuid: SecureRandom.uuid) }
-    end
+    # 既存レコードを一括バックフィル（トランザクション内で確実に埋める）
+    execute <<~SQL
+      UPDATE packing_lists
+      SET uuid = gen_random_uuid()
+      WHERE uuid IS NULL OR uuid = '';
+    SQL
+
+    # 万が一残っていればここで検知して落とす
+    remaining = select_value("SELECT COUNT(*) FROM packing_lists WHERE uuid IS NULL OR uuid = ''").to_i
+    raise StandardError, "uuid backfill failed (#{remaining} rows remain)" if remaining.positive?
 
     change_column_default :packing_lists, :uuid, -> { "gen_random_uuid()" }
     change_column_null :packing_lists, :uuid, false


### PR DESCRIPTION
## 概要
- デプロイ失敗のため、マイグレーションファイルを修正。
## 実施内容
- UPDATE packing_lists SET uuid = gen_random_uuid() WHERE uuid IS NULL OR uuid = ''
- バックフィル後に残件チェックして異常時は例外
- その後でchange_column_default → change_column_null
## 対応Issue
- #271 
## 関連Issue
なし
## 特記事項