### PR TITLE
[add]アーティスト予習ページのXでシェア機能

### DIFF
--- a/app/helpers/x_share_helper.rb
+++ b/app/helpers/x_share_helper.rb
@@ -1,0 +1,17 @@
+module XShareHelper
+  def x_intent_url(text:, url:)
+    "https://twitter.com/intent/tweet?text=#{ERB::Util.url_encode(text + "\n")}&url=#{ERB::Util.url_encode(url)}"
+  end
+
+  def artist_prep_share_url(artist)
+    hashtag_artist = artist.name.to_s.gsub(/\s+/, "")
+    text = "FES READYで#{artist.name}の楽曲を予習中！\n#FESREADY ##{hashtag_artist}"
+    x_intent_url(text: text, url: prep_artist_url(artist))
+  end
+
+  def my_timetable_share_url(festival:, day:, owner_uuid:)
+    text = "FES READYで #{festival.name} のマイタイムテーブルを作成しました！\n#FESREADY"
+    url  = festival_my_timetable_url(festival, date: day.to_s, user_id: owner_uuid)
+    x_intent_url(text: text, url: url)
+  end
+end

--- a/app/views/artists/prep.html.erb
+++ b/app/views/artists/prep.html.erb
@@ -7,9 +7,19 @@
       <div class="flex flex-wrap items-end gap-3">
         <h1 class="text-2xl font-bold text-slate-900">アーティスト予習ページ</h1>
       </div>
-      <p class="text-sm text-slate-600">
-        過去のセットリストから集計した演奏率をもとに、予習すべき曲をチェックしましょう。
-      </p>
+      <% share_href = artist_prep_share_url(@artist) %>
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p class="text-sm text-slate-600">
+          過去のセットリストから集計した演奏率をもとに、予習すべき曲をチェックしましょう。
+        </p>
+        <%= link_to share_href,
+                    class: "inline-flex items-center justify-center gap-2 rounded-2xl bg-black px-5 py-2.5 text-sm font-bold text-white shadow-md interactive-lift hover:bg-neutral-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black",
+                    target: "_blank",
+                    rel: "noopener" do %>
+          <%= image_tag "x-logo.png", alt: "X", class: "h-4 w-4" %>
+          <span>でシェアする</span>
+        <% end %>
+      </div>
     </header>
 
     <section class="space-y-4">

--- a/app/views/my_timetables/show.html.erb
+++ b/app/views/my_timetables/show.html.erb
@@ -63,11 +63,9 @@
              ) %>
 
       <% if @timetable_owner == current_user %>
-        <% share_text = "FES READYで #{@festival.name} のマイタイムテーブルを作成しました！\n#FESREADY" %>
-        <% share_link = festival_my_timetable_url(@festival,
-                                                  date: @selected_day.date.to_s,
-                                                  user_id: current_user.uuid) %>
-        <% share_href = "https://twitter.com/intent/tweet?text=#{ERB::Util.url_encode(share_text + "\n")}&url=#{ERB::Util.url_encode(share_link)}" %>
+        <% share_href = my_timetable_share_url(festival: @festival,
+                                               day: @selected_day.date,
+                                               owner_uuid: current_user.uuid) %>
         <div class="mt-6 flex justify-center">
           <%= link_to share_href,
                       class: "inline-flex items-center justify-center gap-2 rounded-2xl bg-black px-5 py-2.5 text-sm font-bold text-white shadow-md interactive-lift hover:bg-neutral-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black",


### PR DESCRIPTION
## 概要
- Xシェア用のURL生成をヘルパーに共通化し、アーティスト予習ページとマイタイムテーブル詳細のビューを呼び出しだけに整理。アーティスト予習にはマイタイムテーブルと同じ見た目のXシェアボタンを追加。
## 実施内容
- app/helpers/x_share_helper.rb: intent URL生成メソッドを追加。予習ページ用（スペース除去したハッシュタグ付き）とマイタイムテーブル用のシェアURLを共通化。
- app/views/artists/prep.html.erb: 説明文の横/下にXシェアボタンを配置し、ヘルパー呼び出しでシェアURLをセット。
- app/views/my_timetables/show.html.erb: 既存のシェアURL生成ロジックをヘルパー呼び出しに置き換え、ビューを簡潔化。
## 対応Issue
- close #328 
## 関連Issue
なし
## 特記事項
フェス予習ページ追加時にも「Xでシェアボタン」を追加予定。