### PR TITLE
[add]出演枠の一括登録機能

### DIFF
--- a/app/controllers/admin/stage_performances_controller.rb
+++ b/app/controllers/admin/stage_performances_controller.rb
@@ -1,6 +1,6 @@
 class Admin::StagePerformancesController < Admin::BaseController
   before_action :set_stage_performance, only: %i[show edit update destroy]
-  before_action :prepare_form_options, only: %i[new create edit update]
+  before_action :prepare_form_options, only: %i[new create edit update bulk_new bulk_create]
 
   def index
     @festival_days = FestivalDay.includes(:festival).order(:date)
@@ -50,6 +50,51 @@ class Admin::StagePerformancesController < Admin::BaseController
     redirect_to admin_stage_performances_path, notice: "削除しました。"
   end
 
+  def bulk_new
+    @bulk_entries = Array.new(10) { StagePerformance.new(status: :draft) }
+  end
+
+  def bulk_create
+    permitted = bulk_params
+    entry_attrs = normalize_bulk_entries(permitted[:entries])
+    # アーティスト未選択の行は無視し、有効な行だけをまとめて保存する
+    usable_entries = entry_attrs.select { |attrs| attrs[:artist_id].present? }
+
+    if usable_entries.empty?
+      flash.now[:alert] = "1行以上入力してください。"
+      @bulk_entries = build_bulk_entries(entry_attrs)
+      render :bulk_new, status: :unprocessable_entity and return
+    end
+
+    StagePerformance.transaction do
+      usable_entries.each do |attrs|
+        canceled_value = ActiveModel::Type::Boolean.new.cast(attrs[:canceled])
+        canceled_value = false if canceled_value.nil?
+
+        StagePerformance.create!(
+          festival_day_id: permitted[:festival_day_id],
+          stage_id: permitted[:stage_id],
+          artist_id: attrs[:artist_id],
+          starts_at: attrs[:starts_at],
+          ends_at: attrs[:ends_at],
+          status: attrs[:status].presence || :draft,
+          canceled: canceled_value
+        )
+      end
+    end
+
+    redirect_to admin_stage_performances_path, notice: "#{usable_entries.size}件の出演枠を追加しました。"
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::StatementInvalid => e
+    flash.now[:alert] =
+      if e.is_a?(ActiveRecord::StatementInvalid)
+        friendly_pg_error(e)
+      else
+        e.record.errors.full_messages.first || "保存に失敗しました。"
+      end
+    @bulk_entries = build_bulk_entries(entry_attrs)
+    render :bulk_new, status: :unprocessable_entity
+  end
+
   private
 
   def set_stage_performance
@@ -60,6 +105,14 @@ class Admin::StagePerformancesController < Admin::BaseController
     params.require(:stage_performance).permit(
       :festival_day_id, :stage_id, :artist_id,
       :starts_at, :ends_at, :status, :canceled
+    )
+  end
+
+  def bulk_params
+    params.require(:bulk).permit(
+      :festival_day_id,
+      :stage_id,
+      entries: %i[artist_id starts_at ends_at status canceled]
     )
   end
 
@@ -76,5 +129,30 @@ class Admin::StagePerformancesController < Admin::BaseController
     @stages_by_festival = Stage.order(:sort_order, :id).group_by(&:festival_id)
     @festival_day_festival_map = @festival_days.map { |day| [ day.id, day.festival_id ] }.to_h
     @festival_day_date_map = @festival_days.map { |day| [ day.id, day.date.iso8601 ] }.to_h
+    @stage_options = @stages_by_festival.transform_values { |stages| stages.map { |stage| { id: stage.id, name: stage.name } } }
+    @stage_collection = @stages_by_festival.values.flatten
+  end
+
+  def build_bulk_entries(entries)
+    filled = entries.presence || []
+    entries_as_models = filled.map { |attrs| StagePerformance.new(attrs) }
+    padding = [ 10 - entries_as_models.size, 0 ].max
+    entries_as_models + Array.new(padding) { StagePerformance.new(status: :draft) }
+  end
+
+  # params[:entries] が Array/ActionController::Parameters どちらでもシンボルキーの配列に揃える
+  def normalize_bulk_entries(entries_param)
+    return [] if entries_param.blank?
+
+    raw_entries = case entries_param
+    when Array
+                    entries_param
+    when ActionController::Parameters
+                    entries_param.to_h.values
+    else
+                    []
+    end
+
+    raw_entries.map { |attrs| attrs.to_h.symbolize_keys }
   end
 end

--- a/app/javascript/controllers/bulk_stage_performance_form_controller.js
+++ b/app/javascript/controllers/bulk_stage_performance_form_controller.js
@@ -1,0 +1,100 @@
+import { Controller } from "@hotwired/stimulus"
+
+// フェス日程変更に合わせて開始/終了の日時とステージ選択を揃える
+export default class extends Controller {
+  static targets = ["festivalDaySelect", "timeField", "stageSelect"]
+  static values = {
+    festivalDayDates: Object,
+    festivalDayFestivalMap: Object,
+    stages: Object,
+    defaultTime: { type: String, default: "00:00" },
+    minuteStep: { type: Number, default: 5 }
+  }
+
+  connect() {
+    this.applyMinuteStep()
+    this.syncStageOptions()
+  }
+
+  onFestivalDayChange() {
+    const dayId = this.festivalDaySelectTarget.value
+    const date = this.festivalDayDatesValue[dayId]
+    if (date) {
+      this.timeFieldTargets.forEach((input) => {
+        const timePart = this.extractTime(input.value) || input.dataset.defaultTime || this.defaultTimeValue
+        input.value = `${date}T${timePart}`
+        this.normalizeTimeForInput(input)
+      })
+    }
+    this.syncStageOptions()
+  }
+
+  normalizeTime(event) {
+    this.normalizeTimeForInput(event.target)
+  }
+
+  applyMinuteStep() {
+    const stepSeconds = this.minuteStepValue * 60
+    this.timeFieldTargets.forEach((input) => {
+      input.step = stepSeconds
+      this.normalizeTimeForInput(input)
+    })
+  }
+
+  syncStageOptions() {
+    const dayId = this.festivalDaySelectTarget.value
+    const festivalId = this.festivalDayFestivalMapValue[dayId]
+    const stageOptions = this.stagesValue[festivalId] || []
+    const current = this.stageSelectTarget.value
+
+    const placeholder = document.createElement("option")
+    placeholder.value = ""
+    placeholder.textContent = "(未定)"
+
+    this.stageSelectTarget.innerHTML = ""
+    this.stageSelectTarget.appendChild(placeholder)
+
+    stageOptions.forEach(({ id, name }) => {
+      const opt = document.createElement("option")
+      opt.value = String(id)
+      opt.textContent = name
+      this.stageSelectTarget.appendChild(opt)
+    })
+
+    const exists = stageOptions.some(({ id }) => String(id) === String(current))
+    this.stageSelectTarget.value = exists ? current : ""
+  }
+
+  normalizeTimeForInput(input) {
+    if (!input) return
+    const value = input.value
+    if (!value) return
+
+    const [date, timePart] = value.split("T")
+    if (!timePart) return
+
+    const [time] = timePart.split(".")
+    const segments = time.split(":")
+    if (segments.length < 2) return
+
+    const hour = parseInt(segments[0], 10)
+    const minute = parseInt(segments[1], 10)
+    if (Number.isNaN(hour) || Number.isNaN(minute)) return
+
+    const normalizedMinute = Math.floor(minute / this.minuteStepValue) * this.minuteStepValue
+    if (normalizedMinute === minute) return
+
+    const normalizedTime = `${this.pad(hour)}:${this.pad(normalizedMinute)}`
+    input.value = `${date}T${normalizedTime}`
+  }
+
+  extractTime(value) {
+    if (!value) return null
+    const match = value.match(/T(\d{2}:\d{2})/)
+    return match ? match[1] : null
+  }
+
+  pad(value) {
+    return String(value).padStart(2, "0")
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -33,3 +33,6 @@ application.register("packing-list-form", PackingListFormController)
 
 import AutoSubmitController from "./auto_submit_controller"
 application.register("auto-submit", AutoSubmitController)
+
+import BulkStagePerformanceFormController from "./bulk_stage_performance_form_controller"
+application.register("bulk-stage-performance-form", BulkStagePerformanceFormController)

--- a/app/views/admin/stage_performances/_form.html.erb
+++ b/app/views/admin/stage_performances/_form.html.erb
@@ -1,16 +1,13 @@
-<% stage_performance = local_assigns.fetch(:stage_performance, @stage_performance) %>
-<% stage_placeholder = "(未定)" %>
-<% stage_options = @stages_by_festival.transform_values { |stages| stages.map { |stage| { id: stage.id, name: stage.name } } } %>
-<% stage_collection = @stages_by_festival.values.flatten %>
-
-<%= form_with model: [:admin, stage_performance],
+<%# 部分テンプレートを単体でも使えるよう、渡された stage_performance を優先してフォームを組む %>
+<%= form_with model: [:admin, local_assigns.fetch(:stage_performance, @stage_performance)],
       class: "space-y-6",
       data: {
         controller: "stage-performance-form",
-        "stage-performance-form-stages-value": json_escape(stage_options.to_json),
+        # Stimulus コントローラに渡す関連マスタ（JSON は data 属性で扱えるようにエスケープ）
+        "stage-performance-form-stages-value": json_escape(@stage_options.to_json),
         "stage-performance-form-festival-day-map-value": json_escape(@festival_day_festival_map.to_json),
         "stage-performance-form-festival-day-dates-value": json_escape(@festival_day_date_map.to_json),
-        "stage-performance-form-stage-placeholder-value": stage_placeholder,
+        "stage-performance-form-stage-placeholder-value": "(未定)",
         "stage-performance-form-minute-step-value": 5
       } do |f| %>
   <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm space-y-6">
@@ -42,10 +39,10 @@
     <div>
       <%= f.label :stage_id, "ステージ（確定時）", class: "block text-sm font-semibold text-slate-700" %>
       <%= f.collection_select :stage_id,
-            stage_collection,
+            @stage_collection,
             :id,
             :name,
-            { include_blank: stage_placeholder },
+            { include_blank: "(未定)" },
             class: "mt-2 w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200",
             data: {
               "stage-performance-form-target": "stageSelect"

--- a/app/views/admin/stage_performances/bulk_new.html.erb
+++ b/app/views/admin/stage_performances/bulk_new.html.erb
@@ -1,0 +1,113 @@
+<div class="mx-auto max-w-5xl px-4 py-10 min-h-[calc(100vh-var(--header-offset,4.5rem)-var(--footer-offset,6rem))]">
+  <div class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+    <div>
+      <h1 class="text-2xl font-bold text-slate-900">出演枠を一括追加</h1>
+      <p class="mt-1 text-sm text-slate-600">日程とステージを固定して、複数行まとめて登録できます。</p>
+    </div>
+    <div class="flex flex-wrap gap-2">
+      <%= link_to "一覧に戻る",
+            admin_stage_performances_path,
+            class: "inline-flex items-center justify-center rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50" %>
+      <%= link_to "単体追加へ",
+            new_admin_stage_performance_path,
+            class: "inline-flex items-center justify-center rounded-lg bg-[#F95858] px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-[#e04f4f]" %>
+    </div>
+  </div>
+
+  <div class="mt-8 rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+    <%# Stimulus で日付を揃えつつフェスごとのステージ候補に絞り込むためのマスタを data 属性で渡す %>
+    <%= form_with url: bulk_create_admin_stage_performances_path, method: :post, local: true, class: "space-y-6",
+          data: {
+            controller: "bulk-stage-performance-form",
+            "bulk-stage-performance-form-festival-day-dates-value": json_escape(@festival_day_date_map.to_json),
+            "bulk-stage-performance-form-festival-day-festival-map-value": json_escape(@festival_day_festival_map.to_json),
+            "bulk-stage-performance-form-stages-value": json_escape(@stage_options.to_json),
+            "bulk-stage-performance-form-default-time-value": "00:00",
+            "bulk-stage-performance-form-minute-step-value": 5
+          } do |f| %>
+      <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div>
+          <label class="text-sm font-semibold text-slate-700">フェス日程（全行に適用）</label>
+          <%= select_tag "bulk[festival_day_id]",
+                options_for_select(@festival_days.map { |d| ["#{d.festival.name} / #{d.date.strftime('%Y/%m/%d')}", d.id] }, params.dig(:bulk, :festival_day_id)),
+                prompt: "選択してください",
+                class: "mt-2 w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200",
+                data: { "bulk-stage-performance-form-target": "festivalDaySelect", action: "change->bulk-stage-performance-form#onFestivalDayChange" } %>
+        </div>
+        <div>
+          <label class="text-sm font-semibold text-slate-700">ステージ（全行に適用）</label>
+          <%= select_tag "bulk[stage_id]",
+                options_from_collection_for_select(@stage_collection, :id, :name, params.dig(:bulk, :stage_id)),
+                include_blank: "(未定)",
+                class: "mt-2 w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200",
+                data: { "bulk-stage-performance-form-target": "stageSelect" } %>
+        </div>
+      </div>
+
+      <div class="overflow-hidden rounded-lg border border-slate-200">
+        <table class="min-w-full divide-y divide-slate-200 text-sm text-slate-800">
+          <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-600">
+            <tr>
+              <th class="px-3 py-2">アーティスト</th>
+              <th class="px-3 py-2">開始</th>
+              <th class="px-3 py-2">終了</th>
+              <th class="px-3 py-2">状態</th>
+              <th class="px-3 py-2">キャンセル</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-slate-100">
+            <% @bulk_entries.each_with_index do |entry, idx| %>
+              <tr class="bg-white">
+                <td class="px-3 py-2">
+                  <%= select_tag "bulk[entries][#{idx}][artist_id]",
+                        options_from_collection_for_select(@artists, :id, :name, entry.artist_id),
+                        include_blank: "選択してください",
+                        class: "w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200" %>
+                </td>
+                <td class="px-3 py-2">
+                  <%= text_field_tag "bulk[entries][#{idx}][starts_at]",
+                        entry.starts_at&.strftime("%Y-%m-%dT%H:%M"),
+                        class: "w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200",
+                        type: "datetime-local",
+                        step: 300,
+                        data: {
+                          "bulk-stage-performance-form-target": "timeField",
+                          default_time: "00:00",
+                          action: "input->bulk-stage-performance-form#normalizeTime change->bulk-stage-performance-form#normalizeTime"
+                        } %>
+                </td>
+                <td class="px-3 py-2">
+                  <%= text_field_tag "bulk[entries][#{idx}][ends_at]",
+                        entry.ends_at&.strftime("%Y-%m-%dT%H:%M"),
+                        class: "w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200",
+                        type: "datetime-local",
+                        step: 300,
+                        data: {
+                          "bulk-stage-performance-form-target": "timeField",
+                          default_time: "00:00",
+                          action: "input->bulk-stage-performance-form#normalizeTime change->bulk-stage-performance-form#normalizeTime"
+                        } %>
+                </td>
+                <td class="px-3 py-2">
+                  <%= select_tag "bulk[entries][#{idx}][status]",
+                        options_for_select(StagePerformance.statuses.keys.map { |k| [k, k] }, entry.status.presence || "draft"),
+                        class: "w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200" %>
+                </td>
+                <td class="px-3 py-2 text-center">
+                  <%= check_box_tag "bulk[entries][#{idx}][canceled]", "1", entry.canceled?,
+                        class: "h-4 w-4 rounded border-slate-300 text-rose-600 focus:ring-rose-500" %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="flex items-center justify-between">
+        <p class="text-xs text-slate-500">空行は無視され、アーティストを選んだ行だけ登録されます。</p>
+        <%= f.submit "まとめて登録",
+              class: "inline-flex items-center rounded bg-[#F95858] px-5 py-2 text-sm font-semibold text-white shadow transition hover:bg-[#e04f4f]" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/stage_performances/index.html.erb
+++ b/app/views/admin/stage_performances/index.html.erb
@@ -4,9 +4,14 @@
       <h1 class="text-2xl font-bold text-slate-900">出演枠一覧</h1>
       <p class="mt-2 text-sm text-slate-600">draft = 出演者のみ登録 / scheduled = 確定</p>
     </div>
-    <%= link_to "新規作成",
-        new_admin_stage_performance_path,
-        class: "inline-flex items-center justify-center rounded-lg bg-[#F95858] px-5 py-2 text-sm font-semibold text-white shadow transition hover:bg-[#e04f4f]" %>
+    <div class="flex flex-wrap gap-2">
+      <%= link_to "新規作成",
+          new_admin_stage_performance_path,
+          class: "inline-flex items-center justify-center rounded-lg bg-[#F95858] px-5 py-2 text-sm font-semibold text-white shadow transition hover:bg-[#e04f4f]" %>
+      <%= link_to "一括追加",
+          bulk_new_admin_stage_performances_path,
+          class: "inline-flex items-center justify-center rounded-lg border border-[#F95858] bg-white px-5 py-2 text-sm font-semibold text-[#F95858] shadow-sm transition hover:bg-[#fff1f1]" %>
+    </div>
   </div>
 
   <div class="mt-4 rounded-lg border border-slate-200 bg-white p-4 shadow-sm">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,7 +48,13 @@ Rails.application.routes.draw do
     get "spotify/search", to: "spotify#search"
     resources :users, only: :index
     resources :artists
-    resources :stage_performances
+    resources :stage_performances do
+      # 一括追加用
+      collection do
+        get :bulk_new
+        post :bulk_create
+      end
+    end
     resources :festivals do
       member do
         get  :setup


### PR DESCRIPTION
## 概要
- 管理画面の出演枠に「一括追加」機能を追加し、日程・ステージを固定して複数枠を5分刻みでまとめて登録できるようにした。フォームのロジックを共通化し、エラー時のメッセージや入力保持も改善。
## 実施内容
- config/routes.rb：bulk_new/bulk_create を追加し、一括追加画面へのルートを用意（コメントで一括用途を明示）。
- app/controllers/admin/stage_performances_controller.rb：絞り込みやマスタ生成を共通化。bulk_new/bulk_create を実装し、行データの正規化・キャンセルのデフォルト値・DB制約/バリデーションエラー時のフレンドリーなメッセージ表示と入力復元を実装。
- app/views/admin/stage_performances/index.html.erb：一括追加画面への導線ボタンを追加。
- app/views/admin/stage_performances/bulk_new.html.erb：日程・ステージ固定の一括入力フォームを新規追加。日程に合わせてステージ候補絞り込み/日付揃え/5分刻み正規化が動くようにデータ属性を付与。
- app/views/admin/stage_performances/_form.html.erb：ステージマスタ等をインスタンス変数に統一し、Stimulus用データの意図をコメントで明示。
- app/javascript/controllers/bulk_stage_performance_form_controller.js：一括入力用のStimulusコントローラを追加し、日程選択で日付揃え・ステージ絞り込み・5分刻み丸めを実装。
## 対応Issue
- close #235 
## 関連Issue
なし
## 特記事項