### PR TITLE
[add]タイムテーブルのテーブルとバリデーションの追加

### DIFF
--- a/app/models/setlist.rb
+++ b/app/models/setlist.rb
@@ -1,0 +1,8 @@
+class Setlist < ApplicationRecord
+  belongs_to :stage_performance
+
+  has_many :setlist_songs, dependent: :destroy
+  has_many :songs, through: :setlist_songs
+
+  validates :stage_performance, presence: true, uniqueness: true
+end

--- a/app/models/setlist_song.rb
+++ b/app/models/setlist_song.rb
@@ -1,0 +1,13 @@
+class SetlistSong < ApplicationRecord
+  belongs_to :setlist
+  belongs_to :song
+
+  validates :setlist, presence: true
+  validates :song, presence: true
+
+  validates :position,
+            presence: true,
+            numericality: { only_integer: true, greater_than_or_equal_to: 1 }
+
+  validates :position, uniqueness: { scope: :setlist_id }
+end

--- a/app/models/stage_performance.rb
+++ b/app/models/stage_performance.rb
@@ -5,6 +5,7 @@ class StagePerformance < ApplicationRecord
   belongs_to :stage, optional: true
   belongs_to :artist
   has_many :user_timetable_entries, dependent: :destroy
+  has_one :setlist, dependent: :destroy
 
   # scheduledのときだけ必須＆妥当性チェック
   with_options if: :scheduled? do

--- a/db/migrate/20251201001000_create_setlists.rb
+++ b/db/migrate/20251201001000_create_setlists.rb
@@ -1,0 +1,9 @@
+class CreateSetlists < ActiveRecord::Migration[8.0]
+  def change
+    create_table :setlists do |t|
+      t.references :stage_performance, null: false, foreign_key: true, index: { unique: true }
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20251201002000_create_setlist_songs.rb
+++ b/db/migrate/20251201002000_create_setlist_songs.rb
@@ -1,0 +1,14 @@
+class CreateSetlistSongs < ActiveRecord::Migration[8.0]
+  def change
+    create_table :setlist_songs do |t|
+      t.references :setlist, null: false, foreign_key: true
+      t.references :song,    null: false, foreign_key: true
+      t.integer    :position, null: false
+      t.text       :note
+
+      t.timestamps null: false
+    end
+
+    add_index :setlist_songs, [ :setlist_id, :position ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_12_01_000000) do
+ActiveRecord::Schema[8.0].define(version: 2025_12_01_002000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "pg_catalog.plpgsql"
@@ -107,6 +107,25 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_01_000000) do
     t.index ["uuid"], name: "index_packing_lists_on_uuid", unique: true
   end
 
+  create_table "setlist_songs", force: :cascade do |t|
+    t.bigint "setlist_id", null: false
+    t.bigint "song_id", null: false
+    t.integer "position", null: false
+    t.text "note"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["setlist_id", "position"], name: "index_setlist_songs_on_setlist_id_and_position", unique: true
+    t.index ["setlist_id"], name: "index_setlist_songs_on_setlist_id"
+    t.index ["song_id"], name: "index_setlist_songs_on_song_id"
+  end
+
+  create_table "setlists", force: :cascade do |t|
+    t.bigint "stage_performance_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["stage_performance_id"], name: "index_setlists_on_stage_performance_id", unique: true
+  end
+
   create_table "songs", force: :cascade do |t|
     t.string "name", null: false
     t.string "normalized_name", null: false
@@ -192,7 +211,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_01_000000) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
+    t.uuid "uuid", null: false
     t.string "provider"
     t.string "uid"
     t.index ["email"], name: "index_users_on_email", unique: true
@@ -207,6 +226,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_01_000000) do
   add_foreign_key "packing_list_items", "packing_lists"
   add_foreign_key "packing_lists", "festival_days"
   add_foreign_key "packing_lists", "users"
+  add_foreign_key "setlist_songs", "setlists"
+  add_foreign_key "setlist_songs", "songs"
+  add_foreign_key "setlists", "stage_performances"
   add_foreign_key "songs", "artists"
   add_foreign_key "stage_performances", "artists"
   add_foreign_key "stage_performances", "festival_days"


### PR DESCRIPTION
## 概要
- セットリスト機能のために setlists と setlist_songs テーブルを追加し、ステージ出演枠と曲を結び付けるモデル・バリデーションを実装。
## 実施内容
マイグレーション
- db/migrate/20251201001000_create_setlists.rb: setlists（stage_performance_id FK/ユニーク、timestamps）を作成。
- db/migrate/20251201002000_create_setlist_songs.rb: setlist_songs（setlist_id/song_id FK, position必須, note任意, timestamps）を作成し、setlist_id + position をユニークに設定。

モデル
- app/models/setlist.rb: belongs_to :stage_performance（1:1）、has_many :setlist_songs、has_many :songs, through: :setlist_songs、stage_performanceの存在・一意バリデーション。
- app/models/setlist_song.rb: belongs_to :setlist/:song、position の必須・整数・1以上、setlist_id スコープの一意バリデーション。
- app/models/stage_performance.rb: has_one :setlist, dependent: :destroy を追加し、出演枠削除時にセットリストも削除する関連を定義。
## 対応Issue
- #179 
## 関連Issue
なし
## 特記事項