### PR TITLE
[fix]持ち物リスト作成・編集機能の改善

### DIFF
--- a/app/controllers/packing_lists_controller.rb
+++ b/app/controllers/packing_lists_controller.rb
@@ -118,7 +118,12 @@ class PackingListsController < ApplicationController
   def prepare_form_data
     @sorted_items = @packing_list.packing_list_items.sort_by { |pli| [ pli.position || 0, pli.id || 0 ] }
     @next_position_value = (@sorted_items.map { |pli| pli.position || 0 }.max || -1) + 1
-    @festival_days = FestivalDay.joins(:festival).includes(:festival).order("festivals.start_date ASC", "festival_days.date ASC")
+    upcoming_days = FestivalDay.for_packing_list_select.to_a
+    @festival_days = upcoming_days
+
+    past_selected_day = @packing_list&.past_selected_festival_day
+
+    @festival_days |= [ past_selected_day ].compact
   end
 
   def apply_template_if_present

--- a/app/models/festival_day.rb
+++ b/app/models/festival_day.rb
@@ -12,4 +12,20 @@ class FestivalDay < ApplicationRecord
       .distinct
       .order("festivals.start_date ASC", "festival_days.date ASC")
   }
+
+  scope :upcoming, ->(today = Date.current) {
+    joins(:festival).where("festivals.end_date >= ?", today)
+  }
+
+  scope :ordered_for_select, -> {
+    joins(:festival).order("festivals.start_date ASC", "festival_days.date ASC")
+  }
+
+  scope :for_packing_list_select, ->(today = Date.current) {
+    upcoming(today).includes(:festival).ordered_for_select
+  }
+
+  def finished?(today = Date.current)
+    festival.end_date < today
+  end
 end

--- a/app/models/packing_list.rb
+++ b/app/models/packing_list.rb
@@ -14,8 +14,22 @@ class PackingList < ApplicationRecord
   validates :title, uniqueness: { scope: :user_id, message: "は既に存在します" }, unless: :template?
   validates :user_id, presence: true, unless: :template?
   validates :template, inclusion: { in: [ true, false ] }
+  validate :festival_day_must_be_upcoming_if_changed
 
   def to_param
     uuid.presence || super
+  end
+
+  def past_selected_festival_day(today = Date.current)
+    return unless festival_day
+    festival_day if festival_day.finished?(today)
+  end
+
+  private
+
+  def festival_day_must_be_upcoming_if_changed
+    return unless will_save_change_to_festival_day_id?
+    return if festival_day.blank?
+    errors.add(:festival_day, "は開催前の日程を選んでください") if festival_day.finished?
   end
 end

--- a/app/views/packing_lists/_form.html.erb
+++ b/app/views/packing_lists/_form.html.erb
@@ -3,7 +3,7 @@
     <div class="space-y-4">
       <%= f.label :title, "リスト名", class: "block text-lg font-semibold text-slate-800 mb-2" %>
       <%= f.text_field :title,
-                       placeholder: "例）9/20 ROCK IN JAPAN FESTIVAL 2025",
+                       placeholder: "例）野外フェス 持ち物リスト",
                        class: [
                          "w-full rounded-xl border px-4 py-3 text-sm text-slate-900 placeholder:text-slate-400 focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-200",
                          (@packing_list.errors[:title].present? ? "border-rose-300 ring-rose-200" : "border-slate-200")
@@ -14,9 +14,13 @@
         <%= f.collection_select :festival_day_id,
                                 @festival_days,
                                 :id,
-                                ->(day) { "#{day.festival.name} / #{format_date_with_weekday(day.date)}" },
+                                ->(day) do
+                                  label = "#{day.festival.name} / #{format_date_with_weekday(day.date)}"
+                                  day.finished? ? "#{label} (開催終了)" : label
+                                end,
                                 { include_blank: "未選択" },
                                 class: "w-full rounded-xl border border-slate-200 px-4 py-2 text-sm text-slate-900 focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-200" %>
+        <p class="text-xs text-slate-500">任意入力です。設定すると天気連携が使えるようになります。</p>
       </div>
     </div>
   </div>

--- a/app/views/packing_lists/show.html.erb
+++ b/app/views/packing_lists/show.html.erb
@@ -10,6 +10,12 @@
           <span class="text-slate-500">/</span>
           <span><%= format_date_with_weekday(day.date) %></span>
         </div>
+      <% else %>
+        <div class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">
+          <span>日程未設定</span>
+          <span class="text-slate-500">/</span>
+          <span>日程を設定すると天気を表示します</span>
+        </div>
       <% end %>
     </header>
 


### PR DESCRIPTION
## 概要
- 持ち物リストのフェス日程選択を「開催前のみ」選択可能にしつつ、既存の過去日程は保持・表示できるように調整。
- 日程設定は任意であることと天気連携の利点をUIで明示し、未設定時のプレースホルダを追加。
- ドメイン寄りのクエリ/判定をモデルに寄せて責務を整理し、日程変更時のバリデーションを追加。
## 実施内容
- FestivalDay に開催前スコープとフォーム用スコープ、並び順スコープ、終了判定を追加（app/models/festival_day.rb）。
- PackingList に過去日程の保持ヘルパーと「日程変更時は開催前のみ」のバリデーションを追加（app/models/packing_list.rb）。
- コントローラでフェス日程取得を新スコープ＋ヘルパーに差し替え、過去日程のみ例外的に選択肢へ復帰させる形に整理（app/controllers/packing_lists_controller.rb）。
- 開催終了後に過去のフェスが紐づいた持ち物リストを編集する際、フォームのセレクトに「(開催終了)」ラベルを付与、任意入力＆天気連携の説明を追記（app/views/packing_lists/_form.html.erb）。
- 詳細画面で日程未設定時に「日程を設定すると天気を表示します」とプレースホルダを表示（app/views/packing_lists/show.html.erb）。
## 対応Issue
なし
## 関連Issue
- #174 
## 特記事項
- 天気連携する際、開催前のフェスしか対象にしなくて良いと判断したため。