### PR TITLE
[fix]フッターのUIの文言の変更

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -25,7 +25,7 @@ focus-visible:outline-offset-2 focus-visible:outline-white" %>
     <%= link_to '#', class: "#{nav_link_classes} relative overflow-hidden", data: nav_link_data do %>
       <div class="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/30">
         <span class="rounded-full bg-white/95 px-2 py-[3px] text-[10px] md:text-xs font-black uppercase tracking-[0.16em] text-[#F95858] shadow-sm">
-          Coming Soon
+          準備中
         </span>
       </div>
       <%= icon 'practice' %>


### PR DESCRIPTION
## 概要
- スマホUIの見た目を調整するため、フッターの予習ボタンの文言変更。
## 実施内容
- 「coming soon」から「準備中」に変更。
## 対応Issue
なし
## 関連Issue
なし
## 特記事項