### PR TITLE
[add]アフィリエイトリンクの追加

### DIFF
--- a/app/views/home/privacy.html.erb
+++ b/app/views/home/privacy.html.erb
@@ -52,8 +52,15 @@
         </p>
       </section>
 
+      <section class="space-y-3" id="affiliate">
+        <h2 class="text-lg font-semibold text-slate-900">5. アフィリエイトプログラムについて</h2>
+        <p>
+          当サイトはAmazonアソシエイト・プログラムの参加者です。Amazonのアソシエイトとして、当サイトは適格販売により収入を得ています。
+        </p>
+      </section>
+
       <section class="space-y-3" id="cookie">
-        <h2 class="text-lg font-semibold text-slate-900">5. クッキー等の利用</h2>
+        <h2 class="text-lg font-semibold text-slate-900">6. クッキー等の利用</h2>
         <p>
           ログイン状態の維持やアクセス解析のためにクッキー・ローカルストレージを使用します。ブラウザ設定で無効化した場合、一部機能が利用できなくなる可能性があります。
           解析ツールを導入する際には、収集する情報と目的をアプリ内・公式ブログで告知します。
@@ -61,7 +68,7 @@
       </section>
 
       <section class="space-y-3" id="third-party">
-        <h2 class="text-lg font-semibold text-slate-900">6. 第三者提供・委託</h2>
+        <h2 class="text-lg font-semibold text-slate-900">7. 第三者提供・委託</h2>
         <p>
           利用者の同意がある場合、法令に基づく要請がある場合、もしくは運営委託先に機密保持契約を結んだうえで業務を委託する場合を除き、個人情報を第三者へ提供しません。
           委託先には適切な監督を行い、安全管理措置の継続的改善を求めます。
@@ -69,7 +76,7 @@
       </section>
 
       <section class="space-y-3" id="security">
-        <h2 class="text-lg font-semibold text-slate-900">7. 情報の管理</h2>
+        <h2 class="text-lg font-semibold text-slate-900">8. 情報の管理</h2>
         <ul class="list-disc space-y-2 pl-5">
           <li>暗号化・アクセス制御・ログ監査など技術的・組織的安全管理措置を講じます。</li>
           <li>退会後のデータは、法令等で保存義務がある場合を除き、一定期間経過後に削除または匿名化します。</li>
@@ -78,7 +85,7 @@
       </section>
 
       <section class="space-y-3" id="rights">
-        <h2 class="text-lg font-semibold text-slate-900">8. 利用者の権利</h2>
+        <h2 class="text-lg font-semibold text-slate-900">9. 利用者の権利</h2>
         <p>
           利用者は、自身の登録情報やログデータに関して開示・訂正・削除・利用停止を求めることができます。お問い合わせフォームあるいはアプリ内サポート機能からご連絡ください。
           本人確認後、合理的な期間内に対応します。
@@ -86,7 +93,7 @@
       </section>
 
       <section class="space-y-3" id="compliance">
-        <h2 class="text-lg font-semibold text-slate-900">9. 法令遵守とポリシーの改定</h2>
+        <h2 class="text-lg font-semibold text-slate-900">10. 法令遵守とポリシーの改定</h2>
         <p>
           適用される法令・ガイドラインの変更やサービス内容の拡張に応じて、本ポリシーを改定します。重要な変更を行う場合は、サービス内のお知らせや公式 note 等で告知します。
           改定後も当サービスを利用した場合、新しいポリシーに同意したものとみなします。
@@ -94,7 +101,7 @@
       </section>
 
       <section class="space-y-3" id="contact">
-        <h2 class="text-lg font-semibold text-slate-900">10. お問い合わせ</h2>
+        <h2 class="text-lg font-semibold text-slate-900">11. お問い合わせ</h2>
         <p>
           個人情報の取り扱いに関するご質問や、ご自身のデータに関する請求は、お問い合わせフォームまたは運営チーム宛てにご連絡ください。
           いただいたお問い合わせ内容は、利用者サポートとサービス改善以外の目的では利用しません。

--- a/app/views/packing_lists/_affiliate_links.html.erb
+++ b/app/views/packing_lists/_affiliate_links.html.erb
@@ -1,0 +1,19 @@
+<div class="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 shadow-sm">
+  <div class="flex flex-wrap items-center gap-2">
+    <span class="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-amber-700">PR</span>
+    <span class="font-semibold text-amber-900">フェスにおすすめのAmazonアイテム</span>
+  </div>
+  <p class="mt-1 text-xs text-amber-700">※リンクはAmazonアソシエイトを利用しています。</p>
+  <div class="mt-3 flex flex-wrap gap-2">
+    <%= link_to "モバイルバッテリー",
+                "https://amzn.to/3KJbJ6A",
+                target: "_blank",
+                rel: "noopener nofollow sponsored",
+                class: "inline-flex items-center justify-center rounded-full bg-amber-500 px-3 py-1.5 text-xs font-bold text-white shadow-sm transition hover:bg-amber-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-500" %>
+    <%= link_to "コンパクトチェア",
+                "https://amzn.to/4aL5s4K",
+                target: "_blank",
+                rel: "noopener nofollow sponsored",
+                class: "inline-flex items-center justify-center rounded-full bg-amber-500 px-3 py-1.5 text-xs font-bold text-white shadow-sm transition hover:bg-amber-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-500" %>
+  </div>
+</div>

--- a/app/views/packing_lists/index.html.erb
+++ b/app/views/packing_lists/index.html.erb
@@ -13,6 +13,8 @@
       </div>
     </header>
 
+    <%= render "packing_lists/affiliate_links" %>
+
     <section class="space-y-3">
       <div class="flex items-center justify-between">
         <h2 class="text-lg font-bold text-slate-900">マイ持ち物リスト</h2>

--- a/app/views/packing_lists/show.html.erb
+++ b/app/views/packing_lists/show.html.erb
@@ -15,6 +15,8 @@
 
     <% owned_list = (@packing_list.user == current_user) %>
 
+    <%= render "packing_lists/affiliate_links" %>
+
     <section class="rounded-3xl border border-slate-200 bg-white px-5 py-4 shadow-sm">
       <h2 class="sr-only">持ち物一覧</h2>
       <% if @packing_list_items.any? %>


### PR DESCRIPTION
## 概要
- 持ち物リスト一覧・詳細にAmazonアフィリエイトリンクをPR表記付きで追加し、プライバシーポリシーにアソシエイト参加文言を追記。リンクブロックはパーシャル化して共通化。
## 実施内容
- app/views/packing_lists/_affiliate_links.html.erb: PRバッジ付きのAmazonリンクカードを新規追加（モバイルバッテリー/ボディバッグ/コンパクトチェア）。
- app/views/packing_lists/index.html.erb, show.html.erb: 個別実装を削除し、パーシャル呼び出しに置き換え。
- app/views/home/privacy.html.erb: Amazonアソシエイト参加の文言を追記し、節番号を繰り下げて調整。
## 対応Issue
- close #335 
## 関連Issue
なし
## 特記事項
今後の動向を見て改善もしくは継続を判断。