### PR TITLE
[add]adminの出演枠一覧画面の絞り込み機能を追加

### DIFF
--- a/app/controllers/admin/stage_performances_controller.rb
+++ b/app/controllers/admin/stage_performances_controller.rb
@@ -3,10 +3,14 @@ class Admin::StagePerformancesController < Admin::BaseController
   before_action :prepare_form_options, only: %i[new create edit update]
 
   def index
-    @pagy, @stage_performances =
-      pagy(StagePerformance
-        .includes(:festival_day, :stage, :artist)
-        .order(:starts_at))
+    @festival_days = FestivalDay.includes(:festival).order(:date)
+    @artists = Artist.order(:name)
+
+    scope = StagePerformance.includes(:festival_day, :stage, :artist)
+                            .order(:starts_at)
+                            .for_day(params[:festival_day_id])
+                            .for_artist(params[:artist_id])
+    @pagy, @stage_performances = pagy(scope)
   end
 
   def show; end

--- a/app/models/stage_performance.rb
+++ b/app/models/stage_performance.rb
@@ -14,10 +14,9 @@ class StagePerformance < ApplicationRecord
     validate  :ends_after_starts
   end
 
-  scope :chronological, -> { order(:starts_at) }
-  scope :for_day,       ->(day_id)    { where(festival_day_id: day_id) }
-  scope :for_stage,     ->(stage_id)  { where(stage_id: stage_id) }
-  scope :for_artist,    ->(artist_id) { where(artist_id: artist_id) }
+  scope :for_day,       ->(day_id)    { day_id.present? ? where(festival_day_id: day_id) : all }
+  scope :for_stage,     ->(stage_id)  { stage_id.present? ? where(stage_id: stage_id) : all }
+  scope :for_artist,    ->(artist_id) { artist_id.present? ? where(artist_id: artist_id) : all }
 
   private
 

--- a/app/views/admin/stage_performances/index.html.erb
+++ b/app/views/admin/stage_performances/index.html.erb
@@ -9,6 +9,29 @@
         class: "inline-flex items-center justify-center rounded-lg bg-[#F95858] px-5 py-2 text-sm font-semibold text-white shadow transition hover:bg-[#e04f4f]" %>
   </div>
 
+  <div class="mt-4 rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+    <%= form_with url: admin_stage_performances_path, method: :get, local: true, class: "grid gap-3 md:grid-cols-[1fr_1fr_auto_auto] md:items-end" do |f| %>
+      <div class="flex flex-col gap-1">
+        <label class="text-xs font-semibold text-slate-600">フェス日程</label>
+        <%= f.select :festival_day_id,
+          options_for_select([["すべて", nil]] + @festival_days.map { |d| ["#{d.festival.name} / #{d.date.strftime('%Y/%m/%d')}", d.id] }, params[:festival_day_id]),
+          {}, class: "rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-800 shadow-sm focus:border-[#F95858] focus:ring-[#F95858]" %>
+      </div>
+
+      <div class="flex flex-col gap-1">
+        <label class="text-xs font-semibold text-slate-600">アーティスト</label>
+        <%= f.select :artist_id,
+          options_for_select([["すべて", nil]] + @artists.map { |a| [a.name, a.id] }, params[:artist_id]),
+          {}, class: "rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-800 shadow-sm focus:border-[#F95858] focus:ring-[#F95858]" %>
+      </div>
+
+      <div class="flex gap-2 md:justify-end">
+        <%= f.submit "絞り込む", class: "inline-flex items-center justify-center rounded-lg bg-[#F95858] px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-[#e04f4f]" %>
+        <%= link_to "リセット", admin_stage_performances_path, class: "inline-flex items-center justify-center rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50" %>
+      </div>
+    <% end %>
+  </div>
+
   <% if @stage_performances.any? %>
     <div class="mt-8 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
       <table class="min-w-full divide-y divide-slate-200 text-sm text-slate-800">


### PR DESCRIPTION
## 概要
- 管理画面の出演枠一覧にフェス日程・アーティストでの絞り込みフォームを追加し、関連読み込みと並び順をコントローラで明示するよう整理。
## 実施内容
- app/controllers/admin/stage_performances_controller.rb：indexでincludesとorder(:starts_at)を直接指定し、for_day/for_artistスコープをチェイン。フィルタ用にフェス日程とアーティストの選択肢をロード。
- app/models/stage_performance.rb：for_day/for_stage/for_artistをpresent?ガード付きに統一し、不要なスコープ（with_relations/chronological）を削除。
- app/views/admin/stage_performances/index.html.erb：上部にGETフォームを追加し、フェス日程・アーティストのセレクトと絞り込む/リセットを配置。選択状態はパラメータを反映。
## 対応Issue
- close #292 
## 関連Issue
なし
## 特記事項