### PR TITLE
[update]セットリスト登録曲数を20曲に拡張

### DIFF
--- a/app/controllers/admin/setlists_controller.rb
+++ b/app/controllers/admin/setlists_controller.rb
@@ -81,7 +81,7 @@ class Admin::SetlistsController < Admin::BaseController
     # nilが紛れ込んでいる場合を排除
     setlist.setlist_songs.target.compact!
 
-    (1..15).each do |pos|
+    (1..20).each do |pos|
       setlist.setlist_songs.build(position: pos) unless setlist.setlist_songs.any? { |s| s.position == pos }
     end
   end

--- a/app/views/admin/setlists/_form.html.erb
+++ b/app/views/admin/setlists/_form.html.erb
@@ -64,7 +64,7 @@
     </div>
 
     <div>
-      <h2 class="text-md font-bold text-slate-800">曲リスト（ポジション1〜15）</h2>
+      <h2 class="text-md font-bold text-slate-800">曲リスト（ポジション1〜20）</h2>
       <p class="text-xs text-slate-500 mt-1">上から順に position として保存されます。空欄は保存時に削除されます。</p>
       <div class="mt-3 space-y-2">
         <%= f.fields_for :setlist_songs do |sf| %>


### PR DESCRIPTION
## 概要
- 管理画面のセットリスト登録/編集で入力できる曲数を15曲から20曲に拡大。
## 実施内容
- app/controllers/admin/setlists_controller.rb: 空行を用意する範囲を1..20に変更。
- app/views/admin/setlists/_form.html.erb: 見出しを「ポジション1〜20」に更新。
## 対応Issue
- close #336 
## 関連Issue
なし
## 特記事項