### PR TITLE
[fix]持ち物リストのチェックボックスの不具合解消

### DIFF
--- a/app/controllers/packing_list_items_controller.rb
+++ b/app/controllers/packing_list_items_controller.rb
@@ -33,7 +33,7 @@ class PackingListItemsController < ApplicationController
   private
 
   def set_packing_list
-    @packing_list = current_user.packing_lists.find(params[:packing_list_id])
+    @packing_list = current_user.packing_lists.find_by!(uuid: params[:packing_list_id])
   end
 
   def set_packing_list_item


### PR DESCRIPTION
## 概要
- 持ち物リストのチェックボックスが反映されない不具合を修正し、UUID を使ったリソース取得に揃えた。
## 実施内容
- app/controllers/packing_list_items_controller.rb：set_packing_list を current_user.packing_lists.find_by!(uuid: params[:packing_list_id]) に変更し、URL で渡される UUID で確実に取得するよう修正。 Turbo PATCH が404で失敗していた問題を解消。
## 対応Issue
- close #298 
## 関連Issue
なし
## 特記事項