### PR TITLE
[add]ステージパフォーマンスターブルに「出演キャンセル」のカラムを追加

### DIFF
--- a/app/components/stage_columns/base_component.rb
+++ b/app/components/stage_columns/base_component.rb
@@ -78,20 +78,25 @@ module StageColumns
       style_rules.join(" ")
     end
 
-    def default_block_content(block, artist_name)
+    def default_block_content(block, artist_name, canceled: false)
+      canceled_classes = canceled ? "text-red-700 line-through decoration-2" : nil
       time_label = block.end_label ? "#{block.start_label}-#{block.end_label}" : block.start_label
 
       time_block = content_tag(:div,
                                content_tag(:div, time_label, class: "whitespace-nowrap"),
-                               class: "font-mono text-[9px] font-medium leading-none opacity-90 sm:text-[10px]")
+                               class: [ "font-mono text-[9px] font-medium leading-none opacity-90 sm:text-[10px]", canceled_classes ].compact.join(" "))
 
       name_block = content_tag(:div,
                                artist_name,
-                               class: "flex-1 overflow-hidden text-ellipsis text-[11px] font-bold leading-tight sm:text-xs")
+                               class: [ "flex-1 overflow-hidden text-ellipsis text-[11px] font-bold leading-tight sm:text-xs", canceled_classes ].compact.join(" "))
 
       content_tag(:div, class: "flex h-full flex-col justify-start gap-px text-left") do
         safe_join([ time_block, name_block ])
       end
+    end
+
+    def canceled?(performance)
+      performance.respond_to?(:canceled?) && performance.canceled?
     end
 
     def stage_color

--- a/app/components/stage_columns/festival_component.rb
+++ b/app/components/stage_columns/festival_component.rb
@@ -11,7 +11,7 @@ module StageColumns
     attr_reader :festival, :selected_day
 
     def render_block(performance, block)
-      block_body = default_block_content(block, block.artist_name)
+      block_body = default_block_content(block, block.artist_name, canceled: canceled?(performance))
       block_style_rules = block_style(block, background_color: stage_color, text_color: stage_text_color)
 
       return content_tag(:div,

--- a/app/components/stage_columns/show_component.rb
+++ b/app/components/stage_columns/show_component.rb
@@ -18,7 +18,7 @@ module StageColumns
       text_color = selected ? stage_text_color : unselected_text_color
       border_color = selected ? "rgba(255,255,255,0.7)" : "rgba(148,163,184,0.7)"
       classes = [ default_block_classes, (selected ? nil : "opacity-80") ].compact.join(" ")
-      block_body = default_block_content(block, block.artist_name)
+      block_body = default_block_content(block, block.artist_name, canceled: canceled?(performance))
       block_style_rules = block_style(block,
                                       background_color: background_color,
                                       text_color: text_color,

--- a/app/controllers/admin/stage_performances_controller.rb
+++ b/app/controllers/admin/stage_performances_controller.rb
@@ -55,7 +55,7 @@ class Admin::StagePerformancesController < Admin::BaseController
   def sp_params
     params.require(:stage_performance).permit(
       :festival_day_id, :stage_id, :artist_id,
-      :starts_at, :ends_at, :status
+      :starts_at, :ends_at, :status, :canceled
     )
   end
 

--- a/app/views/admin/stage_performances/_form.html.erb
+++ b/app/views/admin/stage_performances/_form.html.erb
@@ -88,6 +88,15 @@
         draft=出演者のみ登録 / scheduled=タイムテーブル確定（時間・ステージ必須）
       </p>
     </div>
+
+    <div class="flex items-center gap-2">
+      <%= f.check_box :canceled,
+            class: "h-4 w-4 rounded border-slate-300 text-rose-600 focus:ring-rose-500" %>
+      <div>
+        <%= f.label :canceled, "出演キャンセル", class: "text-sm font-semibold text-slate-700" %>
+        <p class="text-xs text-slate-500">チェックするとタイムテーブル上で赤字＋取り消し線表示になります。</p>
+      </div>
+    </div>
   </div>
 
   <div class="pt-2">

--- a/app/views/admin/stage_performances/index.html.erb
+++ b/app/views/admin/stage_performances/index.html.erb
@@ -47,6 +47,9 @@
                 <% else %>
                   <span class="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-semibold text-slate-700">draft</span>
                 <% end %>
+                <% if sp.canceled? %>
+                  <span class="ml-2 inline-flex items-center rounded-full bg-rose-50 px-2.5 py-0.5 text-[11px] font-semibold text-rose-700">canceled</span>
+                <% end %>
               </td>
               <td class="px-4 py-3">
                 <div class="flex justify-end gap-2 text-sm font-semibold">

--- a/app/views/admin/stage_performances/show.html.erb
+++ b/app/views/admin/stage_performances/show.html.erb
@@ -104,6 +104,9 @@
               <% else %>
                 <span class="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-semibold text-slate-700">draft</span>
               <% end %>
+              <% if @stage_performance.canceled? %>
+                <span class="ml-2 inline-flex items-center rounded-full bg-rose-50 px-2.5 py-0.5 text-[11px] font-semibold text-rose-700">canceled</span>
+              <% end %>
             </dd>
           </div>
         </dl>

--- a/db/migrate/20251130000000_add_canceled_to_stage_performances.rb
+++ b/db/migrate/20251130000000_add_canceled_to_stage_performances.rb
@@ -1,0 +1,5 @@
+class AddCanceledToStagePerformances < ActiveRecord::Migration[7.1]
+  def change
+    add_column :stage_performances, :canceled, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_11_29_090500) do
+ActiveRecord::Schema[8.0].define(version: 2025_11_30_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "pg_catalog.plpgsql"
@@ -111,6 +111,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_29_090500) do
     t.integer "status", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "canceled", default: false, null: false
     t.index ["artist_id", "starts_at"], name: "index_stage_performances_on_artist_id_and_starts_at"
     t.index ["artist_id"], name: "index_stage_performances_on_artist_id"
     t.index ["festival_day_id", "artist_id"], name: "index_stage_performances_on_festival_day_id_and_artist_id", unique: true


### PR DESCRIPTION
## 概要
- ステージ出演枠にキャンセルフラグを追加し、管理画面で登録・表示、タイムテーブル上で赤字＋取り消し線表示できるようにしました。
## 実施内容
- stage_performances に canceled:boolean を追加するマイグレーションを作成（デフォルト false）。
- 管理画面フォームと strong params に canceled を追加し、一覧/詳細でキャンセルバッジを表示。
- タイムテーブル表示用コンポーネントで canceled? の出演枠は文字を赤字＋取り消し線にする処理を追加。
## 対応Issue
- close #266 
## 関連Issue
なし
## 特記事項