### PR TITLE
[add]アーティスト予習ページの作成

### DIFF
--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -1,4 +1,6 @@
 class ArtistsController < ApplicationController
+  before_action :set_artist, only: %i[show prep]
+
   def index
     @festival = nil
     @festival_days = []
@@ -12,6 +14,41 @@ class ArtistsController < ApplicationController
   end
 
   def show
+  end
+
+  def prep
+    @setlist_scope = Setlist
+                      .joins(stage_performance: :festival_day)
+                      .includes(stage_performance: [ :artist, :stage, { festival_day: :festival } ])
+                      .where(stage_performances: { artist_id: @artist.id })
+                      .order("festival_days.date DESC")
+
+    @setlists_count = @setlist_scope.count
+    @setlists = @setlist_scope
+
+    @ranking_entries =
+      if @setlists_count >= 3
+        ranked_songs = Song
+                       .joins(setlist_songs: :setlist)
+                       .where(artist_id: @artist.id, setlists: { id: @setlist_scope.select(:id) })
+                       .select("songs.*", "COUNT(DISTINCT setlist_songs.setlist_id) AS appearances_count")
+                       .group("songs.id")
+                       .order("appearances_count DESC", "songs.name ASC")
+                       .limit(5)
+
+        ranked_songs.map do |song|
+          count = song.read_attribute(:appearances_count).to_i
+          rate  = ((count.to_f / @setlists_count) * 100).round(1)
+          { song: song, count: count, rate: rate }
+        end
+      else
+        []
+      end
+  end
+
+  private
+
+  def set_artist
     @artist = Artist.find_published!(params[:id])
   end
 end

--- a/app/helpers/artists_helper.rb
+++ b/app/helpers/artists_helper.rb
@@ -1,0 +1,50 @@
+module ArtistsHelper
+  def ranking_badge_class(index)
+    case index
+    when 0
+      "bg-gradient-to-br from-amber-300 via-amber-400 to-amber-200 text-white ring-2 ring-amber-200 shadow-lg"
+    when 1
+      "bg-gradient-to-br from-slate-200 via-slate-300 to-slate-100 text-slate-900 ring-2 ring-slate-200 shadow-lg"
+    when 2
+      "bg-gradient-to-br from-amber-800 via-orange-600 to-amber-500 text-white ring-2 ring-amber-300 shadow-lg"
+    else
+      "bg-indigo-500 text-white"
+    end
+  end
+
+  def setlist_label(setlist)
+    sp           = setlist.stage_performance
+    festival     = sp.festival_day.festival
+    festival_day = sp.festival_day
+    label = "#{festival.name}  #{festival_day.date.to_fs(:db)}"
+    label += " / #{sp.stage.name}" if sp.stage.present?
+    label
+  end
+
+  def spotify_embed_for(song)
+    return nil if song.spotify_id.blank?
+
+    content_tag(
+      :iframe,
+      "",
+      src: "https://open.spotify.com/embed/track/#{song.spotify_id}?utm_source=generator&theme=0",
+      width: "100%",
+      height: "152",
+      allowtransparency: true,
+      allow: "autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture",
+      loading: "lazy"
+    )
+  end
+
+  def ranking_entry_locals(entry, index, artist)
+    song  = entry[:song]
+    embed = spotify_embed_for(song)
+    {
+      entry: entry,
+      index: index,
+      artist: artist,
+      song: song,
+      embed: embed
+    }
+  end
+end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -1,5 +1,7 @@
 class Song < ApplicationRecord
   belongs_to :artist
+  has_many :setlist_songs, dependent: :restrict_with_exception
+  has_many :setlists, through: :setlist_songs
 
   normalizes :spotify_id, with: ->(v) { v&.strip.presence }
 

--- a/app/views/artists/prep.html.erb
+++ b/app/views/artists/prep.html.erb
@@ -1,0 +1,62 @@
+<div class="min-h-screen px-4 py-6">
+  <div class="mx-auto max-w-5xl space-y-8">
+    <header class="space-y-3">
+      <div class="flex items-center gap-2 text-sm text-slate-500">
+        <span><%= @artist.name %></span>
+      </div>
+      <div class="flex flex-wrap items-end gap-3">
+        <h1 class="text-2xl font-bold text-slate-900">アーティスト予習ページ</h1>
+      </div>
+      <p class="text-sm text-slate-600">
+        過去のセットリストから集計した演奏率をもとに、予習すべき曲をチェックしましょう。
+      </p>
+    </header>
+
+    <section class="space-y-4">
+      <div class="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+        <h2 class="text-lg font-semibold text-slate-900">演奏率ランキング&nbsp;TOP5</h2>
+        <p class="text-xs text-slate-500">集計対象: <%= @setlists_count %>件のセットリスト</p>
+      </div>
+
+      <% if @setlists_count < 3 %>
+        <div class="rounded-2xl border border-dashed border-slate-200 bg-white px-4 py-6 text-center text-sm text-slate-600 shadow">
+          セットリストが３件未満のため、演奏率ランキングはありません。
+        </div>
+      <% else %>
+        <% if @ranking_entries.any? %>
+          <div class="grid gap-4 md:grid-cols-2">
+            <% @ranking_entries.each_with_index do |entry, index| %>
+              <%= render partial: "artists/prep/ranking_entry",
+                         locals: ranking_entry_locals(entry, index, @artist) %>
+            <% end %>
+          </div>
+        <% else %>
+          <div class="rounded-2xl border border-dashed border-slate-200 bg-white px-4 py-6 text-center text-sm text-slate-600 shadow">
+            集計対象の曲がまだありません。
+          </div>
+        <% end %>
+      <% end %>
+    </section>
+
+    <section class="space-y-4">
+      <div class="flex items-center justify-between">
+        <h2 class="text-lg font-semibold text-slate-900">過去のセットリスト一覧</h2>
+        <p class="text-xs text-slate-500">最新順</p>
+      </div>
+
+      <% if @setlists.any? %>
+        <div class="grid gap-3">
+          <% @setlists.each do |setlist| %>
+            <%= render "shared/nav_stack_button",
+                       label: setlist_label(setlist),
+                       url: festival_path(setlist.stage_performance.festival_day.festival) %>
+          <% end %>
+        </div>
+      <% else %>
+        <div class="rounded-2xl border border-slate-200 bg-white px-4 py-6 text-center text-sm text-slate-600 shadow">
+          まだセットリストがありません。
+        </div>
+      <% end %>
+    </section>
+  </div>
+</div>

--- a/app/views/artists/prep/_ranking_entry.html.erb
+++ b/app/views/artists/prep/_ranking_entry.html.erb
@@ -1,0 +1,28 @@
+<div class="flex flex-col gap-3 rounded-2xl bg-white p-4 shadow-md shadow-slate-200/70 <%= "md:col-span-2" if index.zero? %>">
+  <div class="flex items-center justify-between gap-3">
+    <div class="flex items-center gap-3">
+      <span class="inline-flex h-10 w-10 items-center justify-center rounded-full text-sm font-bold shadow <%= ranking_badge_class(index) %>"><%= index + 1 %></span>
+      <div>
+        <p class="text-sm font-semibold text-slate-900"><%= song.name %></p>
+        <p class="text-xs text-slate-500"><%= artist.name %></p>
+      </div>
+    </div>
+    <div class="rounded-full bg-indigo-50 px-3 py-1 text-xs font-semibold text-indigo-600">
+      演奏率 <%= entry[:rate] %>%
+    </div>
+  </div>
+
+  <% if embed %>
+    <div class="overflow-hidden rounded-xl border border-slate-200 shadow-sm">
+      <%= embed %>
+    </div>
+  <% else %>
+    <div class="flex h-24 items-center justify-between rounded-xl border border-dashed border-slate-300 bg-slate-50 px-4">
+      <div>
+        <p class="text-sm font-semibold text-slate-900"><%= song.name %></p>
+        <p class="text-xs text-slate-500">Spotify未登録のため埋め込みを表示できません</p>
+      </div>
+      <span class="text-xs font-semibold text-slate-500">No Spotify</span>
+    </div>
+  <% end %>
+</div>

--- a/app/views/artists/show.html.erb
+++ b/app/views/artists/show.html.erb
@@ -45,13 +45,10 @@
           出演フェス一覧
         <% end %>
 
-        <%= link_to "#",
-                    class: "relative block w-full overflow-hidden rounded-2xl bg-indigo-500 py-3 text-center text-sm font-bold text-white shadow-md interactive-lift hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-400",
+        <%= link_to prep_artist_path(@artist),
+                    class: "block w-full rounded-2xl bg-indigo-500 py-3 text-center text-sm font-bold text-white shadow-md interactive-lift hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-400",
                     data: { controller: "tap-feedback" } do %>
-          <div class="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/30">
-            <span class="rounded-full bg-white/95 px-2 py-[3px] text-[10px] font-black uppercase tracking-[0.16em] text-indigo-500 shadow-sm">準備中</span>
-          </div>
-          アーティスト予習リストへ
+          アーティスト予習ページへ
         <% end %>
       </div>
     </article>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   get "/manifest.webmanifest", to: "rails/pwa#manifest", defaults: { format: :json }, as: :pwa_manifest
 
   resources :artists, only: [ :index, :show ] do
+    get :prep, on: :member
     resources :festivals, only: [ :index ], module: :artists
     resource :favorite, only: [ :create, :destroy ], module: :artists
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -211,7 +211,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_01_002000) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "uuid", null: false
+    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.string "provider"
     t.string "uid"
     t.index ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
## 概要
- アーティスト予習ページを実装し、セットリスト集計から演奏率TOP5表示とセットリスト一覧を提供。
## 実施内容
- ルーティングにprep_artist_pathを追加し、ArtistsController#prepでセットリスト集計・ランキングロジックを実装。
- 予習ページビューartists/prep.html.erbを新規作成し、演奏率TOP5（1位はPCで横幅いっぱい、バッジ色を金銀銅/以降インディゴ）とセットリスト一覧を表示。セットリスト3件未満時はメッセージを表示。
- ランキングカードはパーシャル化（_ranking_entry.html.erb）し、演奏率やSpotify埋め込み表示を担当。
- ヘルパーArtistsHelperにランキングバッジ色、セットリストラベル生成、Spotify埋め込み生成、パーシャル用ローカルまとめメソッドを追加。
- アーティスト詳細から予習ページへのリンクを追加。
## 対応Issue
- #176
## 関連Issue
なし
## 特記事項
- セットリスト詳細ページ（ユーザー向け）は別で作成。