### PR TITLE
[add]festivalsテーブルに緯度と経度のカラムを追加

### DIFF
--- a/app/controllers/admin/festivals_controller.rb
+++ b/app/controllers/admin/festivals_controller.rb
@@ -63,7 +63,8 @@ class Admin::FestivalsController < Admin::BaseController
     params.require(:festival).permit(
       :name, :slug, :venue_name, :city, :prefecture,
       :start_date, :end_date, :timezone,
-      :official_url, :timetable_published
+      :official_url, :timetable_published,
+      :latitude, :longitude
     )
   end
 
@@ -71,6 +72,7 @@ class Admin::FestivalsController < Admin::BaseController
   def festival_params_nested
     params.require(:festival).permit(
       :name, :venue_name, :city, :prefecture, :timezone, :start_date, :end_date, :official_url, :timetable_published,
+      :latitude, :longitude,
       festival_days_attributes: [ :id, :date, :doors_at, :start_at, :end_at, :note, :_destroy ],
       stages_attributes:        [ :id, :name, :sort_order, :environment, :note, :color_key, :_destroy ]
     )

--- a/app/views/admin/festivals/_form.html.erb
+++ b/app/views/admin/festivals/_form.html.erb
@@ -38,6 +38,23 @@
 
   <div class="grid grid-cols-1 md:grid-cols-2 gap-4 items-start">
     <div>
+      <%= f.label :latitude, "緯度 (latitude)", class: "block font-semibold" %>
+      <%= f.number_field :latitude,
+                         step: :any,
+                         class: "w-full border rounded px-3 py-2",
+                         placeholder: "例）35.689487" %>
+    </div>
+    <div>
+      <%= f.label :longitude, "経度 (longitude)", class: "block font-semibold" %>
+      <%= f.number_field :longitude,
+                         step: :any,
+                         class: "w-full border rounded px-3 py-2",
+                         placeholder: "例）139.691711" %>
+    </div>
+  </div>
+
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-4 items-start">
+    <div>
       <%= f.label :start_date, "開始日", class: "block font-semibold" %>
       <%= f.date_field :start_date, class: "w-full border rounded px-3 py-2" %>
     </div>

--- a/app/views/admin/festivals/show.html.erb
+++ b/app/views/admin/festivals/show.html.erb
@@ -83,6 +83,18 @@
             </dd>
           </div>
           <div class="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-3">
+            <dt class="font-semibold text-slate-500">緯度 / 経度</dt>
+            <dd class="sm:col-span-2">
+              <% if @festival.latitude.present? && @festival.longitude.present? %>
+                <span class="font-mono text-xs text-slate-700">
+                  <%= @festival.latitude %>, <%= @festival.longitude %>
+                </span>
+              <% else %>
+                <span class="text-slate-500">未設定</span>
+              <% end %>
+            </dd>
+          </div>
+          <div class="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-3">
             <dt class="font-semibold text-slate-500">タイムテーブル公開状態</dt>
             <dd class="sm:col-span-2">
               <% if @festival.timetable_published? %>

--- a/db/migrate/20251130100000_add_coordinates_to_festivals.rb
+++ b/db/migrate/20251130100000_add_coordinates_to_festivals.rb
@@ -1,0 +1,7 @@
+class AddCoordinatesToFestivals < ActiveRecord::Migration[8.0]
+  def change
+    add_column :festivals, :latitude, :decimal, precision: 10, scale: 6
+    add_column :festivals, :longitude, :decimal, precision: 10, scale: 6
+    add_index :festivals, [ :latitude, :longitude ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_11_30_093000) do
+ActiveRecord::Schema[8.0].define(version: 2025_11_30_100000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "pg_catalog.plpgsql"
@@ -56,6 +56,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_30_093000) do
     t.datetime "updated_at", null: false
     t.string "official_url"
     t.boolean "timetable_published", default: false, null: false
+    t.decimal "latitude", precision: 10, scale: 6
+    t.decimal "longitude", precision: 10, scale: 6
+    t.index ["latitude", "longitude"], name: "index_festivals_on_latitude_and_longitude"
     t.index ["slug"], name: "index_festivals_on_slug", unique: true
     t.index ["start_date"], name: "index_festivals_on_start_date"
     t.index ["timetable_published"], name: "index_festivals_on_timetable_published"


### PR DESCRIPTION
## 概要
- フェスに緯度・経度を持たせ、管理画面で登録・表示できるようにした。
## 実施内容
- マイグレーション add_coordinates_to_festivals で festivals に latitude/longitude（decimal(10,6)）と複合インデックスを追加。
- 管理画面フェスのストロングパラメータに緯度・経度を許可し、作成/編集フォームに入力欄を追加。詳細画面に緯度・経度表示を追加。
## 対応Issue
なし
## 関連Issue
- #174 
## 特記事項