### PR TITLE
[update]フェス一覧の各フェス表示にサブテキストを追加

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,4 +16,20 @@ module ApplicationHelper
     weekday_names = %w[日 月 火 水 木 金 土]
     "#{date.strftime('%Y/%m/%d')}(#{weekday_names[date.wday]})"
   end
+
+  def festival_date_and_location(festival)
+    return if festival.blank?
+
+    start_label = festival.start_date&.strftime("%Y/%m/%d")
+    end_label   = festival.end_date&.strftime("%Y/%m/%d")
+
+    date_range =
+      if start_label.present? && end_label.present?
+        start_label == end_label ? start_label : "#{start_label}〜#{end_label}"
+      else
+        start_label || end_label
+      end
+
+    [ date_range, festival.prefecture.presence ].compact_blank.join(" / ")
+  end
 end

--- a/app/views/festivals/index.html.erb
+++ b/app/views/festivals/index.html.erb
@@ -43,6 +43,7 @@
                end %>
             <%= render "shared/nav_stack_button",
                        label: festival.name,
+                       subtext: festival_date_and_location(festival),
                        url: festival_url,
                        trailing: favorite_button_for(
                          favorited: festival_favorited?(festival),

--- a/app/views/mypage/favorite_festivals/index.html.erb
+++ b/app/views/mypage/favorite_festivals/index.html.erb
@@ -12,6 +12,7 @@
           <div class="w-full">
             <%= render "shared/nav_stack_button",
                        label: festival.name,
+                       subtext: festival_date_and_location(festival),
                        url: festival_path(festival, from: "mypage_favorites"),
                        trailing: favorite_button_for(
                          favorited: festival_favorited?(festival),

--- a/app/views/shared/_nav_stack_button.html.erb
+++ b/app/views/shared/_nav_stack_button.html.erb
@@ -1,6 +1,11 @@
 <%= link_to url, class: "nav-stack-button interactive-lift", data: { controller: "tap-feedback" } do %>
-  <span class="flex w-full items-center justify-between gap-3">
-    <span><%= label %></span>
+  <span class="flex w-full items-start justify-between gap-3">
+    <span class="min-w-0 space-y-1 leading-tight">
+      <span class="block truncate text-base font-semibold text-slate-900"><%= label %></span>
+      <% if local_assigns[:subtext].present? %>
+        <span class="block text-xs font-medium text-slate-500"><%= subtext %></span>
+      <% end %>
+    </span>
     <% if local_assigns[:trailing].present? %>
       <span class="shrink-0"><%= trailing %></span>
     <% end %>

--- a/app/views/timetables/index.html.erb
+++ b/app/views/timetables/index.html.erb
@@ -40,6 +40,7 @@
           <div class="w-full">
             <%= render "shared/nav_stack_button",
                        label: festival.name,
+                       subtext: festival_date_and_location(festival),
                        url: timetable_path(festival, from: "timetables") %>
           </div>
         <% end %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -75,7 +75,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_12_002000) do
     t.boolean "timetable_published", default: false, null: false
     t.decimal "latitude", precision: 10, scale: 6
     t.decimal "longitude", precision: 10, scale: 6
-    t.integer "environment", default: 0, null: false
     t.index ["latitude", "longitude"], name: "index_festivals_on_latitude_and_longitude"
     t.index ["slug"], name: "index_festivals_on_slug", unique: true
     t.index ["start_date"], name: "index_festivals_on_start_date"
@@ -230,7 +229,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_12_002000) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "uuid", null: false
+    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.string "provider"
     t.string "uid"
     t.index ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
## 概要
- フェス一覧ボタンにフェス名の下で日程＋都道府県を表示できるようにし、視認性を向上。
## 実施内容
- application_helper.rb: フェスの日程範囲と都道府県を「YYYY/MM/DD〜YYYY/MM/DD / ○○県」形式にまとめるfestival_date_and_locationを追加。
- shared/_nav_stack_button.html.erb: サブテキスト表示用にレイアウトを拡張し、小さく薄い文字で下段に表示。
- festivals/index.html.erb, timetables/index.html.erb, mypage/favorite_festivals/index.html.erb: フェス名リストで新しいサブテキストを表示するように変更。
## 対応Issue
なし
## 関連Issue
- #313 
## 特記事項
フェス名だけではわかりにくく感じたため、改善した。