### PR TITLE
[fix]一度uuidカラムを削除し、再作成

### DIFF
--- a/db/migrate/20251129080000_enforce_uuid_default_on_packing_lists.rb
+++ b/db/migrate/20251129080000_enforce_uuid_default_on_packing_lists.rb
@@ -1,7 +1,18 @@
 class EnforceUuidDefaultOnPackingLists < ActiveRecord::Migration[8.0]
-  def change
+  def up
     enable_extension "pgcrypto" unless extension_enabled?("pgcrypto")
-    change_column_default :packing_lists, :uuid, -> { "gen_random_uuid()" }
-    change_column_null :packing_lists, :uuid, false
+
+    # テーブルが空の前提なので一旦カラムを落として作り直す
+    if column_exists?(:packing_lists, :uuid)
+      remove_column :packing_lists, :uuid
+    end
+
+    add_column :packing_lists, :uuid, :uuid, null: false, default: -> { "gen_random_uuid()" }
+    add_index  :packing_lists, :uuid, unique: true
+  end
+
+  def down
+    remove_index  :packing_lists, :uuid if index_exists?(:packing_lists, :uuid)
+    remove_column :packing_lists, :uuid if column_exists?(:packing_lists, :uuid)
   end
 end


### PR DESCRIPTION
## 概要
- マイグレーションの修正。
## 実施内容
- 一度uuidカラムを削除し作成。
## 対応Issue
- #271 
## 関連Issue

## 特記事項