### PR TITLE
[add]セットリスト追加機能の追加

### DIFF
--- a/app/controllers/admin/setlists_controller.rb
+++ b/app/controllers/admin/setlists_controller.rb
@@ -1,0 +1,95 @@
+class Admin::SetlistsController < Admin::BaseController
+  before_action :set_setlist, only: %i[edit update show destroy]
+  before_action :prepare_options, only: %i[new edit create update]
+  before_action :set_artists, only: %i[index]
+
+  def index
+    scope = Setlist.includes(stage_performance: :artist).order(created_at: :desc)
+    scope = scope.joins(:stage_performance).where(stage_performances: { artist_id: params[:artist_id] }) if params[:artist_id].present?
+    @pagy, @setlists = pagy(scope, limit: 20)
+  end
+
+  def show; end
+
+  def new
+    @setlist = Setlist.new
+    build_setlist_songs(@setlist)
+  end
+
+  def create
+    @setlist = Setlist.new(setlist_params)
+    if @setlist.save
+      redirect_to admin_setlists_path, notice: "セットリストを作成しました"
+    else
+      build_missing_setlist_songs
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    build_missing_setlist_songs
+  end
+
+  def update
+    if @setlist.update(setlist_params)
+      redirect_to admin_setlists_path, notice: "セットリストを更新しました"
+    else
+      build_missing_setlist_songs
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @setlist.destroy!
+    redirect_to admin_setlists_path, notice: "セットリストを削除しました"
+  end
+
+  private
+
+  def set_setlist
+    @setlist = Setlist.includes(stage_performance: :artist, setlist_songs: :song).find(params[:id])
+  end
+
+  def setlist_params
+    permitted = params.require(:setlist).permit(
+      :stage_performance_id,
+      setlist_songs_attributes: %i[id song_id position note _destroy]
+    )
+
+    # 曲未選択の行は _destroy=1 にして無視する
+    if permitted[:setlist_songs_attributes].present?
+      permitted[:setlist_songs_attributes].each_value do |attrs|
+        attrs[:_destroy] = "1" if attrs[:song_id].blank?
+      end
+    end
+
+    permitted
+  end
+
+  def prepare_options
+    @artists = Artist.order(:name)
+    @stage_performances_by_artist = StagePerformance.includes(:festival_day, :stage)
+                                                    .order(:starts_at)
+                                                    .group_by(&:artist_id)
+    # 曲のプルダウンは全曲だと大きくなるので、選択したアーティストの曲だけをJSで絞る運用を想定
+    # ここでは全曲を渡す
+    @songs_by_artist = Song.includes(:artist).order(:name).group_by(&:artist_id)
+  end
+
+  def build_setlist_songs(setlist)
+    # nilが紛れ込んでいる場合を排除
+    setlist.setlist_songs.target.compact!
+
+    (1..15).each do |pos|
+      setlist.setlist_songs.build(position: pos) unless setlist.setlist_songs.any? { |s| s.position == pos }
+    end
+  end
+
+  def build_missing_setlist_songs
+    build_setlist_songs(@setlist)
+  end
+
+  def set_artists
+    @artists = Artist.order(:name)
+  end
+end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -42,3 +42,6 @@ application.register("spotify-song-search", SpotifySongSearchController)
 
 import SpotifySongRowSearchController from "./spotify_song_row_search_controller"
 application.register("spotify-song-row-search", SpotifySongRowSearchController)
+
+import SetlistFormController from "./setlist_form_controller"
+application.register("setlist-form", SetlistFormController)

--- a/app/javascript/controllers/setlist_form_controller.js
+++ b/app/javascript/controllers/setlist_form_controller.js
@@ -1,0 +1,75 @@
+import { Controller } from "@hotwired/stimulus"
+
+// セットリストフォーム
+// - アーティスト選択 → そのアーティストの出演枠（stage_performance）を選択
+// - 行ごとの曲プルダウンは、選択済みアーティストの曲で絞り込む
+export default class extends Controller {
+  static targets = ["artist", "stagePerformance", "songSelect"]
+  static values = {
+    performances: Object, // { artist_id: [ {id, festival_day, stage, starts_at}, ... ] }
+    songs: Object         // { artist_id: [ {id, name}, ... ] }
+  }
+
+  connect() {
+    this.onArtistChange()
+  }
+
+  onArtistChange() {
+    const artistId = this.artistTarget.value
+    this.populatePerformances(artistId)
+    this.populateSongs(artistId)
+  }
+
+  populatePerformances(artistId) {
+    const performances = this.performancesValue[artistId] || []
+    this.stagePerformanceTarget.innerHTML = ""
+
+    const placeholder = document.createElement("option")
+    placeholder.value = ""
+    placeholder.textContent = "出演枠を選択"
+    this.stagePerformanceTarget.appendChild(placeholder)
+
+    performances.forEach((p) => {
+      const opt = document.createElement("option")
+      opt.value = p.id
+      opt.textContent = this.formatPerformance(p)
+      this.stagePerformanceTarget.appendChild(opt)
+    })
+
+    // 既存選択を維持
+    const current = this.stagePerformanceTarget.dataset.selected
+    if (current) {
+      this.stagePerformanceTarget.value = current
+    }
+  }
+
+  populateSongs(artistId) {
+    const songs = this.songsValue[artistId] || []
+    this.songSelectTargets.forEach((select) => {
+      const current = select.dataset.selected
+      select.innerHTML = ""
+
+      const blank = document.createElement("option")
+      blank.value = ""
+      blank.textContent = "曲を選択"
+      select.appendChild(blank)
+
+      songs.forEach((s) => {
+        const opt = document.createElement("option")
+        opt.value = s.id
+        opt.textContent = s.name
+        select.appendChild(opt)
+      })
+
+      if (current) select.value = current
+    })
+  }
+
+  formatPerformance(p) {
+    const fest = p.festival_name || ""
+    const date = p.festival_date || ""
+    const stage = p.stage_name || "(未定)"
+    const startsAt = p.starts_at ? p.starts_at : ""
+    return `${fest} / ${date} / ${stage} / ${startsAt}`
+  }
+}

--- a/app/models/setlist.rb
+++ b/app/models/setlist.rb
@@ -5,4 +5,6 @@ class Setlist < ApplicationRecord
   has_many :songs, through: :setlist_songs
 
   validates :stage_performance, presence: true, uniqueness: true
+
+  accepts_nested_attributes_for :setlist_songs, allow_destroy: true
 end

--- a/app/views/admin/home/top.html.erb
+++ b/app/views/admin/home/top.html.erb
@@ -10,6 +10,6 @@
     <%= render "shared/nav_stack_button", label: "出演枠管理", url: admin_stage_performances_path %>
     <%= render "shared/nav_stack_button", label: "持ち物管理", url: admin_items_path %>
     <%= render "shared/nav_stack_button", label: "持ち物リスト管理", url: admin_packing_lists_path %>
-    <%= render "shared/nav_stack_button", label: "セットリスト管理", url: "#" %>
+    <%= render "shared/nav_stack_button", label: "セットリスト管理", url: admin_setlists_path %>
   </nav>
 </div>

--- a/app/views/admin/setlists/_form.html.erb
+++ b/app/views/admin/setlists/_form.html.erb
@@ -1,0 +1,99 @@
+<%= form_with model: [:admin, @setlist],
+              class: "space-y-6",
+              data: {
+                controller: "setlist-form",
+                "setlist-form-performances-value": json_escape(@stage_performances_by_artist.transform_values do |list|
+                  list.map do |sp|
+                    {
+                      id: sp.id,
+                      festival_name: sp.festival_day&.festival&.name,
+                      festival_date: sp.festival_day&.date&.strftime("%Y/%m/%d"),
+                      stage_name: sp.stage&.name,
+                      starts_at: sp.starts_at&.strftime("%H:%M")
+                    }
+                  end
+                end.to_json),
+                "setlist-form-songs-value": json_escape(@songs_by_artist.transform_values do |list|
+                  list.map { |s| { id: s.id, name: s.name } }
+                end.to_json)
+              } do |f| %>
+  <% if @setlist.errors.any? %>
+    <div class="rounded border border-rose-200 bg-rose-50 px-4 py-3 text-rose-700">
+      <div class="font-semibold mb-2"><%= pluralize(@setlist.errors.count, "error") %> prohibited this setlist from being saved:</div>
+      <ul class="list-disc pl-5 text-sm">
+        <% @setlist.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm space-y-6">
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div>
+        <label class="block text-sm font-semibold text-slate-700">アーティスト</label>
+        <select data-setlist-form-target="artist"
+                data-action="change->setlist-form#onArtistChange"
+                class="mt-2 w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200">
+          <option value="">選択してください</option>
+          <% @artists.each do |artist| %>
+            <option value="<%= artist.id %>" <%= "selected" if @setlist.stage_performance&.artist_id == artist.id %>><%= artist.name %></option>
+          <% end %>
+        </select>
+      </div>
+      <div>
+        <label class="block text-sm font-semibold text-slate-700">出演枠</label>
+        <select name="setlist[stage_performance_id]"
+                class="mt-2 w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                data-setlist-form-target="stagePerformance"
+                data-selected="<%= @setlist.stage_performance_id %>">
+          <option value="">出演枠を選択</option>
+          <% if @setlist.stage_performance %>
+            <% sp = @setlist.stage_performance %>
+            <option value="<%= sp.id %>" selected>
+              <%= [sp.festival_day&.date&.strftime("%Y/%m/%d"), sp.stage&.name || "(未定)", sp.starts_at&.strftime("%H:%M")].compact.join(" / ") %>
+            </option>
+          <% end %>
+        </select>
+      </div>
+    </div>
+
+    <div>
+      <h2 class="text-md font-bold text-slate-800">曲リスト（ポジション1〜15）</h2>
+      <p class="text-xs text-slate-500 mt-1">上から順に position として保存されます。空欄は保存時に削除されます。</p>
+      <div class="mt-3 space-y-2">
+        <%= f.fields_for :setlist_songs do |sf| %>
+          <% next if sf.object.nil? %>
+          <% position = sf.object.position || sf.index + 1 %>
+          <div class="grid grid-cols-[60px,1fr] items-center gap-3 rounded border border-slate-200 bg-slate-50 px-3 py-2">
+            <div class="text-center text-sm font-semibold text-slate-600">
+              <%= position %>
+              <%= sf.hidden_field :position, value: position %>
+              <%= sf.hidden_field :_destroy, value: "0" %>
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-[1fr,auto] gap-2">
+              <select name="<%= sf.object_name %>[song_id]"
+                      class="w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                      data-setlist-form-target="songSelect"
+                      data-selected="<%= sf.object.song_id %>">
+                <option value="">曲を選択</option>
+                <% if sf.object.song %>
+                  <option value="<%= sf.object.song_id %>" selected><%= sf.object.song.name %></option>
+                <% end %>
+              </select>
+              <input type="text"
+                     name="<%= sf.object_name %>[note]"
+                     value="<%= sf.object.note %>"
+                     placeholder="メモ（任意）"
+                     class="w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200" />
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
+  <div class="pt-2">
+    <%= f.submit class: "inline-flex items-center rounded bg-[#F95858] px-5 py-2 text-sm font-semibold text-white shadow transition hover:bg-[#e04f4f]" %>
+  </div>
+<% end %>

--- a/app/views/admin/setlists/edit.html.erb
+++ b/app/views/admin/setlists/edit.html.erb
@@ -1,0 +1,4 @@
+<div class="mx-auto max-w-5xl px-4 py-10">
+  <h1 class="text-xl font-bold mb-4">セットリストを編集</h1>
+  <%= render "form" %>
+</div>

--- a/app/views/admin/setlists/index.html.erb
+++ b/app/views/admin/setlists/index.html.erb
@@ -1,0 +1,55 @@
+<div class="mx-auto max-w-5xl px-4 py-10 min-h-[calc(100vh-var(--header-offset,4.5rem)-var(--footer-offset,6rem))]">
+  <div class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+    <div>
+      <h1 class="text-2xl font-bold">セットリスト管理</h1>
+      <p class="mt-2 text-slate-600">出演枠ごとのセットリストを管理します。</p>
+    </div>
+    <%= link_to "新規作成", new_admin_setlist_path, class: "inline-flex items-center justify-center rounded-lg bg-[#F95858] px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-[#e04f4f]" %>
+  </div>
+
+  <div class="mt-6">
+    <%= render "admin/shared/artist_filter",
+          path: admin_setlists_path,
+          artists: @artists,
+          selected: params[:artist_id] %>
+  </div>
+
+  <div class="mt-8 overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm">
+    <table class="min-w-full divide-y divide-slate-200 text-sm">
+      <thead class="bg-slate-50">
+        <tr class="text-left text-xs font-semibold uppercase tracking-wider text-slate-600">
+          <th class="px-4 py-3">ID</th>
+          <th class="px-4 py-3">アーティスト</th>
+          <th class="px-4 py-3">出演枠</th>
+          <th class="px-4 py-3">登録曲数</th>
+          <th class="px-4 py-3"></th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-slate-100 text-slate-800">
+        <% @setlists.each do |setlist| %>
+          <% sp = setlist.stage_performance %>
+          <tr class="hover:bg-slate-50">
+            <td class="px-4 py-3 font-mono text-xs text-slate-500"><%= setlist.id %></td>
+            <td class="px-4 py-3 font-semibold"><%= sp&.artist&.name || "-" %></td>
+            <td class="px-4 py-3 text-slate-700">
+              <% if sp&.festival_day %>
+                <div><%= sp.festival_day.festival.name %></div>
+                <div class="text-xs text-slate-500"><%= sp.festival_day.date %> / <%= sp.stage&.name || "(未定)" %></div>
+              <% else %>
+                <span class="text-slate-400">-</span>
+              <% end %>
+            </td>
+            <td class="px-4 py-3 text-slate-700"><%= setlist.setlist_songs.reject(&:marked_for_destruction?).size %></td>
+            <td class="px-4 py-3">
+              <div class="flex items-center gap-3 text-sm font-semibold">
+                <%= link_to "編集", edit_admin_setlist_path(setlist), class: "text-blue-600 transition hover:text-blue-700" %>
+                <%= link_to "削除", admin_setlist_path(setlist), data: { turbo_method: :delete, turbo_confirm: "削除しますか？" }, class: "text-red-600 transition hover:text-red-700" %>
+              </div>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+  <%= render "shared/pagination", pagy: @pagy %>
+</div>

--- a/app/views/admin/setlists/new.html.erb
+++ b/app/views/admin/setlists/new.html.erb
@@ -1,0 +1,4 @@
+<div class="mx-auto max-w-5xl px-4 py-10">
+  <h1 class="text-xl font-bold mb-4">セットリストを作成</h1>
+  <%= render "form" %>
+</div>

--- a/app/views/admin/shared/_artist_filter.html.erb
+++ b/app/views/admin/shared/_artist_filter.html.erb
@@ -1,0 +1,15 @@
+<% label_text = local_assigns[:label] || "アーティストで絞り込み" %>
+<% select_classes = local_assigns[:select_classes] || "mt-1 w-60 rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200" %>
+
+<%= form_with url: local_assigns.fetch(:path), method: :get, class: "flex flex-wrap gap-3 items-end", data: { controller: "auto-submit" } do |f| %>
+  <div>
+    <label class="block text-xs font-semibold text-slate-600"><%= label_text %></label>
+    <%= select_tag :artist_id,
+          options_for_select([["すべて", ""]] + local_assigns.fetch(:artists).map { |a| [a.name, a.id] }, local_assigns[:selected]),
+          class: select_classes,
+          data: { action: "change->auto-submit#submit" } %>
+  </div>
+  <div>
+    <%= f.submit "適用", class: "hidden" %>
+  </div>
+<% end %>

--- a/app/views/admin/songs/index.html.erb
+++ b/app/views/admin/songs/index.html.erb
@@ -11,18 +11,10 @@
   </div>
 
   <div class="mt-6">
-    <%= form_with url: admin_songs_path, method: :get, class: "flex flex-wrap gap-3 items-end", data: { controller: "auto-submit" } do |f| %>
-      <div>
-        <label class="block text-xs font-semibold text-slate-600">アーティストで絞り込み</label>
-        <%= select_tag :artist_id,
-              options_for_select([["すべて", ""]] + @artists.map { |a| [a.name, a.id] }, params[:artist_id]),
-              class: "mt-1 w-60 rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200",
-              data: { action: "change->auto-submit#submit" } %>
-      </div>
-      <div>
-        <%= f.submit "適用", class: "hidden" %>
-      </div>
-    <% end %>
+    <%= render "admin/shared/artist_filter",
+          path: admin_songs_path,
+          artists: @artists,
+          selected: params[:artist_id] %>
   </div>
 
   <div class="mt-8 overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,7 @@ Rails.application.routes.draw do
         post :bulk_create
       end
     end
+    resources :setlists
     resources :stage_performances do
       # 一括追加用
       collection do


### PR DESCRIPTION
## 概要
- 管理画面にセットリスト管理を追加し、出演枠と曲の紐付けを登録・編集できるようにした。
- 曲/セットリスト一覧でアーティスト絞り込みフォームを共通パーシャル化。
- セットリスト登録フォームでフェス名入りの出演枠選択や曲行プリセットを整備し、空行は自動除外。
## 実施内容
- ルーティング: admin/setlists を追加。
- コントローラ: app/controllers/admin/setlists_controller.rb
  - CRUD実装、position 1〜15をプリセットする build_setlist_songs、空行を _destroy=1 でスキップするパラメータ整形、アーティスト別の出演枠/曲リストをビューに供給。
  - indexでartist_id絞り込み対応、@artists提供。
- モデル: Setlist に accepts_nested_attributes_for :setlist_songs を追加（has_one :setlist はStagePerformance側に既存）。SetlistSongはposition必須・整数・ユニーク。
- ビュー: admin/setlists の index/new/edit/_form を追加。フォームはアーティスト→出演枠選択（フェス名/日付/ステージ/開始時刻表示）、曲行15行（position固定）＋メモ入力。
- JS: setlist_form_controller.js でアーティスト変更時に出演枠と曲プルダウンを該当アーティストに絞り込み、表示を「フェス名/日付/ステージ/開始時刻」に変更。
- 共通パーシャル: app/views/admin/shared/_artist_filter.html.erb を新設し、songs/setlists の一覧でアーティスト絞り込みを共通化。
## 対応Issue
- close #177 
- close #178 
- close #179 
- close #180 
- close #181 
## 関連Issue
なし
## 特記事項