### PR TITLE
[add]「準備中」マーカーの追加

### DIFF
--- a/app/views/artists/show.html.erb
+++ b/app/views/artists/show.html.erb
@@ -46,8 +46,11 @@
         <% end %>
 
         <%= link_to "#",
-                    class: "block w-full rounded-2xl bg-indigo-500 py-3 text-center text-sm font-bold text-white shadow-md interactive-lift hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-400",
+                    class: "relative block w-full overflow-hidden rounded-2xl bg-indigo-500 py-3 text-center text-sm font-bold text-white shadow-md interactive-lift hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-400",
                     data: { controller: "tap-feedback" } do %>
+          <div class="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/30">
+            <span class="rounded-full bg-white/95 px-2 py-[3px] text-[10px] font-black uppercase tracking-[0.16em] text-indigo-500 shadow-sm">準備中</span>
+          </div>
           アーティスト予習リストへ
         <% end %>
       </div>

--- a/app/views/festivals/show.html.erb
+++ b/app/views/festivals/show.html.erb
@@ -71,8 +71,11 @@
           <% end %>
         <% end %>
         <%= link_to "#",
-                    class: "block w-full rounded-2xl bg-indigo-500 py-3 text-center text-sm font-bold text-white shadow-md interactive-lift hover:bg-indigo-400",
+                    class: "relative block w-full overflow-hidden rounded-2xl bg-indigo-500 py-3 text-center text-sm font-bold text-white shadow-md interactive-lift hover:bg-indigo-400",
                     data: { controller: "tap-feedback" } do %>
+          <div class="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/30">
+            <span class="rounded-full bg-white/95 px-2 py-[3px] text-[10px] font-black uppercase tracking-[0.16em] text-indigo-500 shadow-sm">準備中</span>
+          </div>
           フェス予習リストへ
         <% end %>
       </div>


### PR DESCRIPTION
## 概要
- フェス詳細/アーティスト詳細の「予習リスト」リンクに準備中バッジを付与し、未提供であることを明示。
## 実施内容
- app/views/festivals/show.html.erb: 「フェス予習リストへ」ボタンに半透明オーバーレイと「準備中」バッジを追加。
- app/views/artists/show.html.erb: 「アーティスト予習リストへ」ボタンに同様のオーバーレイと「準備中」バッジを追加。
## 対応Issue
なし
## 関連Issue
- #225 
## 特記事項