### PR TITLE
[add]フェスごとの予習機能

### DIFF
--- a/app/controllers/prep/festivals_controller.rb
+++ b/app/controllers/prep/festivals_controller.rb
@@ -1,0 +1,119 @@
+module Prep
+  class FestivalsController < ApplicationController
+    def index
+      @status = Festival.normalized_status(params[:status])
+      @status_labels = Festival.status_labels
+      @festival_tags = FestivalTag.order(:name)
+      @filter_params = filter_params
+      @selected_tag_ids = Array(@filter_params[:tag_ids]).reject(&:blank?).map(&:to_i)
+
+      scoped = Festival.for_status(@status)
+      filtered_scope = apply_filters(scoped, @filter_params)
+
+      @q = filtered_scope.ransack(params[:q])
+      result = @q.result(distinct: true)
+
+      pagy_params = request.query_parameters.merge(status: @status)
+      @pagy, @festivals = pagy(result, items: 20, params: pagy_params)
+    end
+
+    def show
+      @festival = find_festival
+      @festival_days = @festival.timetable_days
+      raise ActiveRecord::RecordNotFound if @festival_days.blank?
+
+      resolve_selected_day
+      build_song_entries
+    end
+
+    private
+
+    def find_festival
+      festival_relation = Festival.includes(:festival_days)
+      Festival.find_by_slug!(params[:id], scope: festival_relation)
+    end
+
+    def resolve_selected_day
+      @selected_day =
+        if params[:date].present?
+          parsed = Date.parse(params[:date]) rescue nil
+          raise ActiveRecord::RecordNotFound unless parsed
+          @festival.festival_days.find_by!(date: parsed)
+        else
+          @festival_days.first
+        end
+    end
+
+    def build_song_entries
+      performing_artists = Artist
+                             .joins(stage_performances: :festival_day)
+                             .where(stage_performances: { status: StagePerformance.statuses[:scheduled] },
+                                    festival_days: { id: @selected_day.id, festival_id: @festival.id })
+                             .merge(Artist.published)
+                             .distinct
+                             .order(:name)
+
+      entries = performing_artists.flat_map do |artist|
+        setlist_scope = Setlist
+                         .joins(:stage_performance)
+                         .where(stage_performances: { artist_id: artist.id })
+
+        setlists_count = setlist_scope.count
+        next if setlists_count < 3
+
+        ranked_songs = Song
+                        .joins(setlist_songs: :setlist)
+                        .where(artist_id: artist.id, setlists: { id: setlist_scope.select(:id) })
+                        .select("songs.*", "COUNT(DISTINCT setlist_songs.setlist_id) AS appearances_count")
+                        .group("songs.id")
+                        .order("appearances_count DESC", "songs.name ASC")
+                        .limit(2)
+
+        ranked_songs.map do |song|
+          count = song.read_attribute(:appearances_count).to_i
+          rate  = ((count.to_f / setlists_count) * 100).round(1)
+          { artist: artist, song: song, count: count, rate: rate }
+        end
+      end.compact
+
+      @pagy, @song_entries = pagy_array(entries, items: 10, page: params[:page])
+    end
+
+    def filter_params
+      params.permit(:start_date_from, :end_date_to, :area, tag_ids: [])
+    end
+
+    def apply_filters(scope, filters)
+      filtered = scope
+
+      from_date = parse_date(filters[:start_date_from])
+      to_date   = parse_date(filters[:end_date_to])
+
+      filtered = filtered.where("start_date >= ?", from_date) if from_date
+      filtered = filtered.where("end_date <= ?", to_date) if to_date
+
+      if filters[:area].present? && Regions::AREA_PREFECTURES.key?(filters[:area])
+        prefectures = Regions::AREA_PREFECTURES[filters[:area]]
+        filtered = filtered.where(prefecture: prefectures)
+      end
+
+      tag_ids = Array(filters[:tag_ids]).reject(&:blank?).map(&:to_i)
+      if tag_ids.any?
+        filtered = filtered
+                     .joins(:festival_festival_tags)
+                     .where(festival_festival_tags: { festival_tag_id: tag_ids })
+                     .group("festivals.id")
+                     .having("COUNT(DISTINCT festival_festival_tags.festival_tag_id) = ?", tag_ids.size)
+      end
+
+      filtered
+    end
+
+    def parse_date(value)
+      return if value.blank?
+      Date.parse(value)
+    rescue ArgumentError
+      nil
+    end
+  end
+end

--- a/app/views/festivals/show.html.erb
+++ b/app/views/festivals/show.html.erb
@@ -79,12 +79,9 @@
             タイムテーブルへ
           <% end %>
         <% end %>
-        <%= link_to "#",
-                    class: "relative block w-full overflow-hidden rounded-2xl bg-indigo-500 py-3 text-center text-sm font-bold text-white shadow-md interactive-lift hover:bg-indigo-400",
+        <%= link_to prep_festival_path(@festival),
+                    class: "block w-full rounded-2xl bg-indigo-500 py-3 text-center text-sm font-bold text-white shadow-md interactive-lift hover:bg-indigo-400",
                     data: { controller: "tap-feedback" } do %>
-          <div class="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/30">
-            <span class="rounded-full bg-white/95 px-2 py-[3px] text-[10px] font-black uppercase tracking-[0.16em] text-indigo-500 shadow-sm">準備中</span>
-          </div>
           フェス予習リストへ
         <% end %>
       </div>

--- a/app/views/prep/festivals/index.html.erb
+++ b/app/views/prep/festivals/index.html.erb
@@ -1,0 +1,65 @@
+<div class="min-h-screen px-4 py-6">
+  <div class="mx-auto max-w-5xl space-y-6">
+    <header class="space-y-4">
+      <h1 class="text-2xl font-bold text-slate-900">フェス予習一覧</h1>
+      <% preserved_query = request.query_parameters.except(:page, :status) %>
+      <div class="flex justify-center">
+        <%= render Shared::SegmentedTabsComponent.new(
+              tabs: @status_labels,
+              active_tab_key: @status,
+              url_builder: ->(key) do
+                path_options = preserved_query.merge(status: key)
+                prep_festivals_path(path_options)
+              end
+            ) %>
+      </div>
+    </header>
+
+    <% search_url = prep_festivals_path %>
+    <% search_query = params.dig(:q, :name_i_cont) %>
+    <% hidden_filter_fields = {
+         start_date_from: @filter_params[:start_date_from],
+         end_date_to: @filter_params[:end_date_to],
+         area: @filter_params[:area],
+         "tag_ids[]": @selected_tag_ids
+       } %>
+    <%= render Shared::SearchFormComponent.new(
+               query: @q,
+               url: search_url,
+               placeholder: "フェス名を入力",
+               status: @status,
+               hidden_fields: hidden_filter_fields
+             ) %>
+
+    <% reset_params = { status: @status } %>
+    <% reset_params[:q] = { name_i_cont: search_query } if search_query.present? %>
+    <% reset_url = prep_festivals_path(reset_params) %>
+
+    <%= render "shared/festival_filters",
+               form_url: search_url,
+               status: @status,
+               search_query: search_query,
+               filter_params: @filter_params,
+               festival_tags: @festival_tags,
+               selected_tag_ids: @selected_tag_ids,
+               reset_url: reset_url %>
+
+    <section class="grid gap-3 md:grid-cols-2 md:gap-4">
+      <% if @festivals.any? %>
+        <% @festivals.each do |festival| %>
+          <div class="w-full">
+            <%= render "shared/nav_stack_button",
+                       label: festival.name,
+                       subtext: festival_date_and_location(festival),
+                       url: prep_festival_path(festival) %>
+          </div>
+        <% end %>
+      <% else %>
+        <p class="rounded-xl bg-white px-4 py-12 text-center text-sm text-slate-500 shadow md:col-span-2">
+          表示できるフェスがありません
+        </p>
+      <% end %>
+    </section>
+    <%= render "shared/pagination", pagy: @pagy %>
+  </div>
+</div>

--- a/app/views/prep/festivals/show.html.erb
+++ b/app/views/prep/festivals/show.html.erb
@@ -1,0 +1,53 @@
+<div class="min-h-screen px-4 py-6">
+  <div class="mx-auto max-w-5xl space-y-6">
+    <header class="space-y-3">
+      <p class="text-sm font-semibold text-rose-500">フェス予習</p>
+      <h1 class="text-2xl font-bold text-slate-900"><%= @festival.name %></h1>
+      <p class="text-sm text-slate-600"><%= festival_date_and_location(@festival) %></p>
+    </header>
+
+    <% day_lookup = @festival_days.index_by(&:id) %>
+    <% tab_items = day_lookup.transform_values { |day| day.date.strftime("%-m/%-d") } %>
+    <div class="flex justify-center">
+      <%= render Shared::SegmentedTabsComponent.new(
+            tabs: tab_items,
+            active_tab_key: @selected_day.id,
+            url_builder: ->(festival_day_id) do
+              day = day_lookup[festival_day_id]
+              prep_festival_path(@festival, date: day.date.to_s)
+            end
+          ) %>
+    </div>
+
+    <section class="space-y-4">
+      <h2 class="text-lg font-semibold text-slate-900">
+        <%= @selected_day.date.strftime("%-m/%-d") %> 出演アーティストの予習曲
+      </h2>
+
+      <% if @song_entries.any? %>
+        <div class="grid gap-3 md:grid-cols-2">
+          <% @song_entries.each do |entry| %>
+            <div class="space-y-2 rounded-2xl bg-white p-4 shadow-sm ring-1 ring-slate-200">
+              <p class="text-sm font-semibold text-slate-900">
+                <%= entry[:song].name %> / <%= entry[:artist].name %>
+              </p>
+              <% embed = spotify_embed_for(entry[:song]) %>
+              <% if embed.present? %>
+                <div class="overflow-hidden rounded-xl border border-slate-200 shadow-sm">
+                  <%= embed %>
+                </div>
+              <% else %>
+                <p class="text-xs text-slate-500">Spotify未登録の曲です</p>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+        <%= render "shared/pagination", pagy: @pagy %>
+      <% else %>
+        <div class="rounded-2xl bg-white px-4 py-12 text-center text-sm text-slate-600 shadow">
+          表示できるアーティストがいません
+        </div>
+      <% end %>
+    </section>
+  </div>
+</div>

--- a/app/views/prep/top.html.erb
+++ b/app/views/prep/top.html.erb
@@ -10,8 +10,7 @@
     <section class="space-y-3">
       <%= render "shared/nav_stack_button",
                  label: "フェスから予習する",
-                 url: "#",
-                 trailing: content_tag(:span, "準備中", class: "rounded-full bg-slate-100 px-3 py-1 text-[11px] font-semibold text-slate-600") %>
+                 url: prep_festivals_path %>
       <%= render "shared/nav_stack_button", label: "アーティストから予習する", url: prep_artists_path %>
     </section>
   </div>

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,5 +1,6 @@
 require "pagy/extras/overflow"
 require "pagy/extras/i18n"
+require "pagy/extras/array"
 
 Pagy::DEFAULT[:limit]    = 20
 Pagy::DEFAULT[:overflow] = :last_page

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   get "/privacy", to: "home#privacy", as: :privacy
   get "/prep", to: "prep#top", as: :prep_top
   namespace :prep, path: "prep" do
+    resources :festivals, only: [ :index, :show ]
     resources :artists, only: [ :index ]
   end
 


### PR DESCRIPTION
## 概要
- フェス予習機能を追加し、一覧・詳細を prep 名前空間で提供。フェス詳細からも予習詳細へ遷移できるよう導線を整備。
## 実施内容
- ルーティング/コントローラ: prep/festivals#index に検索・フィルタ・ステータスタブ（開催前/過去）＋paginateを実装。- prep/festivals#show でフェスslug経由の詳細を追加し、日付タブ切替、出演アーティストの演奏率上位2曲を表示（セットリスト3件未満のアーティストは除外、10曲/ページ）。pagy/extras/array を初期化に追加。
- ビュー: フェス予習一覧を通常フェス一覧と同じUI（検索フォーム、絞り込み、タブ、pagination）に。フェス予習詳細は日付タブ＋曲名/アーティスト名とSpotify埋め込みのシンプルなカード表示に統一。
- 導線: 通常フェス詳細の「フェス予習リストへ」リンク、およびフェス予習一覧の各フェスカードを prep_festival_path に接続。
## 対応Issue
- close #331 
## 関連Issue
なし
## 特記事項