### PR TITLE
[add]アーティスト予習一覧ページの追加

### DIFF
--- a/app/controllers/prep/artists_controller.rb
+++ b/app/controllers/prep/artists_controller.rb
@@ -1,0 +1,11 @@
+module Prep
+  class ArtistsController < ApplicationController
+    def index
+      artists_scope = Artist.published.order(:name)
+      @q     = artists_scope.ransack(params[:q])
+      result = @q.result(distinct: true)
+
+      @pagy, @artists = pagy(result, params: request.query_parameters)
+    end
+  end
+end

--- a/app/views/prep/artists/_card.html.erb
+++ b/app/views/prep/artists/_card.html.erb
@@ -1,0 +1,48 @@
+<div class="relative h-full">
+  <%= link_to prep_artist_path(artist),
+              class: "flex h-full w-full flex-col items-center rounded-3xl border border-slate-200 bg-white p-4 pb-12 shadow-sm interactive-lift focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-400",
+              data: { controller: "tap-feedback" } do %>
+    <div class="aspect-square w-full overflow-hidden rounded-2xl border border-slate-200 bg-slate-50">
+      <% if artist.image_url.present? %>
+        <%= image_tag artist.image_url,
+                      alt: artist.name,
+                      class: "h-full w-full object-cover",
+                      loading: "lazy" %>
+      <% else %>
+        <%= image_tag "artist_image.png",
+                      alt: "",
+                      class: "h-full w-full object-cover",
+                      loading: "lazy" %>
+      <% end %>
+    </div>
+    <p class="mt-3 w-full text-center text-sm font-semibold text-slate-800">
+      <%= artist.name %>
+    </p>
+  <% end %>
+
+  <% if user_signed_in? %>
+    <div class="absolute left-3 bottom-3 z-10 flex h-9 w-9 items-center justify-center">
+      <%= favorite_button_for(
+            favorited: artist_favorited?(artist),
+            toggle_url: artist_favorite_path(artist)
+          ) %>
+    </div>
+  <% end %>
+
+  <% if artist.spotify_artist_id.present? %>
+    <div class="absolute bottom-3 right-3 z-10 flex h-9 w-9 items-center justify-center">
+      <%= link_to "https://open.spotify.com/artist/#{artist.spotify_artist_id}",
+                  target: "_blank",
+                  rel: "noopener",
+                  class: "inline-flex h-9 w-9 items-center justify-center rounded-full transition hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-400" do %>
+        <span class="sr-only"><%= "#{artist.name} をSpotifyで開く" %></span>
+        <%= image_tag "spotify_icon.png",
+                      alt: "",
+                      class: "h-6 w-6",
+                      width: 24,
+                      height: 24,
+                      loading: "lazy" %>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/prep/artists/index.html.erb
+++ b/app/views/prep/artists/index.html.erb
@@ -1,0 +1,31 @@
+<div class="min-h-screen px-4 pb-24 pt-6">
+  <div class="mx-auto max-w-6xl space-y-6">
+    <header class="space-y-4">
+      <h1 class="text-2xl font-bold text-slate-900">アーティスト予習一覧</h1>
+      <p class="text-sm text-slate-600">
+        予習したいアーティストを選んで、効率よく聴き込みましょう。
+      </p>
+    </header>
+
+    <%= render Shared::SearchFormComponent.new(
+               query: @q,
+               url: prep_artists_path,
+               placeholder: "アーティスト名を入力"
+             ) %>
+
+    <section>
+      <% if @artists.any? %>
+        <div class="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
+          <% @artists.each do |artist| %>
+            <%= render "prep/artists/card", artist: artist %>
+          <% end %>
+        </div>
+      <% else %>
+        <p class="rounded-3xl border border-dashed border-slate-300 bg-white px-6 py-16 text-center text-sm text-slate-500">
+          表示できるアーティストがありません
+        </p>
+      <% end %>
+    </section>
+  </div>
+  <%= render "shared/pagination", pagy: @pagy %>
+</div>

--- a/app/views/prep/top.html.erb
+++ b/app/views/prep/top.html.erb
@@ -8,8 +8,11 @@
     </header>
 
     <section class="space-y-3">
-      <%= render "shared/nav_stack_button", label: "フェスから予習する", url: "#" %>
-      <%= render "shared/nav_stack_button", label: "アーティストから予習する", url: "#" %>
+      <%= render "shared/nav_stack_button",
+                 label: "フェスから予習する",
+                 url: "#",
+                 trailing: content_tag(:span, "準備中", class: "rounded-full bg-slate-100 px-3 py-1 text-[11px] font-semibold text-slate-600") %>
+      <%= render "shared/nav_stack_button", label: "アーティストから予習する", url: prep_artists_path %>
     </section>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,9 @@ Rails.application.routes.draw do
   get "/terms", to: "home#terms", as: :terms
   get "/privacy", to: "home#privacy", as: :privacy
   get "/prep", to: "prep#top", as: :prep_top
+  namespace :prep, path: "prep" do
+    resources :artists, only: [ :index ]
+  end
 
   get "up" => "rails/health#show", as: :rails_health_check
   get "/service-worker.js", to: "rails/pwa#service_worker", defaults: { format: :js }, as: :pwa_service_worker


### PR DESCRIPTION
## 概要
- 予習トップから遷移する「アーティスト予習一覧」を新設し、公開アーティストの検索と予習詳細への導線を用意。
## 実施内容
- ルーティング追加: /prep/artists に一覧を割り当て（config/routes.rb）。
- コントローラ追加: 予習用のアーティスト一覧 Prep::ArtistsController#index を作成し、公開アーティストを検索・ページング（app/controllers/prep/artists_controller.rb）。
- ビュー追加: アーティスト予習一覧ページをアーティスト一覧と同様のカードグリッドで構成、検索フォームとページネーション付き（app/views/prep/artists/index.html.erb）。
- カード部品: 予習詳細（artists#prep）へのリンクを持つカードを用意し、画像・お気に入り・Spotifyリンク表示に対応（app/views/prep/artists/_card.html.erb）。
- 予習トップ更新: 「アーティストから予習する」のリンク先を新一覧に変更（app/views/prep/top.html.erb）。
## 対応Issue
なし
## 関連Issue
なし
## 特記事項