### PR TITLE
[add]フッターの「予習」ボタンにcomming soonのタグ追加

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -22,7 +22,12 @@ focus-visible:outline-offset-2 focus-visible:outline-white" %>
       <span class="whitespace-nowrap">タイムテーブル</span>
     <% end %>
 
-    <%= link_to '#', class: nav_link_classes, data: nav_link_data do %>
+    <%= link_to '#', class: "#{nav_link_classes} relative overflow-hidden", data: nav_link_data do %>
+      <div class="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/30">
+        <span class="rounded-full bg-white/95 px-2 py-[3px] text-[10px] md:text-xs font-black uppercase tracking-[0.16em] text-[#F95858] shadow-sm">
+          Coming Soon
+        </span>
+      </div>
       <%= icon 'practice' %>
       <span class="whitespace-nowrap">予習</span>
     <% end %>


### PR DESCRIPTION
## 概要
- フッターの「予習」ボタンに一般公開前の案内として「Coming Soon」オーバーレイを追加し、公開前であることを明示。
## 実施内容
- app/views/shared/_footer.html.erb：予習リンクにオーバーレイを追加し、中央に「Coming Soon」バッジを配置。
## 対応Issue
なし
## 関連Issue
- #225 
## 特記事項