### PR TITLE
[add]未ログイン時のメッセージ追加

### DIFF
--- a/app/views/artists/index.html.erb
+++ b/app/views/artists/index.html.erb
@@ -4,6 +4,12 @@
       <h1 class="text-2xl font-bold text-slate-900">
         <%= @festival ? "#{@festival.name} の出演アーティスト" : "アーティスト一覧" %>
       </h1>
+      <% unless user_signed_in? %>
+        <%= render "shared/login_callout",
+                   title: "ログインしてお気に入りアーティストを登録しましょう",
+                   description: "気になるアーティストを保存すると、次に探すのが楽になります。",
+                   cta_label: "ログイン" %>
+      <% end %>
 
       <% if @festival.present? && @festival_days.any? %>
         <% preserved_query = request.query_parameters.except(:page, :festival_day_id) %>

--- a/app/views/festivals/index.html.erb
+++ b/app/views/festivals/index.html.erb
@@ -4,6 +4,12 @@
       <h1 class="text-2xl font-bold text-slate-900">
         <%= @artist ? "#{@artist.name} の出演フェス" : "フェスを選択" %>
       </h1>
+      <% unless user_signed_in? %>
+        <%= render "shared/login_callout",
+                   title: "ログインしてお気に入りフェスを登録しましょう",
+                   description: "気になるフェスを保存すると、あとで探す手間が省けます。",
+                   cta_label: "ログイン" %>
+      <% end %>
       <% preserved_query = request.query_parameters.except(:page, :status) %>
       <div class="flex justify-center">
         <%= render Shared::SegmentedTabsComponent.new(

--- a/app/views/packing_lists/index.html.erb
+++ b/app/views/packing_lists/index.html.erb
@@ -4,10 +4,12 @@
       <h1 class="text-2xl font-bold text-slate-900">持ち物リスト</h1>
       <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <p class="text-sm text-slate-600">フェスごとの持ち物をまとめてチェックできます。</p>
-        <%= link_to "＋ マイ持ち物リストを新規作成",
-                    new_packing_list_path,
-                    class: "inline-flex items-center justify-center rounded-2xl bg-rose-500 px-4 py-2 text-sm font-bold text-white shadow-md interactive-lift hover:bg-rose-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500",
-                    data: { controller: "tap-feedback" } %>
+        <% if user_signed_in? %>
+          <%= link_to "＋ マイ持ち物リストを新規作成",
+                      new_packing_list_path,
+                      class: "inline-flex items-center justify-center rounded-2xl bg-rose-500 px-4 py-2 text-sm font-bold text-white shadow-md interactive-lift hover:bg-rose-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500",
+                      data: { controller: "tap-feedback" } %>
+        <% end %>
       </div>
     </header>
 
@@ -34,16 +36,10 @@
           </p>
         <% end %>
       <% else %>
-        <div class="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-5 text-sm text-amber-800 shadow-sm space-y-3 text-center">
-          <p class="font-bold">ログイン必須機能です</p>
-          <p>リストの作成・閲覧にはログインが必要です。</p>
-          <div class="flex justify-center">
-            <%= link_to "ログインへ進む",
-                        new_user_session_path,
-                        class: "inline-flex items-center justify-center rounded-xl bg-rose-500 px-4 py-2 text-sm font-bold text-white shadow-sm interactive-lift hover:bg-rose-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500",
-                        data: { controller: "tap-feedback" } %>
-          </div>
-        </div>
+        <%= render "shared/login_callout",
+                   title: "ログインしてマイ持ち物リストを作成しましょう",
+                   description: "持ち物リストの作成・閲覧にはログインが必要です。",
+                   cta_label: "ログイン" %>
       <% end %>
     </section>
 

--- a/app/views/shared/_login_callout.html.erb
+++ b/app/views/shared/_login_callout.html.erb
@@ -1,0 +1,16 @@
+<%# ログインを促す簡易な呼びかけ。title と description を渡す %>
+<div class="rounded-2xl border border-dashed border-slate-300 bg-white px-4 py-4 shadow-sm sm:px-5 sm:py-5">
+  <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+    <div class="space-y-1">
+      <p class="text-sm font-semibold text-slate-800"><%= local_assigns.fetch(:title, "ログインするともっと便利に使えます") %></p>
+      <% if local_assigns[:description].present? %>
+        <p class="text-xs text-slate-600"><%= local_assigns[:description] %></p>
+      <% end %>
+    </div>
+    <div class="flex flex-shrink-0 items-center justify-center gap-2 sm:justify-end">
+      <%= link_to local_assigns.fetch(:cta_label, "ログイン"),
+                  local_assigns.fetch(:cta_path, new_user_session_path),
+                  class: "inline-flex items-center justify-center rounded-lg bg-[#F95858] px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-[#e04f4f]" %>
+    </div>
+  </div>
+</div>

--- a/app/views/timetables/index.html.erb
+++ b/app/views/timetables/index.html.erb
@@ -2,6 +2,12 @@
   <div class="mx-auto max-w-5xl space-y-6">
     <header class="space-y-4">
       <h1 class="text-2xl font-bold text-slate-900">タイムテーブルを見たいフェスを選択</h1>
+      <% unless user_signed_in? %>
+        <%= render "shared/login_callout",
+                   title: "ログインしてマイタイムテーブルを作成しましょう",
+                   description: "お気に入りのステージや出演枠を選んで、自分専用のタイムテーブルを作成できます。",
+                   cta_label: "ログイン" %>
+      <% end %>
       <div class="flex flex-col gap-3 text-sm text-slate-600 sm:flex-row sm:items-center sm:justify-between">
         <p>公開中のタイムテーブルのみ表示しています。</p>
         <% if user_signed_in? %>

--- a/app/views/timetables/show.html.erb
+++ b/app/views/timetables/show.html.erb
@@ -8,6 +8,14 @@
                ) do %>
       <% day_lookup = @festival_days.index_by(&:id) %>
       <% tab_items = day_lookup.transform_values { |day| day.date.strftime("%-m/%-d") } %>
+      <% unless user_signed_in? %>
+        <div class="mt-2">
+          <%= render "shared/login_callout",
+                     title: "ログインしてマイタイムテーブルを作成しましょう",
+                     description: "気になる出演枠をピックして、自分専用のタイムテーブルを保存できます。",
+                     cta_label: "ログイン" %>
+        </div>
+      <% end %>
       <div class="mt-6 flex justify-center">
         <%= render Shared::SegmentedTabsComponent.new(
               tabs: tab_items,


### PR DESCRIPTION
## 概要
- 未ログインユーザー向けのログイン導線を各一覧・詳細ページに追加し、持ち物リスト一覧も含めて案内を統一。
## 実施内容
- app/views/shared/_login_callout.html.erb：ログイン案内コンポーネントを新規追加し、モバイル時はボタンを中央寄せに、デスクトップでは右寄せに配置。
- app/views/festivals/index.html.erb：h1直下に未ログイン向け「お気に入りフェス登録」案内を追加。
- app/views/artists/index.html.erb：h1直下に未ログイン向け「お気に入りアーティスト登録」案内を追加。
- app/views/timetables/index.html.erb：h1直下に未ログイン向け「マイタイムテーブル作成」案内を追加（ログイン時のみ一覧リンクを表示）。
- app/views/timetables/show.html.erb：ヘッダー内で未ログイン向け「マイタイムテーブル作成」案内を追加し、下部の重複案内を削除。
- app/views/packing_lists/index.html.erb：h1直下にログイン案内を追加し、未ログイン時は新規作成ボタンを非表示。ログイン必須案内をコンポーネントに置き換え。
## 対応Issue
- close #296 
## 関連Issue
なし
## 特記事項