### PR TITLE
[add]セットリストテーブルにuuidのカラムを追加

### DIFF
--- a/app/controllers/admin/setlists_controller.rb
+++ b/app/controllers/admin/setlists_controller.rb
@@ -47,7 +47,8 @@ class Admin::SetlistsController < Admin::BaseController
   private
 
   def set_setlist
-    @setlist = Setlist.includes(stage_performance: :artist, setlist_songs: :song).find(params[:id])
+    @setlist = Setlist.includes(stage_performance: :artist, setlist_songs: :song)
+                      .find_by!(uuid: params[:id])
   end
 
   def setlist_params

--- a/app/controllers/setlists_controller.rb
+++ b/app/controllers/setlists_controller.rb
@@ -3,7 +3,7 @@ class SetlistsController < ApplicationController
     @setlist = Setlist
                 .includes(stage_performance: [ :artist, :stage, { festival_day: :festival } ],
                           setlist_songs: :song)
-                .find(params[:id])
+                .find_by!(uuid: params[:id])
 
     @stage_performance = @setlist.stage_performance
     @festival_day      = @stage_performance.festival_day

--- a/app/models/setlist.rb
+++ b/app/models/setlist.rb
@@ -7,4 +7,8 @@ class Setlist < ApplicationRecord
   validates :stage_performance, presence: true, uniqueness: true
 
   accepts_nested_attributes_for :setlist_songs, allow_destroy: true
+
+  def to_param
+    uuid.presence || super
+  end
 end

--- a/db/migrate/20251201004000_add_uuid_to_setlists.rb
+++ b/db/migrate/20251201004000_add_uuid_to_setlists.rb
@@ -1,0 +1,6 @@
+class AddUuidToSetlists < ActiveRecord::Migration[7.1]
+  def change
+    add_column :setlists, :uuid, :uuid, null: false, default: -> { "gen_random_uuid()" }
+    add_index  :setlists, :uuid, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_12_01_002000) do
+ActiveRecord::Schema[8.0].define(version: 2025_12_01_004000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "pg_catalog.plpgsql"
@@ -123,7 +123,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_01_002000) do
     t.bigint "stage_performance_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.index ["stage_performance_id"], name: "index_setlists_on_stage_performance_id", unique: true
+    t.index ["uuid"], name: "index_setlists_on_uuid", unique: true
   end
 
   create_table "songs", force: :cascade do |t|
@@ -211,7 +213,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_01_002000) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
+    t.uuid "uuid", null: false
     t.string "provider"
     t.string "uid"
     t.index ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
## 概要
- セットリストをUUIDで参照するよう変更し、URLからDBのidを隠蔽。ユーザー向け・管理画面双方でUUID経由の取得に統一しました。
## 実施内容
- db/migrate/20251201004000_add_uuid_to_setlists.rb: setlistsにuuid列（gen_random_uuid()、NOT NULL、ユニークインデックス）を追加。
- app/models/setlist.rb: to_paramでuuidを返すよう変更し、URLをUUID化。
- app/controllers/setlists_controller.rb: showをuuidでfind_by!するよう変更。
- app/controllers/admin/setlists_controller.rb: 管理画面のset_setlistもuuid検索に切り替え。
## 対応Issue
- #176 
## 関連Issue
なし
## 特記事項