### PR TITLE
[update]フェスの開催前の条件を改善

### DIFF
--- a/app/models/festival.rb
+++ b/app/models/festival.rb
@@ -15,7 +15,7 @@ class Festival < ApplicationRecord
   validate  :end_not_before_start
 
   scope :ordered,  -> { order(start_date: :asc, name: :asc) }
-  scope :upcoming, ->(today = Date.current) { where("start_date >= ?", today) }
+  scope :upcoming, ->(today = Date.current) { where("end_date >= ?", today) }
   scope :past,     ->(today = Date.current) { where("end_date < ?",  today) }
   scope :with_published_timetable, -> { where(timetable_published: true) }
   scope :with_slug, ->(slug) { where(slug: slug) }


### PR DESCRIPTION
## 概要
- 今日開催中で、開催開始日が過去のフェスが「開催前/開催後」のどちらにも含まれずに表示されない問題の改善。
## 実施内容
- app/models/festival.rb のスコープを更新し、開催前判定を最終日基準に変更。upcoming は end_date >= 今日、past は end_date < 今日 になり、開催期間中は「開催前」に含まれる。
## 対応Issue
- close #251 
## 関連Issue
なし
## 特記事項