### PR TITLE
[fix]フェス出演アーティスト一覧の日程UIの修正

### DIFF
--- a/app/views/artists/index.html.erb
+++ b/app/views/artists/index.html.erb
@@ -13,7 +13,7 @@
 
       <% if @festival.present? && @festival_days.any? %>
         <% preserved_query = request.query_parameters.except(:page, :festival_day_id) %>
-        <% tab_items = @festival_days.map { |festival_day| [ festival_day.id, format_date_with_weekday(festival_day.date) ] }.to_h %>
+        <% tab_items = @festival_days.map { |festival_day| [ festival_day.id, festival_day.date.strftime("%-m/%-d") ] }.to_h %>
         <div class="flex justify-center">
           <%= render Shared::SegmentedTabsComponent.new(
                 tabs: tab_items,
@@ -27,7 +27,7 @@
 
       <% if @festival.present? && @selected_festival_day %>
         <p class="text-sm font-semibold text-slate-600">
-          <%= format_date_with_weekday(@selected_festival_day.date) %> の出演アーティスト
+          <%= @selected_festival_day.date.strftime("%-m/%-d") %> の出演アーティスト
         </p>
       <% end %>
     </header>


### PR DESCRIPTION
## 概要
- アーティスト一覧（フェス出演アーティスト一覧ページ）の日付表示を、タイムテーブル詳細と同じシンプルな M/D 形式に統一。
## 実施内容
- タブ表示用の日付ラベルを festival_day.date.strftime("%-m/%-d") に変更（app/views/artists/index.html.erb）。
- 見出し「〜の出演アーティスト」の日付も同じ M/D 形式に変更。
## 対応Issue
なし
## 関連Issue
なし
## 特記事項