### PR TITLE
[update]戻るボタンのロジック変更

### DIFF
--- a/app/components/stage_columns/festival_component.rb
+++ b/app/components/stage_columns/festival_component.rb
@@ -19,13 +19,7 @@ module StageColumns
                          class: default_block_classes,
                          style: block_style_rules) unless performance.artist.published?
 
-      params = {
-        from: "festival_timetable",
-        festival_id: festival.slug,
-        date: selected_day&.date&.to_s
-      }.compact
-
-      link_to(helpers.artist_path(performance.artist, params),
+      link_to(helpers.artist_path(performance.artist),
               class: default_block_classes,
               data: { controller: "tap-feedback" },
               style: block_style_rules) do

--- a/app/components/stage_columns/show_component.rb
+++ b/app/components/stage_columns/show_component.rb
@@ -29,14 +29,7 @@ module StageColumns
                          class: classes,
                          style: block_style_rules) unless performance.artist.published?
 
-      params = {
-        from: "my_timetable",
-        festival_id: festival.slug,
-        date: selected_day&.date&.to_s
-      }.compact
-      params[:user_id] = owner_identifier if owner_identifier.present?
-
-      link_to(helpers.artist_path(performance.artist, params),
+      link_to(helpers.artist_path(performance.artist),
               class: classes,
               data: { controller: "tap-feedback" },
               style: block_style_rules

--- a/app/controllers/artists/festivals_controller.rb
+++ b/app/controllers/artists/festivals_controller.rb
@@ -4,9 +4,14 @@ class Artists::FestivalsController < ApplicationController
   def index
     @status = Festival.normalized_status(params[:status])
     @status_labels = Festival.status_labels
+    @festival_tags = FestivalTag.order(:name)
+    @filter_params = filter_params
+    @selected_tag_ids = Array(@filter_params[:tag_ids]).reject(&:blank?).map(&:to_i)
 
     festival_scope = @artist.festivals.merge(Festival.for_status(@status))
-    @q   = festival_scope.ransack(params[:q])
+    filtered_scope = apply_filters(festival_scope, @filter_params)
+
+    @q   = filtered_scope.ransack(params[:q])
     result = @q.result(distinct: true)
 
     pagy_params = request.query_parameters.merge(status: @status)
@@ -19,5 +24,42 @@ class Artists::FestivalsController < ApplicationController
 
   def set_artist
     @artist = Artist.find_by_identifier!(params[:artist_id])
+  end
+
+  def filter_params
+    params.permit(:start_date_from, :end_date_to, :area, tag_ids: [])
+  end
+
+  def apply_filters(scope, filters)
+    filtered = scope
+
+    from_date = parse_date(filters[:start_date_from])
+    to_date   = parse_date(filters[:end_date_to])
+
+    filtered = filtered.where("start_date >= ?", from_date) if from_date
+    filtered = filtered.where("end_date <= ?", to_date) if to_date
+
+    if filters[:area].present? && Regions::AREA_PREFECTURES.key?(filters[:area])
+      prefectures = Regions::AREA_PREFECTURES[filters[:area]]
+      filtered = filtered.where(prefecture: prefectures)
+    end
+
+    tag_ids = Array(filters[:tag_ids]).reject(&:blank?).map(&:to_i)
+    if tag_ids.any?
+      filtered = filtered
+                   .joins(:festival_festival_tags)
+                   .where(festival_festival_tags: { festival_tag_id: tag_ids })
+                   .group("festivals.id")
+                   .having("COUNT(DISTINCT festival_festival_tags.festival_tag_id) = ?", tag_ids.size)
+    end
+
+    filtered
+  end
+
+  def parse_date(value)
+    return if value.blank?
+    Date.parse(value)
+  rescue ArgumentError
+    nil
   end
 end

--- a/app/controllers/my_timetables_controller.rb
+++ b/app/controllers/my_timetables_controller.rb
@@ -3,6 +3,7 @@ class MyTimetablesController < ApplicationController
   before_action :set_festival!, except: :index
   before_action :set_selected_day!, except: :index
   before_action :prepare_timetable_context!, only: [ :edit, :show ]
+  before_action :set_header_back_path, only: :edit
   before_action :set_timetable_owner!, only: :show
 
   def index
@@ -93,6 +94,13 @@ class MyTimetablesController < ApplicationController
   def find_user_by_identifier!(identifier)
     user = User.find_by(uuid: identifier) || User.find_by(id: identifier)
     user || raise(ActiveRecord::RecordNotFound)
+  end
+
+  def set_header_back_path
+    options = {}
+    options[:date] = @selected_day.date.to_s if @selected_day&.date
+    options[:user_id] = current_user&.uuid if user_signed_in?
+    @header_back_path = festival_my_timetable_path(@festival, options)
   end
 
   def prepare_timetable_context!

--- a/app/controllers/packing_lists_controller.rb
+++ b/app/controllers/packing_lists_controller.rb
@@ -3,6 +3,7 @@ class PackingListsController < ApplicationController
   before_action :set_packing_list, only: [ :show, :edit, :update, :destroy, :duplicate_from_template ]
   before_action :set_owned_packing_list, only: [ :edit, :update, :destroy ]
   before_action :set_available_items, only: [ :new, :create, :edit, :update ]
+  before_action :set_header_back_path, only: [ :edit, :update ]
 
   def index
     @template_lists = PackingList.templates.order(:title)
@@ -50,6 +51,10 @@ class PackingListsController < ApplicationController
   def destroy
     @packing_list.destroy!
     redirect_to packing_lists_path, notice: "持ち物リストを削除しました"
+  end
+
+  def set_header_back_path
+    @header_back_path = packing_list_path(@packing_list) if @packing_list&.persisted?
   end
 
   def duplicate_from_template

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -1,115 +1,84 @@
 module NavigationHelper
+  PARENT_PATHS = {
+    "home#terms" => -> { root_path },
+    "home#privacy" => -> { root_path },
+
+    "prep#show" => -> { root_path },
+    "prep/festivals#index" => -> { prep_path },
+    "prep/festivals#show" => -> { prep_festivals_path },
+    "prep/artists#index" => -> { prep_path },
+    "prep/artists#show" => -> { prep_artists_path },
+
+    "festivals#index" => -> { root_path },
+    "festivals#show" => -> { festivals_path },
+
+    "artists#index" => -> { root_path },
+    "artists#show" => -> { artists_path },
+
+    "timetables#index" => -> { root_path },
+    "timetables#show" => -> { timetables_path },
+
+    "my_timetables#index" => -> { timetables_path },
+    "my_timetables#show" => -> { my_timetables_path },
+    "my_timetables#edit" => -> { my_timetables_path },
+
+    "packing_lists#index" => -> { root_path },
+    "packing_lists#show" => -> { packing_lists_path },
+    "packing_lists#new" => -> { packing_lists_path },
+    "packing_lists#edit" => -> { packing_lists_path },
+
+    # 管理者向け
+    "admin/home#top" => -> { root_path },
+    "admin/festivals#index" => -> { admin_root_path },
+    "admin/festivals#show" => -> { admin_festivals_path },
+    "admin/festivals#new" => -> { admin_festivals_path },
+    "admin/festivals#edit" => -> { admin_festivals_path },
+
+    "admin/artists#index" => -> { admin_root_path },
+    "admin/artists#show" => -> { admin_artists_path },
+    "admin/artists#new" => -> { admin_artists_path },
+    "admin/artists#edit" => -> { admin_artists_path },
+
+    "admin/songs#index" => -> { admin_root_path },
+    "admin/songs#show" => -> { admin_songs_path },
+    "admin/songs#new" => -> { admin_songs_path },
+    "admin/songs#edit" => -> { admin_songs_path },
+
+    "admin/stage_performances#index" => -> { admin_root_path },
+    "admin/stage_performances#show" => -> { admin_stage_performances_path },
+    "admin/stage_performances#new" => -> { admin_stage_performances_path },
+    "admin/stage_performances#edit" => -> { admin_stage_performances_path },
+
+    "admin/festival_tags#index" => -> { admin_root_path },
+    "admin/festival_tags#show" => -> { admin_festival_tags_path },
+    "admin/festival_tags#new" => -> { admin_festival_tags_path },
+    "admin/festival_tags#edit" => -> { admin_festival_tags_path },
+
+    "admin/items#index" => -> { admin_root_path },
+    "admin/items#show" => -> { admin_items_path },
+    "admin/items#new" => -> { admin_items_path },
+    "admin/items#edit" => -> { admin_items_path },
+
+    "admin/packing_lists#index" => -> { admin_root_path },
+    "admin/packing_lists#show" => -> { admin_packing_lists_path },
+    "admin/packing_lists#new" => -> { admin_packing_lists_path },
+    "admin/packing_lists#edit" => -> { admin_packing_lists_path },
+
+    "admin/users#index" => -> { admin_root_path },
+
+    "mypage/favorite_festivals#index" => -> { mypage_dashboard_path },
+    "mypage/favorite_artists#index" => -> { mypage_dashboard_path },
+    "mypage/dashboard#show" => -> { root_path }
+  }.freeze
+
   def header_back_path
     return nil if current_page?(root_path)
     return @header_back_path if defined?(@header_back_path) && @header_back_path.present?
 
-    case controller_path
-    when "home"
-      home_back_path
-    when "festivals", "festivals/artists"
-      festivals_back_path
-    when "artists", "artists/festivals"
-      artists_back_path
-    when "my_timetables"
-      my_timetables_back_path
-    when "mypage/dashboard"
-      root_path
-    when "mypage/favorite_festivals", "mypage/favorite_artists"
-      mypage_back_path
-    else
-      root_path
-    end
-  end
-
-  private
-
-  def home_back_path
-    return safe_referer_path || root_path if %w[terms privacy].include?(action_name)
+    key = "#{controller_path}##{action_name}"
+    resolver = PARENT_PATHS[key]
+    return instance_exec(&resolver) if resolver
 
     root_path
-  end
-
-  def safe_referer_path
-    return if request.referer.blank?
-
-    uri = URI.parse(request.referer)
-    return if uri.host.present? && uri.host != request.host
-
-    path = uri.path.presence || root_path
-    query = uri.query.present? ? "?#{uri.query}" : ""
-    fragment = uri.fragment.present? ? "##{uri.fragment}" : ""
-    "#{path}#{query}#{fragment}"
-  rescue URI::InvalidURIError
-    nil
-  end
-
-  def festivals_back_path
-    case params[:from]
-    when "artist_festivals"
-      return artist_festivals_path(params[:artist_id]) if params[:artist_id].present?
-    when "timetables"
-      return timetables_path
-    when "mypage_favorites"
-      return mypage_favorite_festivals_path
-    end
-
-    return artist_path(params[:artist_id]) if params[:artist_id].present?
-
-    case action_name
-    when "index" then root_path
-    when "timetable" then festival_path(params[:id])
-    else
-      festivals_path
-    end
-  end
-
-  def artists_back_path
-    case params[:from]
-    when "festival_timetable"
-      return timetable_back_path if params[:festival_id].present?
-    when "my_timetable"
-      return my_timetable_back_path
-    when "mypage_favorites"
-      return mypage_favorite_artists_path
-    end
-
-    return festival_path(params[:festival_id]) if params[:festival_id].present?
-
-    case action_name
-    when "index" then root_path
-    else
-      artists_path
-    end
-  end
-
-  def timetable_back_path
-    options = {}
-    options[:date] = params[:date] if params[:date].present?
-    timetable_path(params[:festival_id], options)
-  end
-
-  def my_timetable_back_path
-    return root_path if params[:festival_id].blank?
-    options = {}
-    options[:date] = params[:date] if params[:date].present?
-    options[:user_id] = params[:user_id] if params[:user_id].present?
-    festival_my_timetable_path(params[:festival_id], options)
-  end
-
-  def my_timetables_back_path
-    case action_name
-    when "index"
-      return mypage_dashboard_path if params[:from] == "mypage"
-      timetables_path
-    when "show"
-      my_timetables_path
-    else
-      identifier = params[:festival_id] || params[:id]
-      identifier.present? ? timetable_path(identifier) : root_path
-    end
-  end
-
-  def mypage_back_path
-    mypage_dashboard_path
   end
 end

--- a/app/views/festivals/index.html.erb
+++ b/app/views/festivals/index.html.erb
@@ -56,16 +56,10 @@
       <% if @festivals.any? %>
         <% @festivals.each do |festival| %>
           <div class="w-full">
-            <% festival_url =
-               if @artist
-                 festival_path(festival, from: "artist_festivals", artist_id: @artist.to_param)
-               else
-                 festival_path(festival)
-               end %>
             <%= render "shared/nav_stack_button",
                        label: festival.name,
                        subtext: festival_date_and_location(festival),
-                       url: festival_url,
+                       url: festival_path(festival),
                        trailing: favorite_button_for(
                          favorited: festival_favorited?(festival),
                          toggle_url: festival_favorite_path(festival)

--- a/app/views/mypage/dashboard/show.html.erb
+++ b/app/views/mypage/dashboard/show.html.erb
@@ -26,7 +26,7 @@
                   url: mypage_favorite_artists_path %>
         <%= render "shared/nav_stack_button",
                   label: "マイタイムテーブル",
-                  url: my_timetables_path(from: "mypage") %>       
+                  url: my_timetables_path %>       
       </div>
     </section>
   </div>

--- a/app/views/mypage/favorite_artists/index.html.erb
+++ b/app/views/mypage/favorite_artists/index.html.erb
@@ -10,7 +10,7 @@
       <% if @artists.any? %>
         <div class="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
           <% @artists.each do |artist| %>
-            <%= render "shared/artist_card", artist: artist, from: "mypage_favorites" %>
+            <%= render "shared/artist_card", artist: artist %>
           <% end %>
         </div>
       <% else %>

--- a/app/views/mypage/favorite_festivals/index.html.erb
+++ b/app/views/mypage/favorite_festivals/index.html.erb
@@ -13,7 +13,7 @@
             <%= render "shared/nav_stack_button",
                        label: festival.name,
                        subtext: festival_date_and_location(festival),
-                       url: festival_path(festival, from: "mypage_favorites"),
+                       url: festival_path(festival),
                        trailing: favorite_button_for(
                          favorited: festival_favorited?(festival),
                          toggle_url: festival_favorite_path(festival)

--- a/app/views/shared/_artist_card.html.erb
+++ b/app/views/shared/_artist_card.html.erb
@@ -1,7 +1,5 @@
 <div class="relative h-full">
-  <% link_params = {} %>
-  <% link_params[:from] = local_assigns[:from] if local_assigns[:from].present? %>
-  <%= link_to artist_path(artist, link_params),
+  <%= link_to artist_path(artist),
               class: "flex h-full w-full flex-col items-center rounded-3xl border border-slate-200 bg-white p-4 pb-12 shadow-sm interactive-lift focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-400",
               data: { controller: "tap-feedback" } do %>
     <div class="aspect-square w-full overflow-hidden rounded-2xl border border-slate-200 bg-slate-50">

--- a/app/views/timetables/index.html.erb
+++ b/app/views/timetables/index.html.erb
@@ -62,7 +62,7 @@
             <%= render "shared/nav_stack_button",
                        label: festival.name,
                        subtext: festival_date_and_location(festival),
-                       url: timetable_path(festival, from: "timetables") %>
+                       url: timetable_path(festival) %>
           </div>
         <% end %>
       <% else %>


### PR DESCRIPTION
## 概要
- 戻るボタンを「論理的な親」へ戻す方針に整理し、コントローラ側で必要な画面だけ戻り先を明示するようリファクタリング。
- 不要になった from パラメータを各ビューから削除し、リンクをシンプル化。
- アーティスト出演フェス一覧でフェス一覧と同等のフィルター機能を補完し、ビューの期待変数不足によるエラーを解消。
## 実施内容
- NavigationHelper に戻り先マップを定義し、親パスをシンプルに解決する形に変更。マイページお気に入り一覧や管理画面も含めて親を定義（app/helpers/navigation_helper.rb）。
- 編集系画面の戻り先をコントローラで明示: マイタイムテーブル編集、持ち物リスト編集で @header_back_path をセット（app/controllers/my_timetables_controller.rb, app/controllers/packing_lists_controller.rb）。
- 不要になった from クエリを各リンクから削除し、リンク先をシンプルに（フェス一覧、タイムテーブル一覧、マイページ系、ステージカラムのアーティストリンクなどのビュー/コンポーネント）。
- アーティスト出演フェス一覧にフィルターセットアップとフィルター適用処理を追加し、エラーを解消（app/controllers/artists/festivals_controller.rb）。
## 対応Issue
- #268 
## 関連Issue
なし
## 特記事項
各要素の「一覧画面→詳細」という動きをベースに戻るボタンの挙動を設定しているため、例外については追加対応が必要。
（例: 「フェス詳細画面→タイムテーブル詳細」と移動した場合、現状では戻るボタンの挙動上「タイムテーブル一覧画面」に戻ってしまう。）