### PR TITLE
[fix]マイページ周辺のディレクトリ構成の見直し

### DIFF
--- a/app/controllers/mypage/dashboard_controller.rb
+++ b/app/controllers/mypage/dashboard_controller.rb
@@ -1,0 +1,9 @@
+module Mypage
+  class DashboardController < ApplicationController
+    before_action :authenticate_user!
+
+    def show
+      @user = current_user
+    end
+  end
+end

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -1,7 +1,0 @@
-class MypagesController < ApplicationController
-  before_action :authenticate_user!
-
-  def show
-    @user = current_user
-  end
-end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -14,7 +14,7 @@ class Users::PasswordsController < Devise::PasswordsController
     if successfully_sent?(resource)
       respond_to do |format|
         format.html do
-          redirect_path = user_signed_in? ? mypage_path : after_sending_reset_password_instructions_path_for(resource_name)
+          redirect_path = user_signed_in? ? mypage_dashboard_path : after_sending_reset_password_instructions_path_for(resource_name)
           redirect_to redirect_path, notice: "パスワード再設定用メールを送信しました。"
         end
         format.all { head :ok }

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -12,7 +12,7 @@ module NavigationHelper
       artists_back_path
     when "my_timetables"
       my_timetables_back_path
-    when "mypages"
+    when "mypage/dashboard"
       root_path
     when "mypage/favorite_festivals", "mypage/favorite_artists"
       mypage_back_path
@@ -99,6 +99,7 @@ module NavigationHelper
   def my_timetables_back_path
     case action_name
     when "index"
+      return mypage_dashboard_path if params[:from] == "mypage"
       timetables_path
     when "show"
       my_timetables_path
@@ -109,6 +110,6 @@ module NavigationHelper
   end
 
   def mypage_back_path
-    mypage_path
+    mypage_dashboard_path
   end
 end

--- a/app/views/mypage/dashboard/show.html.erb
+++ b/app/views/mypage/dashboard/show.html.erb
@@ -26,7 +26,7 @@
                   url: mypage_favorite_artists_path %>
         <%= render "shared/nav_stack_button",
                   label: "マイタイムテーブル",
-                  url: my_timetables_path %>       
+                  url: my_timetables_path(from: "mypage") %>       
       </div>
     </section>
   </div>

--- a/app/views/shared/_side_menu.html.erb
+++ b/app/views/shared/_side_menu.html.erb
@@ -1,6 +1,6 @@
 <% is_signed_in = defined?(user_signed_in?) && user_signed_in? %>
 <% primary_links = is_signed_in ? [
-  { label: "マイページ", href: mypage_path },
+  { label: "マイページ", href: mypage_dashboard_path },
   { label: "ログアウト", href: destroy_user_session_path, method: :delete }
 ] : [
   { label: "ログイン", href: new_user_session_path }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,8 +20,8 @@ Rails.application.routes.draw do
 
   resources :timetables, only: [ :index, :show ]
   resources :my_timetables, only: [ :index ]
-  resource :mypage, only: [ :show ]
-  namespace :mypage do
+  namespace :mypage, path: "mypage" do
+    get "/", to: "dashboard#show", as: :dashboard
     resources :favorite_festivals, only: [ :index ], path: "festivals"
     resources :favorite_artists, only: [ :index ], path: "artists"
   end


### PR DESCRIPTION
## 概要
- マイページ関連を mypage 名前空間で統一し、ダッシュボード＋お気に入り機能を整理。
- マイページからマイタイムテーブル一覧への戻り先をマイページに統一。
## 実施内容
- マイページトップを Mypage::DashboardController#show に移行し、ルーティングを namespace :mypage, path: "mypage" 配下へ集約。ビューは app/views/mypage/dashboard/show.html.erb に配置。
- お気に入りフェス/アーティストは Mypage::Favorite*Controller をそのまま同 namespace で維持。
- ナビゲーション/リンクを新パスに更新 (mypage_dashboard_path など)。パスワードリセット後のリダイレクト、サイドメニューも対応。
- マイページ→マイタイムテーブル一覧→戻るでマイページに戻るように、リンクに from: "mypage" を付与し、NavigationHelper の戻り先分岐を追加。
## 対応Issue
なし
## 関連Issue
なし
## 特記事項