### PR TITLE
[add]セットリスト詳細ページの追加

### DIFF
--- a/app/controllers/setlists_controller.rb
+++ b/app/controllers/setlists_controller.rb
@@ -1,0 +1,12 @@
+class SetlistsController < ApplicationController
+  def show
+    @setlist = Setlist
+                .includes(stage_performance: [ :artist, :stage, { festival_day: :festival } ],
+                          setlist_songs: :song)
+                .find(params[:id])
+
+    @stage_performance = @setlist.stage_performance
+    @festival_day      = @stage_performance.festival_day
+    @setlist_songs     = @setlist.setlist_songs.includes(:song).order(:position)
+  end
+end

--- a/app/helpers/artists_helper.rb
+++ b/app/helpers/artists_helper.rb
@@ -21,7 +21,7 @@ module ArtistsHelper
     label
   end
 
-  def spotify_embed_for(song)
+  def spotify_embed_for(song, height: 152, css_class: nil)
     return nil if song.spotify_id.blank?
 
     content_tag(
@@ -29,7 +29,8 @@ module ArtistsHelper
       "",
       src: "https://open.spotify.com/embed/track/#{song.spotify_id}?utm_source=generator&theme=0",
       width: "100%",
-      height: "152",
+      height: height.to_s,
+      class: css_class,
       allowtransparency: true,
       allow: "autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture",
       loading: "lazy"

--- a/app/helpers/setlists_helper.rb
+++ b/app/helpers/setlists_helper.rb
@@ -1,0 +1,34 @@
+module SetlistsHelper
+  def stage_time_label(stage_performance)
+    return "未定" if stage_performance.blank?
+
+    parts = []
+    parts << stage_performance.stage&.name
+
+    starts_at = stage_performance.starts_at
+    ends_at   = stage_performance.ends_at
+
+    if starts_at.present? && ends_at.present?
+      parts << "#{starts_at.strftime('%H:%M')}〜#{ends_at.strftime('%H:%M')}"
+    elsif starts_at.present?
+      parts << "#{starts_at.strftime('%H:%M')}〜"
+    end
+
+    label = parts.compact.reject(&:blank?).join(" / ")
+    label.presence || "未定"
+  end
+
+  def setlist_entries(setlist_songs, artist)
+    setlist_songs.filter_map do |setlist_song|
+      song = setlist_song.song
+      next unless song
+
+      {
+        setlist_song: setlist_song,
+        song: song,
+        embed: spotify_embed_for(song),
+        artist: artist
+      }
+    end
+  end
+end

--- a/app/views/artists/prep.html.erb
+++ b/app/views/artists/prep.html.erb
@@ -49,7 +49,7 @@
           <% @setlists.each do |setlist| %>
             <%= render "shared/nav_stack_button",
                        label: setlist_label(setlist),
-                       url: festival_path(setlist.stage_performance.festival_day.festival) %>
+                       url: setlist_path(setlist) %>
           <% end %>
         </div>
       <% else %>

--- a/app/views/setlists/show.html.erb
+++ b/app/views/setlists/show.html.erb
@@ -1,0 +1,71 @@
+<div class="min-h-screen px-4 pb-24 pt-6">
+  <div class="mx-auto max-w-5xl space-y-8">
+    <header class="space-y-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-lg shadow-slate-200/70">
+      <p class="text-xs font-semibold tracking-wide text-indigo-600"><%= @stage_performance.artist.name %></p>
+      <h1 class="text-2xl font-bold text-slate-900"><%= "#{@festival_day.festival.name} のセットリスト" %></h1>
+
+      <dl class="grid grid-cols-1 gap-4 text-sm text-slate-600 sm:grid-cols-3">
+        <div class="flex flex-col gap-1">
+          <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">フェス</dt>
+          <dd class="font-semibold text-slate-900"><%= @festival_day.festival.name %></dd>
+        </div>
+        <div class="flex flex-col gap-1">
+          <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">日程</dt>
+          <dd class="font-semibold text-slate-900"><%= format_date_with_weekday(@festival_day.date) %></dd>
+        </div>
+        <div class="flex flex-col gap-1">
+          <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">ステージ / 時間</dt>
+          <dd class="font-semibold text-slate-900"><%= stage_time_label(@stage_performance) %></dd>
+        </div>
+      </dl>
+    </header>
+
+    <section class="space-y-4">
+      <div class="flex items-center justify-between">
+        <h2 class="text-lg font-semibold text-slate-900">セットリスト</h2>
+        <p class="text-xs text-slate-500">全<%= @setlist_songs.size %>曲</p>
+      </div>
+
+      <% if @setlist_songs.any? %>
+        <div class="grid gap-4 md:grid-cols-2">
+          <% setlist_entries(@setlist_songs, @stage_performance.artist).each do |entry| %>
+            <% setlist_song = entry[:setlist_song] %>
+            <% song         = entry[:song] %>
+            <% embed        = entry[:embed] %>
+
+            <article class="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow shadow-slate-200/70">
+              <div class="flex items-center justify-between gap-3 border-b border-slate-100 px-4 py-3">
+                <div class="flex items-center gap-3">
+                  <span class="flex h-10 w-10 items-center justify-center rounded-full bg-indigo-50 text-sm font-bold text-indigo-700"><%= setlist_song.position %></span>
+                  <div>
+                    <p class="text-sm font-semibold text-slate-900"><%= song.name %></p>
+                    <p class="text-xs text-slate-500"><%= @stage_performance.artist.name %></p>
+                  </div>
+                </div>
+                <% unless embed %>
+                  <span class="rounded-full bg-slate-100 px-3 py-1 text-[11px] font-semibold text-slate-500">Spotify未登録</span>
+                <% end %>
+              </div>
+
+              <% if embed %>
+                <div class="bg-slate-50 px-2 py-1">
+                  <div class="overflow-hidden rounded-xl border border-slate-200 shadow-sm">
+                    <%= embed %>
+                  </div>
+                </div>
+              <% else %>
+                <div class="px-4 py-2 text-sm text-slate-600">
+                  Spotify IDが登録されていないため埋め込みを表示できません。
+                </div>
+              <% end %>
+            </article>
+          <% end %>
+        </div>
+      <% else %>
+        <div class="rounded-2xl border border-dashed border-slate-200 bg-white px-4 py-6 text-center text-sm text-slate-600 shadow">
+          まだセットリストが登録されていません。
+        </div>
+      <% end %>
+    </section>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
     resource :favorite, only: [ :create, :destroy ], module: :artists
   end
 
+  resources :setlists, only: [ :show ]
   resources :timetables, only: [ :index, :show ]
   resources :my_timetables, only: [ :index ]
   namespace :mypage, path: "mypage" do


### PR DESCRIPTION
## 概要
- ユーザー向けセットリスト詳細ページを追加し、アーティスト予習ページから遷移するように調整。
- フェス名を冠したタイトル表示やステージ/時間ラベル整形などのヘルパーを追加し、ビュー内ロジックを整理。
## 実施内容
- config/routes.rbに一般ユーザー向けsetlists#showルートを追加。
- app/controllers/setlists_controller.rbでセットリスト詳細用showを実装し、出演情報・曲順をincludesした上で取得。
- app/helpers/setlists_helper.rbにステージ/時間表示ヘルパーとセットリスト曲エントリをまとめるヘルパーを追加。
- app/views/setlists/show.html.erbでセットリスト詳細ページを実装。フェス名タイトル、ステージ/時間表示、Spotifyカード付き曲リスト（PC2列/モバイル1列）を配置。埋め込み生成をヘルパー経由に変更。
- app/views/artists/prep.html.erbのセットリストリンクを新しい詳細ページへ差し替え。
## 対応Issue
- close #176 
## 関連Issue
なし
## 特記事項