### PR TITLE
[update]戻るボタンの例外パターンの挙動修正

### DIFF
--- a/app/controllers/artists/festivals_controller.rb
+++ b/app/controllers/artists/festivals_controller.rb
@@ -1,5 +1,8 @@
 class Artists::FestivalsController < ApplicationController
   before_action :set_artist
+  before_action :set_header_back_path
+  # 一覧→詳細で戻るときに元の一覧URLを渡すためのパラメータ
+  before_action :set_back_to_param
 
   def index
     @status = Festival.normalized_status(params[:status])
@@ -61,5 +64,14 @@ class Artists::FestivalsController < ApplicationController
     Date.parse(value)
   rescue ArgumentError
     nil
+  end
+
+  def set_header_back_path
+    @header_back_path = artist_path(@artist) if @artist
+  end
+
+  def set_back_to_param
+    # 現在の一覧URLを保存し、詳細遷移時の戻り先として渡す
+    @back_to = request.fullpath
   end
 end

--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -1,5 +1,7 @@
 class ArtistsController < ApplicationController
   before_action :set_artist, only: :show
+  # 一覧から渡された戻り先があれば採用する
+  before_action :set_header_back_path, only: :show
 
   def index
     @festival = nil
@@ -19,5 +21,13 @@ class ArtistsController < ApplicationController
 
   def set_artist
     @artist = Artist.find_published!(params[:id])
+  end
+
+  def set_header_back_path
+    back = params[:back_to].to_s
+    return if back.blank?
+    return unless back.start_with?("/")
+
+    @header_back_path = back
   end
 end

--- a/app/controllers/festivals/artists_controller.rb
+++ b/app/controllers/festivals/artists_controller.rb
@@ -1,6 +1,9 @@
 class Festivals::ArtistsController < ApplicationController
   before_action :set_festival
   before_action :set_festival_days
+  before_action :set_header_back_path
+  # 一覧→詳細で戻るときに元の一覧URLを渡すためのパラメータ
+  before_action :set_back_to_param
 
   def index
     artists_scope = @festival.artists_for_day(@selected_festival_day)
@@ -22,5 +25,14 @@ class Festivals::ArtistsController < ApplicationController
   def set_festival_days
     @festival_days = @festival.festival_days.order(:date)
     @selected_festival_day = @festival_days.find_by(id: params[:festival_day_id]) || @festival_days.first
+  end
+
+  def set_header_back_path
+    @header_back_path = festival_path(@festival) if @festival
+  end
+
+  def set_back_to_param
+    # 現在の一覧URLを保存し、詳細遷移時の戻り先として渡す
+    @back_to = request.fullpath
   end
 end

--- a/app/controllers/festivals_controller.rb
+++ b/app/controllers/festivals_controller.rb
@@ -1,5 +1,7 @@
 class FestivalsController < ApplicationController
   before_action :set_festival, only: :show
+  # 一覧から渡された戻り先があれば採用する
+  before_action :set_header_back_path, only: :show
 
   def index
     @artist = nil
@@ -64,5 +66,13 @@ class FestivalsController < ApplicationController
     Date.parse(value)
   rescue ArgumentError
     nil
+  end
+
+  def set_header_back_path
+    back = params[:back_to].to_s
+    return if back.blank?
+    return unless back.start_with?("/")
+
+    @header_back_path = back
   end
 end

--- a/app/controllers/prep/artists_controller.rb
+++ b/app/controllers/prep/artists_controller.rb
@@ -38,12 +38,19 @@ module Prep
         else
           []
         end
+
+      set_header_back_path
     end
 
     private
 
     def set_artist
       @artist = Artist.find_published!(params[:id])
+    end
+
+    def set_header_back_path
+      return unless params[:back_to] == "artist"
+      @header_back_path = artist_path(@artist) if @artist
     end
   end
 end

--- a/app/controllers/prep/festivals_controller.rb
+++ b/app/controllers/prep/festivals_controller.rb
@@ -24,6 +24,7 @@ module Prep
 
       resolve_selected_day
       build_song_entries
+      set_header_back_path
     end
 
     private
@@ -120,6 +121,11 @@ module Prep
       Date.parse(value)
     rescue ArgumentError
       nil
+    end
+
+    def set_header_back_path
+      return unless params[:back_to] == "festival"
+      @header_back_path = festival_path(@festival) if @festival
     end
   end
 end

--- a/app/controllers/timetables_controller.rb
+++ b/app/controllers/timetables_controller.rb
@@ -2,6 +2,7 @@ class TimetablesController < ApplicationController
   before_action :set_festival, only: :show
   before_action :ensure_timetable_published!, only: :show
   before_action :load_festival_days, only: :show
+  before_action :set_header_back_path, only: :show
 
   def index
     @status = Festival.normalized_status(params[:status])
@@ -91,7 +92,7 @@ class TimetablesController < ApplicationController
   end
 
   def timetable_query_params
-    params.permit(:from, :artist_id, :festival_id, :user_id).to_h
+    params.permit(:from, :artist_id, :festival_id, :user_id, :back_to).to_h
   end
 
   def filter_params
@@ -129,5 +130,12 @@ class TimetablesController < ApplicationController
     Date.parse(value)
   rescue ArgumentError
     nil
+  end
+
+  def set_header_back_path
+    return unless @festival
+    return unless params[:back_to] == "festival"
+
+    @header_back_path = festival_path(@festival)
   end
 end

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -27,6 +27,10 @@ module NavigationHelper
     "packing_lists#new" => -> { packing_lists_path },
     "packing_lists#edit" => -> { packing_lists_path },
 
+    "mypage/favorite_festivals#index" => -> { mypage_dashboard_path },
+    "mypage/favorite_artists#index" => -> { mypage_dashboard_path },
+    "mypage/dashboard#show" => -> { root_path },
+
     # 管理者向け
     "admin/home#top" => -> { root_path },
     "admin/festivals#index" => -> { admin_root_path },
@@ -64,11 +68,7 @@ module NavigationHelper
     "admin/packing_lists#new" => -> { admin_packing_lists_path },
     "admin/packing_lists#edit" => -> { admin_packing_lists_path },
 
-    "admin/users#index" => -> { admin_root_path },
-
-    "mypage/favorite_festivals#index" => -> { mypage_dashboard_path },
-    "mypage/favorite_artists#index" => -> { mypage_dashboard_path },
-    "mypage/dashboard#show" => -> { root_path }
+    "admin/users#index" => -> { admin_root_path }
   }.freeze
 
   def header_back_path

--- a/app/views/artists/index.html.erb
+++ b/app/views/artists/index.html.erb
@@ -49,7 +49,7 @@
       <% if @artists.any? %>
         <div class="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
           <% @artists.each do |artist| %>
-            <%= render "shared/artist_card", artist: artist %>
+            <%= render "shared/artist_card", artist: artist, back_to: @back_to %>
           <% end %>
         </div>
       <% else %>

--- a/app/views/artists/show.html.erb
+++ b/app/views/artists/show.html.erb
@@ -45,7 +45,7 @@
           出演フェス一覧
         <% end %>
 
-        <%= link_to prep_artist_path(@artist),
+        <%= link_to prep_artist_path(@artist, back_to: "artist"),
                     class: "block w-full rounded-2xl bg-indigo-500 py-3 text-center text-sm font-bold text-white shadow-md interactive-lift hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-400",
                     data: { controller: "tap-feedback" } do %>
           アーティスト予習ページへ

--- a/app/views/festivals/index.html.erb
+++ b/app/views/festivals/index.html.erb
@@ -59,7 +59,7 @@
             <%= render "shared/nav_stack_button",
                        label: festival.name,
                        subtext: festival_date_and_location(festival),
-                       url: festival_path(festival),
+                       url: festival_path(festival, back_to: @back_to),
                        trailing: favorite_button_for(
                          favorited: festival_favorited?(festival),
                          toggle_url: festival_favorite_path(festival)

--- a/app/views/festivals/show.html.erb
+++ b/app/views/festivals/show.html.erb
@@ -73,13 +73,13 @@
           出演アーティスト一覧へ
         <% end %>
         <% if @festival.timetable_published? %>
-          <%= link_to timetable_path(@festival),
+          <%= link_to timetable_path(@festival, back_to: "festival"),
                       class: "block w-full rounded-2xl bg-indigo-500 py-3 text-center text-sm font-bold text-white shadow-md interactive-lift hover:bg-indigo-400",
                       data: { controller: "tap-feedback" } do %>
             タイムテーブルへ
           <% end %>
         <% end %>
-        <%= link_to prep_festival_path(@festival),
+        <%= link_to prep_festival_path(@festival, back_to: "festival"),
                     class: "block w-full rounded-2xl bg-indigo-500 py-3 text-center text-sm font-bold text-white shadow-md interactive-lift hover:bg-indigo-400",
                     data: { controller: "tap-feedback" } do %>
           フェス予習リストへ

--- a/app/views/prep/festivals/show.html.erb
+++ b/app/views/prep/festivals/show.html.erb
@@ -14,7 +14,7 @@
             active_tab_key: @selected_day.id,
             url_builder: ->(festival_day_id) do
               day = day_lookup[festival_day_id]
-              prep_festival_path(@festival, date: day.date.to_s)
+              prep_festival_path(@festival, date: day.date.to_s, back_to: params[:back_to])
             end
           ) %>
     </div>

--- a/app/views/shared/_artist_card.html.erb
+++ b/app/views/shared/_artist_card.html.erb
@@ -1,5 +1,5 @@
 <div class="relative h-full">
-  <%= link_to artist_path(artist),
+  <%= link_to artist_path(artist, back_to: local_assigns[:back_to]),
               class: "flex h-full w-full flex-col items-center rounded-3xl border border-slate-200 bg-white p-4 pb-12 shadow-sm interactive-lift focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-400",
               data: { controller: "tap-feedback" } do %>
     <div class="aspect-square w-full overflow-hidden rounded-2xl border border-slate-200 bg-slate-50">


### PR DESCRIPTION
## 概要
- 戻るボタンの親子関係を整理し、一覧→詳細で元の一覧へ戻れるように back_to をパラメータで渡す仕組みを追加。
- フェス予習／アーティスト予習の戻り先を親ページ以外から来た場合（フェス詳細・アーティスト詳細）に戻せるように調整。
## 実施内容
- NavigationHelper の親マップ整備に加え、各コントローラで @header_back_path を必要なケースだけセットする方針に統一。
- festivals/artists#index と artists/festivals#index に @back_to を追加（request.fullpath）、詳細リンクに back_to を付与し、詳細側で採用できるようにした。
- フェス詳細→タイムテーブル/予習詳細、アーティスト詳細→予習詳細で back_to を受け取って親詳細に戻す挙動を追加（。
## 対応Issue
- close #268 
## 関連Issue
なし
## 特記事項
今後も不具合が出たら追加修正。