### PR TITLE
[add]持ち物リストのuuidをURLに適用

### DIFF
--- a/app/controllers/admin/packing_lists_controller.rb
+++ b/app/controllers/admin/packing_lists_controller.rb
@@ -44,7 +44,7 @@ class Admin::PackingListsController < Admin::BaseController
   private
 
   def set_packing_list
-    @packing_list = PackingList.templates.find(params[:id])
+    @packing_list = PackingList.templates.find_by!(uuid: params[:id])
   end
 
   def set_available_items

--- a/app/controllers/packing_lists_controller.rb
+++ b/app/controllers/packing_lists_controller.rb
@@ -77,11 +77,11 @@ class PackingListsController < ApplicationController
   private
 
   def set_packing_list
-    @packing_list = PackingList.templates.or(PackingList.owned_by(current_user)).find(params[:id])
+    @packing_list = PackingList.templates.or(PackingList.owned_by(current_user)).find_by!(uuid: params[:id])
   end
 
   def set_owned_packing_list
-    @packing_list = current_user.packing_lists.find(params[:id])
+    @packing_list = current_user.packing_lists.find_by!(uuid: params[:id])
   end
 
   def set_available_items

--- a/app/models/packing_list.rb
+++ b/app/models/packing_list.rb
@@ -13,4 +13,8 @@ class PackingList < ApplicationRecord
   validates :title, uniqueness: { scope: :user_id, message: "は既に存在します" }, unless: :template?
   validates :user_id, presence: true, unless: :template?
   validates :template, inclusion: { in: [ true, false ] }
+
+  def to_param
+    uuid.presence || super
+  end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -174,7 +174,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_29_090500) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "uuid", null: false
+    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.string "provider"
     t.string "uid"
     t.index ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
## 概要
- 持ち物リストのURLをUUIDベースに変更し、ユーザー側・管理画面ともにUUIDでレコードを参照するようにしました。
## 実施内容
- PackingList#to_paramをUUID返却に変更（app/models/packing_list.rb）。
- 一般/管理側コントローラのレコード取得をfind_by!(uuid: params[:id])に変更（app/controllers/packing_lists_controller.rb, app/controllers/admin/packing_lists_controller.rb）。
## 対応Issue
- close #271 
## 関連Issue

## 特記事項