### PR TITLE
[add]songsテーブルの作成とモデルへの追記

### DIFF
--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -8,6 +8,7 @@ class Artist < ApplicationRecord
   has_many :stage_performances, dependent: :destroy
   has_many :festival_days, through: :stage_performances
   has_many :festivals, -> { distinct }, through: :festival_days
+  has_many :songs, dependent: :restrict_with_exception
   has_many :user_artist_favorites, dependent: :destroy
   has_many :favorited_users, through: :user_artist_favorites, source: :user
 

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -1,0 +1,29 @@
+class Song < ApplicationRecord
+  belongs_to :artist
+
+  normalizes :spotify_id, with: ->(v) { v&.strip.presence }
+
+  before_validation :set_normalized_name
+
+  validates :name, presence: true
+  validates :normalized_name, presence: true
+  validates :artist, presence: true
+
+  # SpotifyのトラックIDは Base62 22文字（例: 0OdUWJ0sBjDrqHygGUXeCF）
+  validates :spotify_id,
+            format: { with: /\A[0-9A-Za-z]{22}\z/, message: "is invalid (22-char base62)" },
+            allow_nil: true
+
+  validates :normalized_name, uniqueness: { scope: :artist_id }
+
+  def self.normalize_name(value)
+    value.to_s.mb_chars.normalize(:nfkc).downcase.strip.gsub(/\s+/, " ")
+  end
+
+  private
+
+  def set_normalized_name
+    return if name.blank?
+    self.normalized_name = self.class.normalize_name(name)
+  end
+end

--- a/db/migrate/20251201000000_create_songs.rb
+++ b/db/migrate/20251201000000_create_songs.rb
@@ -1,0 +1,15 @@
+class CreateSongs < ActiveRecord::Migration[8.0]
+  def change
+    create_table :songs do |t|
+      t.string     :name,             null: false
+      t.string     :normalized_name,  null: false
+      t.references :artist,           null: false, foreign_key: true
+      t.string     :spotify_id
+
+      t.timestamps null: false
+    end
+
+    add_index :songs, :spotify_id
+    add_index :songs, %i[artist_id normalized_name], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_11_30_100000) do
+ActiveRecord::Schema[8.0].define(version: 2025_12_01_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "pg_catalog.plpgsql"
@@ -107,6 +107,18 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_30_100000) do
     t.index ["uuid"], name: "index_packing_lists_on_uuid", unique: true
   end
 
+  create_table "songs", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "normalized_name", null: false
+    t.bigint "artist_id", null: false
+    t.string "spotify_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["artist_id", "normalized_name"], name: "index_songs_on_artist_id_and_normalized_name", unique: true
+    t.index ["artist_id"], name: "index_songs_on_artist_id"
+    t.index ["spotify_id"], name: "index_songs_on_spotify_id"
+  end
+
   create_table "stage_performances", force: :cascade do |t|
     t.bigint "festival_day_id", null: false
     t.bigint "stage_id"
@@ -180,7 +192,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_30_100000) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
+    t.uuid "uuid", null: false
     t.string "provider"
     t.string "uid"
     t.index ["email"], name: "index_users_on_email", unique: true
@@ -195,6 +207,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_30_100000) do
   add_foreign_key "packing_list_items", "packing_lists"
   add_foreign_key "packing_lists", "festival_days"
   add_foreign_key "packing_lists", "users"
+  add_foreign_key "songs", "artists"
   add_foreign_key "stage_performances", "artists"
   add_foreign_key "stage_performances", "festival_days"
   add_foreign_key "stage_performances", "stages"


### PR DESCRIPTION
## 概要
- 曲テーブル新設のためのマイグレーション追加と、Songモデルの関連付け/正規化・重複防止ロジックを実装。
- Artistモデルに songs 関連を追加し、削除時に巻き込みを防ぐ制約を設定。
## 実施内容
- db/migrate/20251201000000_create_songs.rb: songs テーブルを追加（name/normalized_name/artist参照/spotify_id/timestamps、spotify_idインデックス、artist_id+normalized_nameユニーク制約）。
- app/models/song.rb: Artistとの関連、Spotify ID正規化、名前正規化（NFKC+小文字化+空白圧縮）、必須/形式/ユニークバリデーション、保存前コールバックを実装。
- app/models/artist.rb: has_many :songs, dependent: :restrict_with_exception を追加し、曲があるアーティストの削除を禁止。
## 対応Issue
- #315 
## 関連Issue
なし
## 特記事項