### PR TITLE
[add]uuidの再追加

### DIFF
--- a/db/migrate/20251129090500_add_uuid_to_packing_lists_again.rb
+++ b/db/migrate/20251129090500_add_uuid_to_packing_lists_again.rb
@@ -1,0 +1,7 @@
+class AddUuidToPackingListsAgain < ActiveRecord::Migration[8.0]
+  def change
+    enable_extension "pgcrypto" unless extension_enabled?("pgcrypto")
+    add_column :packing_lists, :uuid, :uuid, null: false, default: -> { "gen_random_uuid()" }
+    add_index  :packing_lists, :uuid, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_11_29_090000) do
+ActiveRecord::Schema[8.0].define(version: 2025_11_29_090500) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "pg_catalog.plpgsql"
@@ -95,9 +95,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_29_090000) do
     t.string "template_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.index ["template"], name: "index_packing_lists_on_template"
     t.index ["user_id", "title"], name: "index_packing_lists_on_user_and_title_when_owned", unique: true, where: "(user_id IS NOT NULL)"
     t.index ["user_id"], name: "index_packing_lists_on_user_id"
+    t.index ["uuid"], name: "index_packing_lists_on_uuid", unique: true
   end
 
   create_table "stage_performances", force: :cascade do |t|


### PR DESCRIPTION
## 概要
- 持ち物リストのテーブルにuuidを再作成。
## 実施内容
- pgcrypto有効化
- packing_lists.uuidをuuid型・null: false・default gen_random_uuid()で追加
- ユニークインデックス付与
## 対応Issue
- #271 
## 関連Issue

## 特記事項