### PR TITLE
[add]セットリスト曲のメモをセットリスト詳細に表示

### DIFF
--- a/app/views/setlists/show.html.erb
+++ b/app/views/setlists/show.html.erb
@@ -58,6 +58,13 @@
                   Spotify IDが登録されていないため埋め込みを表示できません。
                 </div>
               <% end %>
+
+              <% if setlist_song.note.present? %>
+                <div class="flex gap-2 border-t border-slate-100 bg-slate-50 px-4 py-3 text-sm text-slate-700">
+                  <span class="mt-[2px] rounded-full bg-indigo-100 px-2 py-0.5 text-[11px] font-semibold text-indigo-700">MEMO</span>
+                  <p class="leading-relaxed"><%= setlist_song.note %></p>
+                </div>
+              <% end %>
             </article>
           <% end %>
         </div>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -213,7 +213,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_01_004000) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "uuid", null: false
+    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.string "provider"
     t.string "uid"
     t.index ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
## 概要
- セットリスト詳細画面で、各曲にメモがある場合はカード内に表示されるように改善。
## 実施内容
- app/views/setlists/show.html.erb にメモ表示ブロックを追加し、埋め込み/未登録メッセージの下で setlist_songs.note をラベル付きで表示するように変更。
## 対応Issue
- close #325 
## 関連Issue
なし
## 特記事項