### PR TITLE
[add]曲検索・追加機能の実装

### DIFF
--- a/app/controllers/admin/songs_controller.rb
+++ b/app/controllers/admin/songs_controller.rb
@@ -1,0 +1,98 @@
+class Admin::SongsController < Admin::BaseController
+  before_action :set_song, only: [ :edit, :update, :destroy ]
+  before_action :set_artists, only: [ :index, :new, :edit, :create, :update, :bulk_new, :bulk_create ]
+
+  def index
+    scope = Song.includes(:artist).order(:name)
+    scope = scope.where(artist_id: params[:artist_id]) if params[:artist_id].present?
+    @pagy, @songs = pagy(scope, limit: 20)
+  end
+
+  def new
+    @song = Song.new
+  end
+
+  def create
+    @song = Song.new(song_params)
+    if @song.save
+      redirect_to admin_songs_path, notice: "曲を登録しました"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit; end
+
+  def update
+    if @song.update(song_params)
+      redirect_to admin_songs_path, notice: "曲を更新しました"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @song.destroy!
+    redirect_to admin_songs_path, notice: "曲を削除しました"
+  end
+
+  def bulk_new
+    @bulk_entries = build_bulk_entries([])
+  end
+
+  def bulk_create
+    permitted = bulk_params
+    entry_attrs = (permitted[:entries] || []).map do |attrs|
+      next if ActiveModel::Type::Boolean.new.cast(attrs[:_destroy])
+      {
+        name: attrs[:name].to_s.strip,
+        spotify_id: attrs[:spotify_id].presence,
+        artist_id: attrs[:artist_id].presence
+      }
+    end.compact
+
+    usable_entries = entry_attrs.select { |attrs| attrs[:name].present? && attrs[:artist_id].present? }
+
+    if usable_entries.empty?
+      flash.now[:alert] = "1行以上入力してください。"
+      @bulk_entries = build_bulk_entries(entry_attrs)
+      render :bulk_new, status: :unprocessable_entity and return
+    end
+
+    Song.transaction do
+      usable_entries.each do |attrs|
+        Song.create!(attrs)
+      end
+    end
+
+    redirect_to admin_songs_path, notice: "#{usable_entries.size}件の曲を追加しました。"
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::StatementInvalid => e
+    flash.now[:alert] = e.record&.errors&.full_messages&.first || "保存に失敗しました。"
+    @bulk_entries = build_bulk_entries(entry_attrs)
+    render :bulk_new, status: :unprocessable_entity
+  end
+
+  private
+
+  def set_song
+    @song = Song.find(params[:id])
+  end
+
+  def set_artists
+    @artists = Artist.order(:name)
+  end
+
+  def song_params
+    params.require(:song).permit(:name, :spotify_id, :artist_id)
+  end
+
+  def bulk_params
+    params.require(:bulk).permit(entries: %i[name spotify_id artist_id _destroy])
+  end
+
+  def build_bulk_entries(entries)
+    filled = entries.presence || []
+    padding = [ 10 - filled.size, 0 ].max
+    filled + Array.new(padding) { { name: nil, spotify_id: nil, artist_id: nil } }
+  end
+end

--- a/app/controllers/admin/spotify_controller.rb
+++ b/app/controllers/admin/spotify_controller.rb
@@ -6,4 +6,12 @@ class Admin::SpotifyController < Admin::BaseController
     Rails.logger.error(e.full_message)
     render json: { artists: [], error: "Spotify検索でエラーが発生しました" }, status: :bad_gateway
   end
+
+  def search_tracks
+    results = Spotify::SearchTracks.call(query: params[:q].to_s, limit: 10, market: "JP") # ← 固定
+    render json: { tracks: results, market: "JP" }
+  rescue => e
+    Rails.logger.error(e.full_message)
+    render json: { tracks: [], error: "Spotify検索でエラーが発生しました" }, status: :bad_gateway
+  end
 end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -36,3 +36,9 @@ application.register("auto-submit", AutoSubmitController)
 
 import BulkStagePerformanceFormController from "./bulk_stage_performance_form_controller"
 application.register("bulk-stage-performance-form", BulkStagePerformanceFormController)
+
+import SpotifySongSearchController from "./spotify_song_search_controller"
+application.register("spotify-song-search", SpotifySongSearchController)
+
+import SpotifySongRowSearchController from "./spotify_song_row_search_controller"
+application.register("spotify-song-row-search", SpotifySongRowSearchController)

--- a/app/javascript/controllers/spotify_song_row_search_controller.js
+++ b/app/javascript/controllers/spotify_song_row_search_controller.js
@@ -1,0 +1,107 @@
+import { Controller } from "@hotwired/stimulus"
+
+// 行単位のシンプルなSpotify曲検索（bulk用）
+export default class extends Controller {
+  static targets = ["name", "spotifyId", "artistSelect", "results"]
+
+  connect() {
+    this.abortController = null
+  }
+
+  disconnect() {
+    if (this.abortController) this.abortController.abort()
+  }
+
+  onSearch(event) {
+    event?.preventDefault()
+    const q = this.nameTarget.value.trim()
+    if (!q) return this.clearResults()
+    this.search(q)
+  }
+
+  async search(q) {
+    try {
+      if (this.abortController) this.abortController.abort()
+      this.abortController = new AbortController()
+
+      this.resultsTarget.innerHTML = `<div class="px-3 py-2 text-sm text-slate-500">検索中...</div>`
+      this.resultsTarget.classList.remove("hidden")
+
+      const url = `/admin/spotify/search_tracks?q=${encodeURIComponent(q)}&market=JP`
+      const res = await fetch(url, {
+        headers: { "Accept": "application/json" },
+        signal: this.abortController.signal
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const data = await res.json()
+      this.renderResults(data.tracks || [])
+    } catch (e) {
+      if (e.name === "AbortError") return
+      this.resultsTarget.innerHTML = `<div class="px-3 py-2 text-sm text-slate-500">取得に失敗しました</div>`
+      this.resultsTarget.classList.remove("hidden")
+    }
+  }
+
+  renderResults(tracks) {
+    if (!tracks.length) return this.clearResults()
+
+    this.resultsTarget.innerHTML = tracks.map((t, idx) => {
+      const artists = (t.artists || []).map((a) => this.escape(a.name)).join(", ")
+      const album = this.escape(t.album_name)
+      const img = t.image_url
+        ? `<img src="${t.image_url}" class="h-10 w-10 object-cover rounded mr-3 shrink-0" alt="">`
+        : `<div class="h-10 w-10 bg-slate-200 rounded mr-3 shrink-0"></div>`
+      return `
+        <button type="button"
+                data-index="${idx}"
+                class="w-full text-left px-3 py-2 hover:bg-slate-50 focus:bg-slate-50 flex items-start gap-3">
+          ${img}
+          <div class="flex-1 min-w-0">
+            <div class="font-semibold truncate">${this.escape(t.name)}</div>
+            <div class="text-xs text-slate-500 truncate">${artists}</div>
+            ${album ? `<div class="text-xs text-slate-400 truncate">${album}</div>` : ""}
+          </div>
+        </button>
+      `
+    }).join("")
+
+    this.resultsTarget.querySelectorAll("button[data-index]").forEach(btn => {
+      btn.addEventListener("click", (ev) => {
+        const index = Number(ev.currentTarget.dataset.index)
+        this.applySelection(tracks[index])
+      }, { once: true })
+    })
+
+    this.resultsTarget.classList.remove("hidden")
+  }
+
+  applySelection(track) {
+    if (!track) return
+    if (track.name) this.nameTarget.value = track.name
+    if (track.id) this.spotifyIdTarget.value = track.id
+
+    const firstArtist = (track.artists || [])[0]
+    if (firstArtist && this.hasArtistSelectTarget) {
+      const option = Array.from(this.artistSelectTarget.options).find(
+        (opt) => opt.dataset.spotifyId && opt.dataset.spotifyId === firstArtist.id
+      )
+      if (option) {
+        this.artistSelectTarget.value = option.value
+        this.artistSelectTarget.dispatchEvent(new Event("change"))
+      }
+    }
+
+    this.clearResults()
+  }
+
+  clearResults() {
+    this.resultsTarget.innerHTML = ""
+    this.resultsTarget.classList.add("hidden")
+  }
+
+  escape(s) {
+    return (s || "").replace(/[&<>"']/g, m => ({
+      "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;"
+    }[m]))
+  }
+}

--- a/app/javascript/controllers/spotify_song_search_controller.js
+++ b/app/javascript/controllers/spotify_song_search_controller.js
@@ -1,0 +1,119 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["query", "results", "name", "spotifyId", "artistSelect"]
+
+  connect() {
+    this.minLen = 1
+    this.abortController = null
+    this.tracks = []
+    this.clearResults()
+    this._onClickOutside = (e) => {
+      if (!this.element.contains(e.target)) this.clearResults()
+    }
+    document.addEventListener("click", this._onClickOutside)
+  }
+
+  disconnect() {
+    if (this.abortController) this.abortController.abort()
+    document.removeEventListener("click", this._onClickOutside)
+  }
+
+  onSearch(event) {
+    event?.preventDefault()
+    const q = this.queryTarget.value.trim()
+    if (q.length < this.minLen) return this.clearResults()
+    this.search(q)
+  }
+
+  async search(q) {
+    try {
+      if (this.abortController) this.abortController.abort()
+      this.abortController = new AbortController()
+
+      this.resultsTarget.innerHTML = `<div class="px-3 py-2 text-sm text-slate-500">検索中...</div>`
+      this.resultsTarget.classList.remove("hidden")
+
+      const url = `/admin/spotify/search_tracks?q=${encodeURIComponent(q)}&market=JP`
+      const res = await fetch(url, {
+        headers: { "Accept": "application/json" },
+        signal: this.abortController.signal
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const data = await res.json()
+      this.tracks = data.tracks || []
+      this.renderResults(this.tracks)
+    } catch (e) {
+      if (e.name === "AbortError") return
+      this.resultsTarget.innerHTML = `<div class="px-3 py-2 text-sm text-slate-500">取得に失敗しました</div>`
+      this.resultsTarget.classList.remove("hidden")
+    }
+  }
+
+  renderResults(tracks) {
+    if (!tracks.length) return this.clearResults()
+
+    this.resultsTarget.setAttribute("role", "listbox")
+    this.resultsTarget.innerHTML = tracks.map((t, idx) => {
+      const img = t.image_url
+        ? `<img src="${t.image_url}" class="h-10 w-10 object-cover rounded mr-3" alt="">`
+        : `<div class="h-10 w-10 bg-slate-200 rounded mr-3"></div>`
+      const artists = (t.artists || []).map((a) => this.escape(a.name)).join(", ")
+      const album = this.escape(t.album_name)
+      return `
+        <button type="button" role="option" aria-selected="false"
+                data-index="${idx}"
+                class="w-full flex items-center px-3 py-2 hover:bg-slate-50 focus:bg-slate-50">
+          ${img}
+          <div class="text-left">
+            <div class="font-semibold">${this.escape(t.name)}</div>
+            <div class="text-xs text-slate-500">${artists}</div>
+            ${album ? `<div class="text-xs text-slate-400">${album}</div>` : ""}
+          </div>
+          <span class="ml-auto text-xs text-slate-400">${t.id || ""}</span>
+        </button>
+      `
+    }).join("")
+    this.resultsTarget.classList.remove("hidden")
+
+    this.resultsTarget.querySelectorAll("button[role=option]").forEach(btn => {
+      btn.addEventListener("click", (ev) => {
+        const index = Number(ev.currentTarget.dataset.index)
+        this.applySelection(tracks[index])
+      }, { once: true })
+    })
+  }
+
+  applySelection(track) {
+    if (!track) return
+    if (this.nameTarget.value.trim() === "" && track.name) {
+      this.nameTarget.value = track.name
+    }
+    if (track.id) this.spotifyIdTarget.value = track.id
+
+    // アーティスト自動選択（最初のアーティストのSpotify IDで一致する option を探す）
+    const firstArtist = (track.artists || [])[0]
+    if (firstArtist && this.hasArtistSelectTarget) {
+      const option = Array.from(this.artistSelectTarget.options).find(
+        (opt) => opt.dataset.spotifyId && opt.dataset.spotifyId === firstArtist.id
+      )
+      if (option) {
+        this.artistSelectTarget.value = option.value
+        this.artistSelectTarget.dispatchEvent(new Event("change"))
+      }
+    }
+
+    this.clearResults()
+  }
+
+  clearResults() {
+    this.resultsTarget.innerHTML = ""
+    this.resultsTarget.classList.add("hidden")
+  }
+
+  escape(s) {
+    return (s || "").replace(/[&<>"']/g, m => ({
+      "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;"
+    }[m]))
+  }
+}

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -17,7 +17,14 @@ class Song < ApplicationRecord
   validates :normalized_name, uniqueness: { scope: :artist_id }
 
   def self.normalize_name(value)
-    value.to_s.mb_chars.normalize(:nfkc).downcase.strip.gsub(/\s+/, " ")
+    base = value.to_s.strip
+    # Unicode正規化が利用可能なら実行（環境によってunicode_normalize拡張が無い場合がある）
+    base = base.unicode_normalize(:nfkc) if base.respond_to?(:unicode_normalize)
+
+    base.mb_chars
+        .downcase
+        .to_s
+        .gsub(/\s+/, " ")
   end
 
   private

--- a/app/services/spotify/search_tracks.rb
+++ b/app/services/spotify/search_tracks.rb
@@ -1,0 +1,7 @@
+module Spotify
+  class SearchTracks
+    def self.call(query:, limit: 10, market: "JP")
+      Spotify::Client.new.search_tracks(query: query, limit: limit, market: market)
+    end
+  end
+end

--- a/app/views/admin/home/top.html.erb
+++ b/app/views/admin/home/top.html.erb
@@ -6,6 +6,7 @@
     <%= render "shared/nav_stack_button", label: "ユーザー管理", url: admin_users_path %>
     <%= render "shared/nav_stack_button", label: "フェス管理", url: admin_festivals_path %>
     <%= render "shared/nav_stack_button", label: "アーティスト管理", url: admin_artists_path %>
+    <%= render "shared/nav_stack_button", label: "曲管理", url: admin_songs_path %>
     <%= render "shared/nav_stack_button", label: "出演枠管理", url: admin_stage_performances_path %>
     <%= render "shared/nav_stack_button", label: "持ち物管理", url: admin_items_path %>
     <%= render "shared/nav_stack_button", label: "持ち物リスト管理", url: admin_packing_lists_path %>

--- a/app/views/admin/songs/_form.html.erb
+++ b/app/views/admin/songs/_form.html.erb
@@ -1,0 +1,59 @@
+<%= form_with model: [:admin, @song], class: "space-y-6", data: { controller: "spotify-song-search" } do |f| %>
+  <% if @song.errors.any? %>
+    <div class="rounded border border-rose-200 bg-rose-50 px-4 py-3 text-rose-700">
+      <div class="font-semibold mb-2"><%= pluralize(@song.errors.count, "error") %> prohibited this song from being saved:</div>
+      <ul class="list-disc pl-5 text-sm">
+        <% @song.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="border rounded-md p-4">
+    <label class="block font-semibold mb-1">Spotifyで曲を検索</label>
+    <div class="flex flex-col gap-2 sm:flex-row">
+      <input type="text"
+             placeholder="曲名で検索"
+             class="w-full border rounded px-3 py-2 bg-white"
+             data-spotify-song-search-target="query"
+             data-action="keydown.enter->spotify-song-search#onSearch" />
+      <button type="button"
+              class="sm:w-auto px-4 py-2 rounded bg-slate-800 text-white shadow-sm interactive-lift hover:bg-slate-900"
+              data-action="click->spotify-song-search#onSearch"
+              data-controller="tap-feedback">
+        Search
+      </button>
+    </div>
+    <p class="text-xs text-slate-500 mt-2">最大10件を表示します。</p>
+
+    <div class="mt-3 border rounded divide-y hidden bg-white"
+         data-spotify-song-search-target="results"></div>
+  </div>
+
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-4 items-start">
+    <div>
+      <%= f.label :name, "曲名", class: "block font-semibold" %>
+      <%= f.text_field :name, class: "w-full border rounded px-3 py-2", data: { "spotify-song-search-target": "name" } %>
+    </div>
+    <div>
+      <%= f.label :spotify_id, "Spotify Track ID（自動入力）", class: "block font-semibold" %>
+      <%= f.text_field :spotify_id, class: "w-full border rounded px-3 py-2 bg-slate-100", readonly: true, data: { "spotify-song-search-target": "spotifyId" } %>
+      <p class="text-xs text-slate-500 mt-1">空でも登録可能です。Spotifyでヒットしない楽曲は空のままにしてください。</p>
+    </div>
+  </div>
+
+  <div>
+    <%= f.label :artist_id, "アーティスト", class: "block font-semibold" %>
+    <%= f.select :artist_id,
+          options_for_select(@artists.map { |a| [a.name, a.id, { data: { spotify_id: a.spotify_artist_id } }] }, @song.artist_id),
+          {},
+          class: "mt-2 w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200",
+          data: { "spotify-song-search-target": "artistSelect" } %>
+    <p class="text-xs text-slate-500 mt-1">Spotify検索結果のアーティストIDが一致する場合は自動で選択されます。</p>
+  </div>
+
+  <div class="pt-4">
+    <%= f.submit "登録する", class: "px-4 py-2 rounded bg-[#F95858] text-white shadow-sm interactive-lift hover:bg-[#e14f4f] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#F95858]", data: { controller: "tap-feedback" } %>
+  </div>
+<% end %>

--- a/app/views/admin/songs/_row.html.erb
+++ b/app/views/admin/songs/_row.html.erb
@@ -1,0 +1,45 @@
+<tr data-nested-form-wrapper data-controller="spotify-song-row-search">
+  <td class="px-3 py-2 align-top">
+    <div class="flex items-center gap-2">
+      <input type="text"
+             name="bulk[entries][][name]"
+             value="<%= attrs[:name] %>"
+             class="w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+             placeholder="曲名"
+             data-spotify-song-row-search-target="name" />
+      <button type="button"
+              class="inline-flex items-center rounded bg-slate-200 px-3 py-1 text-xs font-semibold text-slate-800 shadow hover:bg-slate-300"
+              data-action="spotify-song-row-search#onSearch">
+        検索
+      </button>
+    </div>
+    <div class="mt-2 border rounded bg-white hidden"
+         data-spotify-song-row-search-target="results"></div>
+  </td>
+  <td class="px-3 py-2">
+    <input type="text"
+           name="bulk[entries][][spotify_id]"
+           value="<%= attrs[:spotify_id] %>"
+           class="w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+           placeholder="Spotify ID (任意)"
+           data-spotify-song-row-search-target="spotifyId" />
+  </td>
+  <td class="px-3 py-2">
+    <select name="bulk[entries][][artist_id]"
+            class="w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+            data-spotify-song-row-search-target="artistSelect">
+      <option value="">未選択</option>
+      <% artists.each do |artist| %>
+        <option value="<%= artist.id %>" data-spotify-id="<%= artist.spotify_artist_id %>" <%= "selected" if attrs[:artist_id].to_s == artist.id.to_s %>><%= artist.name %></option>
+      <% end %>
+    </select>
+  </td>
+  <td class="px-3 py-2 text-right align-middle">
+    <input type="hidden" name="bulk[entries][][_destroy]" value="0" />
+    <button type="button"
+            class="text-sm font-semibold text-slate-500 hover:text-rose-600"
+            data-action="nested-form#remove">
+      削除
+    </button>
+  </td>
+</tr>

--- a/app/views/admin/songs/bulk_new.html.erb
+++ b/app/views/admin/songs/bulk_new.html.erb
@@ -1,0 +1,58 @@
+<div class="mx-auto max-w-5xl px-4 py-10" data-controller="nested-form">
+  <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between mb-6">
+    <div>
+      <h1 class="text-2xl font-bold">曲をまとめて追加</h1>
+      <p class="text-slate-600 mt-1 text-sm">曲名とアーティストを行ごとに入力します。空行は無視されます。</p>
+    </div>
+    <div class="flex gap-3">
+      <%= link_to "一覧に戻る", admin_songs_path, class: "text-sm font-semibold text-slate-600 hover:text-slate-800" %>
+      <button type="button"
+              class="inline-flex items-center rounded bg-slate-800 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-slate-900"
+              data-action="nested-form#add">
+        行を追加
+      </button>
+    </div>
+  </div>
+
+  <%= form_with url: bulk_create_admin_songs_path, scope: :bulk, class: "space-y-4" do %>
+    <% if flash.now[:alert].present? %>
+      <div class="rounded border border-rose-200 bg-rose-50 px-4 py-3 text-rose-700">
+        <%= flash.now[:alert] %>
+      </div>
+    <% end %>
+
+    <div class="overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm">
+      <table class="min-w-full divide-y divide-slate-200 text-sm">
+        <thead class="bg-slate-50 text-xs font-semibold uppercase tracking-wide text-slate-600">
+          <tr>
+            <th class="px-3 py-2 text-left w-1/3">曲名</th>
+            <th class="px-3 py-2 text-left w-1/3">Spotify ID（任意）</th>
+            <th class="px-3 py-2 text-left w-1/3">アーティスト</th>
+            <th class="px-3 py-2 text-right w-[80px]"></th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-100" data-nested-form-target="container">
+          <% @bulk_entries.each_with_index do |attrs, idx| %>
+            <%= render "row", artists: @artists, attrs: attrs, index: idx %>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="flex items-center gap-3">
+      <button type="submit"
+              class="inline-flex items-center rounded bg-[#F95858] px-5 py-2 text-sm font-semibold text-white shadow transition hover:bg-[#e04f4f]">
+        まとめて追加する
+      </button>
+      <button type="button"
+              class="text-sm font-semibold text-slate-600 hover:text-slate-800"
+              data-action="nested-form#add">
+        行を追加
+      </button>
+    </div>
+  <% end %>
+
+  <template data-nested-form-target="template">
+    <%= render "row", artists: @artists, attrs: {}, index: "NEW_RECORD" %>
+  </template>
+</div>

--- a/app/views/admin/songs/edit.html.erb
+++ b/app/views/admin/songs/edit.html.erb
@@ -1,0 +1,4 @@
+<div class="mx-auto max-w-3xl px-4 py-10">
+  <h1 class="text-xl font-bold mb-4">曲を編集</h1>
+  <%= render "form" %>
+</div>

--- a/app/views/admin/songs/index.html.erb
+++ b/app/views/admin/songs/index.html.erb
@@ -1,0 +1,58 @@
+<div class="mx-auto max-w-5xl px-4 py-10 min-h-[calc(100vh-var(--header-offset,4.5rem)-var(--footer-offset,6rem))]">
+  <div class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+    <div>
+      <h1 class="text-2xl font-bold">曲管理</h1>
+      <p class="mt-2 text-slate-600">登録済みの曲を確認・編集できます。</p>
+    </div>
+    <div class="flex gap-2">
+      <%= link_to "一括追加", bulk_new_admin_songs_path, class: "inline-flex items-center justify-center rounded-lg bg-slate-200 px-4 py-2 text-sm font-semibold text-slate-800 shadow transition hover:bg-slate-300" %>
+      <%= link_to "新規作成", new_admin_song_path, class: "inline-flex items-center justify-center rounded-lg bg-[#F95858] px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-[#e04f4f]" %>
+    </div>
+  </div>
+
+  <div class="mt-6">
+    <%= form_with url: admin_songs_path, method: :get, class: "flex flex-wrap gap-3 items-end", data: { controller: "auto-submit" } do |f| %>
+      <div>
+        <label class="block text-xs font-semibold text-slate-600">アーティストで絞り込み</label>
+        <%= select_tag :artist_id,
+              options_for_select([["すべて", ""]] + @artists.map { |a| [a.name, a.id] }, params[:artist_id]),
+              class: "mt-1 w-60 rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200",
+              data: { action: "change->auto-submit#submit" } %>
+      </div>
+      <div>
+        <%= f.submit "適用", class: "hidden" %>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="mt-8 overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm">
+    <table class="min-w-full divide-y divide-slate-200 text-sm">
+      <thead class="bg-slate-50">
+        <tr class="text-left text-xs font-semibold uppercase tracking-wider text-slate-600">
+          <th class="px-4 py-3">ID</th>
+          <th class="px-4 py-3">曲名</th>
+          <th class="px-4 py-3">アーティスト</th>
+          <th class="px-4 py-3">Spotify ID</th>
+          <th class="px-4 py-3"></th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-slate-100 text-slate-800">
+        <% @songs.each do |song| %>
+          <tr class="hover:bg-slate-50">
+            <td class="px-4 py-3 font-mono text-xs text-slate-500"><%= song.id %></td>
+            <td class="px-4 py-3 font-semibold"><%= song.name %></td>
+            <td class="px-4 py-3 text-slate-700"><%= song.artist&.name %></td>
+            <td class="px-4 py-3 font-mono text-xs text-slate-600"><%= song.spotify_id.presence || "-" %></td>
+            <td class="px-4 py-3">
+              <div class="flex items-center gap-3 text-sm font-semibold">
+                <%= link_to "編集", edit_admin_song_path(song), class: "text-blue-600 transition hover:text-blue-700" %>
+                <%= link_to "削除", admin_song_path(song), data: { turbo_method: :delete, turbo_confirm: "削除しますか？" }, class: "text-red-600 transition hover:text-red-700" %>
+              </div>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+  <%= render "shared/pagination", pagy: @pagy %>
+</div>

--- a/app/views/admin/songs/new.html.erb
+++ b/app/views/admin/songs/new.html.erb
@@ -1,0 +1,4 @@
+<div class="mx-auto max-w-3xl px-4 py-10">
+  <h1 class="text-xl font-bold mb-4">曲を新規登録</h1>
+  <%= render "form" %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,8 +46,15 @@ Rails.application.routes.draw do
   namespace :admin do
     root "home#top"
     get "spotify/search", to: "spotify#search"
+    get "spotify/search_tracks", to: "spotify#search_tracks"
     resources :users, only: :index
     resources :artists
+    resources :songs do
+      collection do
+        get :bulk_new
+        post :bulk_create
+      end
+    end
     resources :stage_performances do
       # 一括追加用
       collection do

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -192,7 +192,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_01_000000) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "uuid", null: false
+    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.string "provider"
     t.string "uid"
     t.index ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
## 概要
- 管理画面に曲管理機能を追加し、Spotify検索を活用した単体登録と複数行一括登録、一覧のアーティスト絞り込みを実装。
## 実施内容
- ルーティング: config/routes.rb に admin/songs CRUD＋bulk_new/bulk_create、Spotify曲検索エンドポイントを追加。
- モデル: app/models/song.rb で名前正規化・バリデーション・重複防止（artist_id＋normalized_name）、Spotify IDの形式チェックを実装。
- サービス/API: app/services/spotify/search_tracks.rb と Spotify::Client#search_tracks を追加し、Admin::SpotifyController#search_tracks でJSON返却。
- 管理画面UI: admin/songs に一覧/新規/編集/一括追加ビューを追加。一覧に「アーティスト絞り込み」セレクトと「一括追加」導線を追加。
- 一括追加フォーム: bulk_new で複数行入力を生成し、bulk_create で空行・削除行を除外してトランザクション保存。各行でSpotify曲検索ができ、曲名・Spotify ID自動入力とアーティスト自動選択を行うStimulusコントローラ（spotify_song_row_search_controller.js）を追加。
## 対応Issue
- close #315 
## 関連Issue
なし
## 特記事項