### PR TITLE
[remove]stageテーブルの「屋内/屋外」のカラム削除

### DIFF
--- a/app/controllers/admin/festivals_controller.rb
+++ b/app/controllers/admin/festivals_controller.rb
@@ -74,7 +74,7 @@ class Admin::FestivalsController < Admin::BaseController
       :name, :venue_name, :city, :prefecture, :timezone, :start_date, :end_date, :official_url, :timetable_published,
       :latitude, :longitude,
       festival_days_attributes: [ :id, :date, :doors_at, :start_at, :end_at, :note, :_destroy ],
-      stages_attributes:        [ :id, :name, :sort_order, :environment, :note, :color_key, :_destroy ]
+      stages_attributes:        [ :id, :name, :sort_order, :note, :color_key, :_destroy ]
     )
   end
 end

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -3,11 +3,6 @@ class Stage < ApplicationRecord
   has_many :stage_performances, dependent: :destroy
   validates :name, presence: true
 
-  # 任意: 屋内/屋外など（UIは後で）
-  enum :environment, { unspecified: 0, outdoor: 1, indoor: 2 },
-  prefix: true,
-  default: 0
-
   COLOR_PALETTE = {
     "red"      => "#F95858",
     "emerald"  => "#10B981",

--- a/app/views/admin/festivals/_stage_fields.html.erb
+++ b/app/views/admin/festivals/_stage_fields.html.erb
@@ -3,11 +3,6 @@
 
   <%= f.text_field :name, placeholder: "メインステージ", class: "border rounded px-2 py-1" %>
 
-  <%= f.select :environment,
-               Stage.environments.keys.map { |k| [k, k] },
-               {},
-               class: "border rounded px-2 py-1" %>
-
   <div class="flex items-center gap-2">
     <%# color_key をセレクトで選ぶ %>
     <%= f.select :color_key,

--- a/app/views/admin/festivals/show.html.erb
+++ b/app/views/admin/festivals/show.html.erb
@@ -167,7 +167,6 @@
           <% stages.each do |stage| %>
             <% hex = stage.color_hex %>
             <% text_color = stage_text_color(hex) %>
-            <% environment_label = stage.environment.present? ? I18n.t("enums.stage.environment.#{stage.environment}", default: stage.environment.humanize) : "-" %>
             <div class="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
               <div class="flex items-center justify-between gap-2">
                 <h3 class="text-base font-semibold text-slate-800"><%= stage.name %></h3>
@@ -179,10 +178,6 @@
                 <div class="flex justify-between gap-3">
                   <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">表示順</dt>
                   <dd class="font-mono text-xs text-slate-600"><%= stage.sort_order %></dd>
-                </div>
-                <div class="flex justify-between gap-3">
-                  <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">環境</dt>
-                  <dd><%= environment_label %></dd>
                 </div>
                 <div>
                   <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">メモ</dt>

--- a/db/migrate/20241121000000_remove_environment_from_stages.rb
+++ b/db/migrate/20241121000000_remove_environment_from_stages.rb
@@ -1,0 +1,5 @@
+class RemoveEnvironmentFromStages < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :stages, :environment, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -164,7 +164,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_01_004000) do
     t.bigint "festival_id", null: false
     t.string "name", null: false
     t.integer "sort_order", default: 0, null: false
-    t.integer "environment"
     t.string "note"
     t.string "color_key"
     t.datetime "created_at", null: false
@@ -213,7 +212,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_01_004000) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
+    t.uuid "uuid", null: false
     t.string "provider"
     t.string "uid"
     t.index ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
## 概要
- ステージの環境カラム・関連UIを廃止し、管理画面から環境指定をなくしました。
## 実施内容
- マイグレーションで stages.environment を削除（db/migrate/20241121000000_remove_environment_from_stages.rb）。
- Stage モデルから enum :environment を削除（app/models/stage.rb）。
- 管理画面から環境入力/表示を削除: ステージフォームのセレクト除去（app/views/admin/festivals/_stage_fields.html.erb）、ステージ詳細の環境行除去（app/views/admin/festivals/show.html.erb）。
- strong params から environment を削除（app/controllers/admin/festivals_controller.rb）。
## 対応Issue
- close #314 
## 関連Issue
なし
## 特記事項
- ステージごとに「屋外/屋内」は不要と判断したため。