### PR TITLE
[add]持ち物リストテーブルにフェス日程のカラム追加

### DIFF
--- a/app/controllers/admin/packing_lists_controller.rb
+++ b/app/controllers/admin/packing_lists_controller.rb
@@ -54,12 +54,13 @@ class Admin::PackingListsController < Admin::BaseController
   def prepare_form_data
     @sorted_items = @packing_list.packing_list_items.includes(:item).sort_by { |pli| [ pli.position || 0, pli.id || 0 ] }
     @next_position_value = (@sorted_items.map { |pli| pli.position || 0 }.max || -1) + 1
+    @festival_days = FestivalDay.joins(:festival).includes(:festival).order("festivals.start_date ASC", "festival_days.date ASC")
   end
 
   def packing_list_params
     raw = params.require(:packing_list)
 
-    safe = raw.permit(:title).to_h
+    safe = raw.permit(:title, :festival_day_id).to_h
     safe[:packing_list_items_attributes] = sanitize_packing_list_items(raw[:packing_list_items_attributes])
     safe
   end

--- a/app/models/packing_list.rb
+++ b/app/models/packing_list.rb
@@ -1,5 +1,6 @@
 class PackingList < ApplicationRecord
   belongs_to :user, optional: true
+  belongs_to :festival_day, optional: true
 
   has_many :packing_list_items, dependent: :destroy, inverse_of: :packing_list
   has_many :items, through: :packing_list_items

--- a/app/views/admin/packing_lists/_form.html.erb
+++ b/app/views/admin/packing_lists/_form.html.erb
@@ -8,6 +8,17 @@
                        required: true %>
     </div>
 
+    <div>
+      <%= f.label :festival_day_id, "フェス日程（任意）", class: "block text-sm font-semibold text-slate-700" %>
+      <%= f.collection_select :festival_day_id,
+                              @festival_days,
+                              :id,
+                              ->(day) { "#{day.festival.name} / #{format_date_with_weekday(day.date)}" },
+                              { include_blank: "未選択" },
+                              class: "mt-2 w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200" %>
+      <p class="mt-1 text-xs text-slate-500">テンプレートに紐づけたい場合のみ選択してください。</p>
+    </div>
+
     <div class="border-t border-slate-100 pt-4"
          data-controller="packing-list-form"
          data-packing-list-form-next-position-value="<%= @next_position_value || 0 %>">

--- a/app/views/packing_lists/_form.html.erb
+++ b/app/views/packing_lists/_form.html.erb
@@ -8,6 +8,16 @@
                          "w-full rounded-xl border px-4 py-3 text-sm text-slate-900 placeholder:text-slate-400 focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-200",
                          (@packing_list.errors[:title].present? ? "border-rose-300 ring-rose-200" : "border-slate-200")
                        ].join(" ") %>
+
+      <div class="space-y-2 pt-2">
+        <%= f.label :festival_day_id, "フェス日程（当日の天気表示用）", class: "block text-sm font-semibold text-slate-700" %>
+        <%= f.collection_select :festival_day_id,
+                                @festival_days,
+                                :id,
+                                ->(day) { "#{day.festival.name} / #{format_date_with_weekday(day.date)}" },
+                                { include_blank: "未選択（天気表示なし）" },
+                                class: "w-full rounded-xl border border-slate-200 px-4 py-2 text-sm text-slate-900 focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-200" %>
+      </div>
     </div>
   </div>
 

--- a/app/views/packing_lists/edit.html.erb
+++ b/app/views/packing_lists/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="min-h-screen px-4 pb-24 pt-6">
   <div class="mx-auto max-w-3xl space-y-6">
     <header class="space-y-2">
-      <h1 class="text-2xl font-bold text-slate-900">持ち物リスト作成・編集</h1>
+      <h1 class="text-2xl font-bold text-slate-900">持ち物リスト編集</h1>
       <p class="text-sm text-slate-600">テンプレートから選ぶか、カスタムの持ち物を追加してください。</p>
     </header>
 

--- a/app/views/packing_lists/show.html.erb
+++ b/app/views/packing_lists/show.html.erb
@@ -3,6 +3,14 @@
     <header class="space-y-2">
       <h1 class="text-2xl font-bold text-slate-900">持ち物リスト詳細</h1>
       <p class="text-lg font-bold text-slate-900"><%= @packing_list.title %></p>
+      <% if @packing_list.festival_day.present? %>
+        <% day = @packing_list.festival_day %>
+        <div class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">
+          <span><%= day.festival.name %></span>
+          <span class="text-slate-500">/</span>
+          <span><%= format_date_with_weekday(day.date) %></span>
+        </div>
+      <% end %>
     </header>
 
     <% owned_list = (@packing_list.user == current_user) %>

--- a/db/migrate/20251130093000_add_festival_day_id_to_packing_lists.rb
+++ b/db/migrate/20251130093000_add_festival_day_id_to_packing_lists.rb
@@ -1,0 +1,5 @@
+class AddFestivalDayIdToPackingLists < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :packing_lists, :festival_day, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_11_30_000000) do
+ActiveRecord::Schema[8.0].define(version: 2025_11_30_093000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "pg_catalog.plpgsql"
@@ -96,6 +96,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_30_000000) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
+    t.bigint "festival_day_id"
+    t.index ["festival_day_id"], name: "index_packing_lists_on_festival_day_id"
     t.index ["template"], name: "index_packing_lists_on_template"
     t.index ["user_id", "title"], name: "index_packing_lists_on_user_and_title_when_owned", unique: true, where: "(user_id IS NOT NULL)"
     t.index ["user_id"], name: "index_packing_lists_on_user_id"
@@ -175,7 +177,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_30_000000) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
+    t.uuid "uuid", null: false
     t.string "provider"
     t.string "uid"
     t.index ["email"], name: "index_users_on_email", unique: true
@@ -188,6 +190,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_30_000000) do
   add_foreign_key "items", "users"
   add_foreign_key "packing_list_items", "items"
   add_foreign_key "packing_list_items", "packing_lists"
+  add_foreign_key "packing_lists", "festival_days"
   add_foreign_key "packing_lists", "users"
   add_foreign_key "stage_performances", "artists"
   add_foreign_key "stage_performances", "festival_days"


### PR DESCRIPTION
## 概要
- 持ち物リストにフェス日程を紐づけるため packing_lists に festival_day_id を追加し、日程選択をユーザー/管理フォームで可能にしました。
## 実施内容
- マイグレーションで packing_lists に festival_day_id（null可・FK付き）を追加。
- PackingList を belongs_to :festival_day, optional: true に変更。
- ユーザー/管理の packing_list_params で festival_day_id を許可し、フォーム用に @festival_days を用意。
- ユーザー/管理フォームにフェス日程のプルダウンを追加（未選択可）。
- 持ち物リスト詳細に選択したフェス日程（フェス名/日付）の表示バッジを追加。
## 対応Issue
なし
## 関連Issue
- #174 
## 特記事項