### PR TITLE
[fix]マイグレーションファイルを修正

### DIFF
--- a/db/migrate/20251129070500_backfill_and_enforce_uuid_on_packing_lists_retry.rb
+++ b/db/migrate/20251129070500_backfill_and_enforce_uuid_on_packing_lists_retry.rb
@@ -2,16 +2,21 @@ class BackfillAndEnforceUuidOnPackingListsRetry < ActiveRecord::Migration[8.0]
   def up
     enable_extension "pgcrypto" unless extension_enabled?("pgcrypto")
 
+    # 新規作成分がNULLにならないよう先にデフォルトを付与
+    change_column_default :packing_lists, :uuid, -> { "gen_random_uuid()" }
+
+    # 既存のNULLをバックフィル
     execute <<~SQL
       UPDATE packing_lists
       SET uuid = gen_random_uuid()
       WHERE uuid IS NULL;
     SQL
 
+    # 残っていれば異常として止める
     remaining = select_value("SELECT COUNT(*) FROM packing_lists WHERE uuid IS NULL").to_i
     raise StandardError, "uuid backfill failed (#{remaining} rows remain)" if remaining.positive?
 
-    change_column_default :packing_lists, :uuid, -> { "gen_random_uuid()" }
+    # NOT NULL 制約
     change_column_null :packing_lists, :uuid, false
   end
 


### PR DESCRIPTION
## 概要
- デプロイエラーによるマイグレーションファイルの変更。
## 実施内容
- 先にデフォルトを付与→NULLバックフィル→残件チェック→NOT NULL の順に変更。
## 対応Issue
- #271 
## 関連Issue
なし
## 特記事項