### PR TITLE
[add]予習TOPページの作成

### DIFF
--- a/app/controllers/prep_controller.rb
+++ b/app/controllers/prep_controller.rb
@@ -1,0 +1,3 @@
+class PrepController < ApplicationController
+  def top; end
+end

--- a/app/views/prep/top.html.erb
+++ b/app/views/prep/top.html.erb
@@ -1,0 +1,15 @@
+<div class="min-h-screen px-4 py-6">
+  <div class="mx-auto max-w-5xl space-y-6">
+    <header class="space-y-3">
+      <h1 class="text-2xl font-bold text-slate-900">予習</h1>
+      <p class="text-sm text-slate-600">
+        フェス全体で聴き込むか、気になるアーティストから絞って予習するかを選んでください。
+      </p>
+    </header>
+
+    <section class="space-y-3">
+      <%= render "shared/nav_stack_button", label: "フェスから予習する", url: "#" %>
+      <%= render "shared/nav_stack_button", label: "アーティストから予習する", url: "#" %>
+    </section>
+  </div>
+</div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -22,12 +22,7 @@ focus-visible:outline-offset-2 focus-visible:outline-white" %>
       <span class="whitespace-nowrap">タイムテーブル</span>
     <% end %>
 
-    <%= link_to '#', class: "#{nav_link_classes} relative overflow-hidden", data: nav_link_data do %>
-      <div class="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/30">
-        <span class="rounded-full bg-white/95 px-2 py-[3px] text-[10px] md:text-xs font-black uppercase tracking-[0.16em] text-[#F95858] shadow-sm">
-          準備中
-        </span>
-      </div>
+    <%= link_to prep_top_path, class: nav_link_classes, data: nav_link_data do %>
       <%= icon 'practice' %>
       <span class="whitespace-nowrap">予習</span>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   root "home#top"
   get "/terms", to: "home#terms", as: :terms
   get "/privacy", to: "home#privacy", as: :privacy
+  get "/prep", to: "prep#top", as: :prep_top
 
   get "up" => "rails/health#show", as: :rails_health_check
   get "/service-worker.js", to: "rails/pwa#service_worker", defaults: { format: :js }, as: :pwa_service_worker


### PR DESCRIPTION
## 概要
- 予習TOPページを新設し、ユーザーが予習開始の起点を選べる導線を用意。
- フッターの予習タブをプレースホルダから実ページへリンク。
## 実施内容
- ルート追加: get "/prep", to: "prep#top", as: :prep_top（config/routes.rb）。
- コントローラ新設: PrepController#top を追加（app/controllers/prep_controller.rb）。
- 予習TOPビュー作成: nav stackボタンで「フェスから予習する」「アーティストから予習する」を配置（リンクは #）（app/views/prep/top.html.erb）。
- フッター更新: 予習タブを prep_top_path へリンクし、準備中オーバーレイを削除（app/views/shared/_footer.html.erb）。
## 対応Issue
- close #175 
## 関連Issue
なし
## 特記事項