### PR TITLE
[add]FactoryBotを有効化し、持ち物リスト周辺のP0モデルのRSpecを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,7 @@ group :development, :test do
 
   gem "dotenv-rails"
   # RSpec
-  gem 'rspec-rails'
+  gem "rspec-rails"
 end
 
 group :development do
@@ -87,7 +87,7 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
-  gem 'factory_bot_rails'
+  gem "factory_bot_rails"
 end
 
 gem "dockerfile-rails", ">= 1.7", group: :development

--- a/spec/factories/festival_days.rb
+++ b/spec/factories/festival_days.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :festival_day do
+    association :festival
+    date { festival.start_date }
+  end
+end

--- a/spec/factories/festivals.rb
+++ b/spec/factories/festivals.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :festival do
+    sequence(:name) { |n| "Festival #{n}" }
+    sequence(:slug) { |n| "festival-#{n}" }
+    start_date { Date.current + 30.days }
+    end_date { start_date + 1.day }
+    timezone { "Asia/Tokyo" }
+    venue_name { "会場" }
+    latitude { 35.0 }
+    longitude { 139.0 }
+  end
+end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :item do
+    association :user, strategy: :create
+    sequence(:name) { |n| "Item #{n}" }
+    template { false }
+  end
+
+  factory :template_item, parent: :item do
+    user { nil }
+    template { true }
+  end
+end

--- a/spec/factories/packing_list_items.rb
+++ b/spec/factories/packing_list_items.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :packing_list_item do
+    association :packing_list, strategy: :create
+    association :item, strategy: :create
+    position { 0 }
+    checked { false }
+    note { nil }
+  end
+end

--- a/spec/factories/packing_lists.rb
+++ b/spec/factories/packing_lists.rb
@@ -1,0 +1,17 @@
+FactoryBot.define do
+  factory :packing_list do
+    association :user, strategy: :create
+    sequence(:title) { |n| "持ち物リスト #{n}" }
+    template { false }
+    uuid { SecureRandom.uuid }
+
+    trait :with_festival_day do
+      association :festival_day
+    end
+  end
+
+  factory :template_packing_list, parent: :packing_list do
+    user { nil }
+    template { true }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user do
+    sequence(:email) { |n| "user#{n}@example.com" }
+    password { "password" }
+    sequence(:nickname) { |n| "user#{n}" }
+  end
+end

--- a/spec/models/festival_day_spec.rb
+++ b/spec/models/festival_day_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe FestivalDay, type: :model do
+  describe "#finished?" do
+    it "フェスの終了日が今日以降ならfalse" do
+      festival = create(:festival, start_date: Date.current, end_date: Date.current + 1)
+      day = build(:festival_day, festival: festival, date: festival.start_date)
+
+      expect(day.finished?(Date.current)).to be false
+    end
+
+    it "フェスの終了日が今日より前ならtrue" do
+      festival = create(:festival, start_date: Date.current - 10, end_date: Date.current - 5)
+      day = build(:festival_day, festival: festival, date: festival.start_date)
+
+      expect(day.finished?(Date.current)).to be true
+    end
+  end
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.describe Item, type: :model do
+  describe "バリデーション" do
+    it "デフォルトのファクトリなら有効" do
+      expect(build(:item)).to be_valid
+    end
+
+    it "nameは必須" do
+      item = build(:item, name: nil)
+      expect(item).to be_invalid
+      expect(item.errors[:name]).to be_present
+    end
+
+    it "nameは100文字以内" do
+      item = build(:item, name: "a" * 101)
+      expect(item).to be_invalid
+    end
+
+    it "templateでなければuserが必須" do
+      item = build(:item, user: nil, template: false)
+      expect(item).to be_invalid
+      expect(item.errors[:user_id]).to be_present
+    end
+
+    it "templateならuserなしでよい" do
+      expect(build(:template_item)).to be_valid
+    end
+
+    it "templateフラグは真偽値のみ" do
+      item = build(:item, template: nil)
+      expect(item).to be_invalid
+    end
+  end
+
+  describe "スコープ" do
+    it ".templates はテンプレートのみ返す" do
+      template = create(:template_item)
+      non_template = create(:item)
+
+      expect(Item.templates).to include(template)
+      expect(Item.templates).not_to include(non_template)
+    end
+
+    it ".owned_by は指定ユーザーのアイテムのみ返す" do
+      user = create(:user)
+      owned = create(:item, user: user)
+      other = create(:item)
+
+      expect(Item.owned_by(user)).to contain_exactly(owned)
+      expect(Item.owned_by(user)).not_to include(other)
+    end
+  end
+end

--- a/spec/models/packing_list_item_spec.rb
+++ b/spec/models/packing_list_item_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe PackingListItem, type: :model do
+  describe "バリデーション" do
+    it "デフォルトのファクトリなら有効" do
+      expect(build(:packing_list_item)).to be_valid
+    end
+
+    it "同一リスト内でitemはユニーク" do
+      packing_list = create(:packing_list)
+      item = create(:item)
+      create(:packing_list_item, packing_list: packing_list, item: item)
+
+      duplicate = build(:packing_list_item, packing_list: packing_list, item: item)
+      expect(duplicate).to be_invalid
+      expect(duplicate.errors[:item_id]).to be_present
+    end
+
+    it "checkedは真偽値のみ" do
+      pli = build(:packing_list_item, checked: nil)
+      expect(pli).to be_invalid
+    end
+
+    it "positionは0以上の整数" do
+      negative = build(:packing_list_item, position: -1)
+      decimal = build(:packing_list_item, position: 1.5)
+
+      expect(negative).to be_invalid
+      expect(decimal).to be_invalid
+    end
+  end
+end

--- a/spec/models/packing_list_spec.rb
+++ b/spec/models/packing_list_spec.rb
@@ -1,0 +1,115 @@
+require "rails_helper"
+
+RSpec.describe PackingList, type: :model do
+  describe "バリデーション" do
+    it "デフォルトのファクトリなら有効" do
+      expect(build(:packing_list)).to be_valid
+    end
+
+    it "titleは必須" do
+      packing_list = build(:packing_list, title: nil)
+      expect(packing_list).to be_invalid
+      expect(packing_list.errors[:title]).to be_present
+    end
+
+    it "titleは100文字以内" do
+      packing_list = build(:packing_list, title: "a" * 101)
+      expect(packing_list).to be_invalid
+    end
+
+    it "templateでなければuserが必須" do
+      packing_list = build(:packing_list, user: nil, template: false)
+      expect(packing_list).to be_invalid
+      expect(packing_list.errors[:user_id]).to be_present
+    end
+
+    it "templateならuserなしでよい" do
+      expect(build(:template_packing_list)).to be_valid
+    end
+
+    it "非テンプレはユーザー内でtitleユニーク" do
+      user = create(:user)
+      create(:packing_list, user: user, title: "被り不可")
+
+      duplicate = build(:packing_list, user: user, title: "被り不可")
+      expect(duplicate).to be_invalid
+      expect(duplicate.errors[:title]).to be_present
+    end
+
+    it "別ユーザーなら同名titleを許可" do
+      title = "同名OK"
+      create(:packing_list, title: title)
+
+      expect(build(:packing_list, title: title)).to be_valid
+    end
+
+    it "templateフラグは真偽値のみ" do
+      packing_list = build(:packing_list, template: nil)
+      expect(packing_list).to be_invalid
+    end
+
+    it "過去の日程は選べない" do
+      festival = create(:festival, start_date: Date.current - 10, end_date: Date.current - 5)
+      past_day = create(:festival_day, festival: festival, date: festival.start_date)
+
+      packing_list = build(:packing_list, festival_day: past_day)
+      expect(packing_list).to be_invalid
+      expect(packing_list.errors[:festival_day]).to include("は開催前の日程を選んでください")
+    end
+
+    it "未来の日程ならOK" do
+      festival = create(:festival, start_date: Date.current + 10, end_date: Date.current + 11)
+      upcoming_day = create(:festival_day, festival: festival, date: festival.start_date)
+
+      expect(build(:packing_list, festival_day: upcoming_day)).to be_valid
+    end
+  end
+
+  describe "スコープ" do
+    it ".templates はテンプレートのみ返す" do
+      template = create(:template_packing_list)
+      owned = create(:packing_list)
+
+      expect(PackingList.templates).to include(template)
+      expect(PackingList.templates).not_to include(owned)
+    end
+
+    it ".owned_by は指定ユーザーのリストのみ返す" do
+      user = create(:user)
+      owned = create(:packing_list, user: user)
+      other = create(:packing_list)
+
+      expect(PackingList.owned_by(user)).to contain_exactly(owned)
+      expect(PackingList.owned_by(user)).not_to include(other)
+    end
+  end
+
+  describe "#to_param" do
+    it "uuidをそのまま返す" do
+      packing_list = create(:packing_list)
+      expect(packing_list.to_param).to eq(packing_list.uuid)
+    end
+  end
+
+  describe "#past_selected_festival_day" do
+    it "日程未設定ならnilを返す" do
+      expect(build(:packing_list).past_selected_festival_day).to be_nil
+    end
+
+    it "未来の日程ならnilを返す" do
+      festival = create(:festival, start_date: Date.current + 1, end_date: Date.current + 2)
+      day = create(:festival_day, festival: festival, date: festival.start_date)
+      packing_list = build(:packing_list, festival_day: day)
+
+      expect(packing_list.past_selected_festival_day).to be_nil
+    end
+
+    it "終了済みの日程ならその日程を返す" do
+      festival = create(:festival, start_date: Date.current - 10, end_date: Date.current - 5)
+      day = create(:festival_day, festival: festival, date: festival.start_date)
+      packing_list = build(:packing_list, festival_day: day)
+
+      expect(packing_list.past_selected_festival_day(Date.current)).to eq(day)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,7 +23,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
+Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
 
 # Ensures that the test database schema matches the current schema file.
 # If there are pending migrations it will invoke `db:test:prepare` to

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end


### PR DESCRIPTION
## 概要
- FactoryBotを有効化し、持ち物リスト周辺のP0モデル（Item/PackingList/PackingListItem/FestivalDay）のRSpecを追加。
- 基本ファクトリを整備し、関連付きのテストデータを自動生成できるようにした。
## 実施内容
- spec/rails_helper.rb: spec/support/**/*.rb 自動読み込みを有効化。
- spec/support/factory_bot.rb: FactoryBotシンタックスをRSpecにmix-in。
- spec/factories/*.rb: user/nickname付き、festival/festival_day、item（テンプレ含む）、packing_list（テンプレ・日程トレイト含む）、packing_list_itemを追加・調整（関連はcreate戦略、uuid付与など）。
- spec/models/*.rb: Item/PackingList/PackingListItem/FestivalDayのバリデーション・スコープ・メソッド（to_param/past判定など）を日本語でテスト。
- テスト: docker compose exec web bundle exec rspec spec/models で全30件グリーン。
## 対応Issue
- #86 
## 関連Issue
なし
## 特記事項