### PR TITLE
[fix]

### DIFF
--- a/db/migrate/20251129070500_backfill_and_enforce_uuid_on_packing_lists_retry.rb
+++ b/db/migrate/20251129070500_backfill_and_enforce_uuid_on_packing_lists_retry.rb
@@ -1,0 +1,22 @@
+class BackfillAndEnforceUuidOnPackingListsRetry < ActiveRecord::Migration[8.0]
+  def up
+    enable_extension "pgcrypto" unless extension_enabled?("pgcrypto")
+
+    execute <<~SQL
+      UPDATE packing_lists
+      SET uuid = gen_random_uuid()
+      WHERE uuid IS NULL;
+    SQL
+
+    remaining = select_value("SELECT COUNT(*) FROM packing_lists WHERE uuid IS NULL").to_i
+    raise StandardError, "uuid backfill failed (#{remaining} rows remain)" if remaining.positive?
+
+    change_column_default :packing_lists, :uuid, -> { "gen_random_uuid()" }
+    change_column_null :packing_lists, :uuid, false
+  end
+
+  def down
+    change_column_null :packing_lists, :uuid, true
+    change_column_default :packing_lists, :uuid, nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_11_29_070000) do
+ActiveRecord::Schema[8.0].define(version: 2025_11_29_070500) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "pg_catalog.plpgsql"
@@ -95,7 +95,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_29_070000) do
     t.string "template_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "uuid"
+    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.index ["template"], name: "index_packing_lists_on_template"
     t.index ["user_id", "title"], name: "index_packing_lists_on_user_and_title_when_owned", unique: true, where: "(user_id IS NOT NULL)"
     t.index ["user_id"], name: "index_packing_lists_on_user_id"


### PR DESCRIPTION
## 概要
- 既存データにuuidを埋めて、null:false制約を追加。
## 実施内容
- up: pgcrypto有効化 → 全レコードをgen_random_uuid()で埋める → 残件チェック → default gen_random_uuid()付与 → NOT NULL制約
- down: NOT NULL解除とデフォルト解除
## 対応Issue
- #271 
## 関連Issue
なし
## 特記事項