### PR TITLE
[fix]持ち物リスト画面のレイアウト変更

### DIFF
--- a/app/views/packing_lists/index.html.erb
+++ b/app/views/packing_lists/index.html.erb
@@ -13,8 +13,6 @@
       </div>
     </header>
 
-    <%= render "packing_lists/affiliate_links" %>
-
     <section class="space-y-3">
       <div class="flex items-center justify-between">
         <h2 class="text-lg font-bold text-slate-900">マイ持ち物リスト</h2>
@@ -68,5 +66,9 @@
         </div>
       </section>
     <% end %>
+
+    <div class="mt-12 sm:mt-16">
+      <%= render "packing_lists/affiliate_links" %>
+    </div>
   </div>
 </div>

--- a/app/views/packing_lists/show.html.erb
+++ b/app/views/packing_lists/show.html.erb
@@ -21,10 +21,12 @@
 
     <% owned_list = (@packing_list.user == current_user) %>
 
-    <%= render "packing_lists/affiliate_links" %>
-
     <% if @festival_weather_forecast.present? %>
       <%= render "packing_lists/festival_weather", forecast: @festival_weather_forecast %>
+    <% elsif @packing_list.festival_day.present? %>
+      <div class="rounded-2xl border border-dashed border-slate-300 bg-slate-50 px-4 py-3 text-sm text-slate-700">
+        開催日の約2週間前から天気予報を表示します。
+      </div>
     <% end %>
 
     <section class="rounded-3xl border border-slate-200 bg-white px-5 py-4 shadow-sm">
@@ -90,6 +92,10 @@
                       class: "inline-flex min-w-[12rem] items-center justify-center rounded-2xl bg-indigo-500 px-6 py-3 text-sm font-bold text-white shadow-md interactive-lift hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500",
                       data: { controller: "tap-feedback" } %>
       <% end %>
+    </div>
+
+    <div class="mt-12 sm:mt-16">
+      <%= render "packing_lists/affiliate_links" %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## 概要
- 持ち物リスト詳細/一覧画面のアフィリエイト表示位置をさらに下げて余白を確保。
- 天気予報が表示されない場合に「開催約2週間前から表示される」旨の案内を追加し、非表示理由を明示。
## 実施内容
- app/views/packing_lists/show.html.erb: アフィリエイトブロックを余白付きラッパーで下に配置。天気予報がnilかつ日程ありの場合にガイダンスを表示。
- app/views/packing_lists/index.html.erb: 一覧画面のアフィリエイトブロックにも同じ余白を適用して配置を下げました。
## 対応Issue
なし
## 関連Issue
なし
## 特記事項
- アフィリエイトが上にあると、本当にユーザーが見たい情報がスクロール必須になってしまうため、変更。