### PR TITLE
[fix]アーティスト予習ページのセットリスト一覧のスマホビュー改善

### DIFF
--- a/app/helpers/artists_helper.rb
+++ b/app/helpers/artists_helper.rb
@@ -15,10 +15,11 @@ module ArtistsHelper
   def setlist_label(setlist)
     sp           = setlist.stage_performance
     festival     = sp.festival_day.festival
-    festival_day = sp.festival_day
-    label = "#{festival.name}  #{festival_day.date.to_fs(:db)}"
-    label += " / #{sp.stage.name}" if sp.stage.present?
-    label
+    festival.name
+  end
+
+  def setlist_subtext(setlist)
+    setlist.stage_performance.festival_day.date.to_fs(:db)
   end
 
   def spotify_embed_for(song, height: 152, css_class: nil)

--- a/app/views/artists/prep.html.erb
+++ b/app/views/artists/prep.html.erb
@@ -59,6 +59,7 @@
           <% @setlists.each do |setlist| %>
             <%= render "shared/nav_stack_button",
                        label: setlist_label(setlist),
+                       subtext: setlist_subtext(setlist),
                        url: setlist_path(setlist) %>
           <% end %>
         </div>

--- a/app/views/shared/_nav_stack_button.html.erb
+++ b/app/views/shared/_nav_stack_button.html.erb
@@ -1,7 +1,7 @@
 <%= link_to url, class: "nav-stack-button interactive-lift", data: { controller: "tap-feedback" } do %>
   <span class="flex w-full items-start justify-between gap-3">
     <span class="min-w-0 space-y-1 leading-tight">
-      <span class="block truncate text-base font-semibold text-slate-900"><%= label %></span>
+      <span class="block text-base font-semibold leading-snug text-slate-900 line-clamp-2"><%= label %></span>
       <% if local_assigns[:subtext].present? %>
         <span class="block text-xs font-medium text-slate-500"><%= subtext %></span>
       <% end %>


### PR DESCRIPTION
## 概要
- ナビスタックボタンのラベルをデフォルトで2行まで折り返し可能にして、スマホでも見切れを解消。
- アーティスト予習ページの過去セットリスト表示を「フェス名（改行）日程」にし、フェス一覧と同じレイアウトに統一。
## 実施内容
- shared/_nav_stack_button.html.erb: ラベルに leading-snug line-clamp-2 を適用し、truncate を撤廃。
- artists_helper.rb: setlist_label をフェス名のみ返すよう変更し、日付用の setlist_subtext を追加。
- artists/prep.html.erb: セットリスト一覧で subtext に日付を渡し、2行構成で表示。
## 対応Issue
なし
## 関連Issue
なし
## 特記事項