### PR TITLE
[add]Google Search ConsoleのHTMLタグを追加

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <meta name="turbo-cache-control" content="no-preview">
+    <meta name="google-site-verification" content="xNg2EK5ZIULaKlH5D5Bje-I9rxqh0AwNZnFbsfcgoXA" />
 
     <meta property="og:site_name" content="FES READY">
     <meta property="og:title" content="<%= content_for(:title) || 'FES READY' %>">


### PR DESCRIPTION
## 概要
- Google Search ConsoleのHTMLタグを追加。
## 実施内容
- views/layouts/application.html.erbのhead部分に、検索用のタグを追加。
## 対応Issue
なし
## 関連Issue
なし
## 特記事項