### PR TITLE
[update]フェス予習詳細画面の表示条件の修正

### DIFF
--- a/app/controllers/admin/festivals_controller.rb
+++ b/app/controllers/admin/festivals_controller.rb
@@ -5,7 +5,7 @@ class Admin::FestivalsController < Admin::BaseController
   def index
     @pagy, @festivals = pagy(
       Festival.includes(:festival_days, :stages).order(start_date: :desc),
-      items: 10
+      limit: 10
     )
   end
 

--- a/app/controllers/artists/festivals_controller.rb
+++ b/app/controllers/artists/festivals_controller.rb
@@ -10,7 +10,7 @@ class Artists::FestivalsController < ApplicationController
     result = @q.result(distinct: true)
 
     pagy_params = request.query_parameters.merge(status: @status)
-    @pagy, @festivals = pagy(result, items: 20, params: pagy_params)
+    @pagy, @festivals = pagy(result, limit: 20, params: pagy_params)
 
     render "festivals/index"
   end

--- a/app/controllers/festivals_controller.rb
+++ b/app/controllers/festivals_controller.rb
@@ -16,7 +16,7 @@ class FestivalsController < ApplicationController
     result = @q.result(distinct: true)
 
     pagy_params = request.query_parameters.merge(status: @status)
-    @pagy, @festivals = pagy(result, items: 20, params: pagy_params)
+    @pagy, @festivals = pagy(result, limit: 20, params: pagy_params)
   end
 
   def show

--- a/app/controllers/mypage/favorite_artists_controller.rb
+++ b/app/controllers/mypage/favorite_artists_controller.rb
@@ -4,7 +4,7 @@ module Mypage
 
     def index
       favorites_scope = Artist.favorited_by(current_user)
-      @pagy, @artists = pagy(favorites_scope, items: 20)
+      @pagy, @artists = pagy(favorites_scope, limit: 20)
     end
   end
 end

--- a/app/controllers/mypage/favorite_festivals_controller.rb
+++ b/app/controllers/mypage/favorite_festivals_controller.rb
@@ -4,7 +4,7 @@ module Mypage
 
     def index
       favorites_scope = Festival.favorited_by(current_user)
-      @pagy, @festivals = pagy(favorites_scope, items: 20)
+      @pagy, @festivals = pagy(favorites_scope, limit: 20)
     end
   end
 end

--- a/app/controllers/timetables_controller.rb
+++ b/app/controllers/timetables_controller.rb
@@ -19,7 +19,7 @@ class TimetablesController < ApplicationController
     result = @q.result(distinct: true)
 
     pagy_params = request.query_parameters.merge(status: @status)
-    @pagy, @festivals = pagy(result, items: 20, params: pagy_params)
+    @pagy, @festivals = pagy(result, limit: 20, params: pagy_params)
   end
 
   def show


### PR DESCRIPTION
## 概要
- 予習ページの曲抽出をSpotify登録曲優先に改善。
- 件数指定が効かない問題を修正してページネーションを正常化。
## 実施内容
- フェス予習詳細: 演奏率TOP5の中からSpotify ID付き曲のみを先頭2曲採用し、全曲未登録ならそのアーティストを非表示に変更 (Prep::FestivalsController#build_song_entries 調整)。
- Pagy v9対応: これまで items: で無視されていた件数指定を limit: に統一し、配列用の pagy_array も含めて期待件数でページングされるよう修正。
## 対応Issue
なし
## 関連Issue
なし
## 特記事項