### PR TITLE
[update]開催済みのフェス一覧の順番を日付が新しい順に変更

### DIFF
--- a/app/models/festival.rb
+++ b/app/models/festival.rb
@@ -60,7 +60,9 @@ class Festival < ApplicationRecord
   def self.for_status(status, reference_date: Date.current)
     normalized = normalized_status(status)
     relation = normalized == "past" ? past(reference_date) : upcoming(reference_date)
-    relation.merge(ordered)
+    # 開催済みのフェスは新しい日付が上に来るよう降順、開催前のフェスは古い日付が上に来るように昇順でソート
+    order_direction = normalized == "past" ? :desc : :asc
+    relation.order(start_date: order_direction, name: :asc)
   end
 
   def self.find_by_slug!(slug, scope: all)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -76,7 +76,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_13_000000) do
     t.boolean "timetable_published", default: false, null: false
     t.decimal "latitude", precision: 10, scale: 6
     t.decimal "longitude", precision: 10, scale: 6
-    t.integer "environment", default: 0, null: false
     t.index ["end_date"], name: "index_festivals_on_end_date"
     t.index ["latitude", "longitude"], name: "index_festivals_on_latitude_and_longitude"
     t.index ["prefecture"], name: "index_festivals_on_prefecture"
@@ -233,7 +232,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_13_000000) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "uuid", null: false
+    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.string "provider"
     t.string "uid"
     t.index ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
## 概要
- 開催済みフェスの並び順を開催日が新しい順になるよう調整。
## 実施内容
- app/models/festival.rb の for_status でステータスが past の場合は start_date を降順、それ以外は昇順に並べるよう変更。
- 並び替え意図を示す短いコメントを追加。
## 対応Issue
なし
## 関連Issue
なし
## 特記事項
開催済みのフェスに関しては、開催が新しいものが上に来る方が適していると考えたため。