### PR TITLE
[update]他アーティスト曲のセットリスト入力時の表示改善

### DIFF
--- a/app/javascript/controllers/setlist_form_controller.js
+++ b/app/javascript/controllers/setlist_form_controller.js
@@ -71,10 +71,10 @@ export default class extends Controller {
     select.appendChild(blank)
 
     let hasCurrent = false
-    songs.forEach((s) => {
+    ;[...songs].sort((a, b) => a.name.localeCompare(b.name, "ja")).forEach((s) => {
       const opt = document.createElement("option")
       opt.value = s.id
-      opt.textContent = s.name
+      opt.textContent = showAll && s.artist_name ? `${s.name} / ${s.artist_name}` : s.name
       if (current && String(current) === String(s.id)) hasCurrent = true
       select.appendChild(opt)
     })

--- a/app/views/admin/setlists/_form.html.erb
+++ b/app/views/admin/setlists/_form.html.erb
@@ -14,10 +14,12 @@
                   end
                 end.to_json),
                 "setlist-form-songs-value": json_escape(@songs_by_artist.transform_values do |list|
-                  list.map { |s| { id: s.id, name: s.name } }
+                  list.map { |s| { id: s.id, name: s.name, artist_name: s.artist.name } }
                 end.to_json),
                 "setlist-form-all-songs-value": json_escape(
-                  @songs_by_artist.values.flatten.uniq { |s| s.id }.map { |s| { id: s.id, name: s.name } }.to_json
+                  @songs_by_artist.values.flatten.uniq { |s| s.id }
+                                 .sort_by { |s| s.name.downcase }
+                                 .map { |s| { id: s.id, name: s.name, artist_name: s.artist.name } }.to_json
                 )
               } do |f| %>
   <% if @setlist.errors.any? %>


### PR DESCRIPTION
## 概要
- 管理画面セットリストフォームの「他アーティストも表示」オン時の曲プルダウンを、曲名の五十音順に並べ、表示ラベルを「曲名 / アーティスト名」に変更。
## 実施内容
- app/views/admin/setlists/_form.html.erb で Stimulus に渡す楽曲データを { id, name, artist_name } 形式に拡張し、全曲リストを曲名順で並べて渡すよう調整。
- app/javascript/controllers/setlist_form_controller.js の populateSongSelect で候補配列を日本語ロケールでソートし、「他アーティストも表示」時の <option> 表示を 曲名 / アーティスト名 に変更。
## 対応Issue
なし
## 関連Issue
なし
## 特記事項