### PR TITLE
[add]model周りのspecコードの追加

### DIFF
--- a/spec/factories/artists.rb
+++ b/spec/factories/artists.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :artist do
+    sequence(:name) { |n| "Artist #{n}" }
+    published { true }
+    uuid { SecureRandom.uuid }
+  end
+end

--- a/spec/factories/festival_festival_tags.rb
+++ b/spec/factories/festival_festival_tags.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :festival_festival_tag do
+    association :festival, strategy: :create
+    association :festival_tag, strategy: :create
+  end
+end

--- a/spec/factories/festival_tags.rb
+++ b/spec/factories/festival_tags.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :festival_tag do
+    sequence(:name) { |n| "Tag #{n}" }
+  end
+end

--- a/spec/factories/setlist_songs.rb
+++ b/spec/factories/setlist_songs.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :setlist_song do
+    association :setlist, strategy: :create
+    association :song, strategy: :create
+    position { 1 }
+  end
+end

--- a/spec/factories/setlists.rb
+++ b/spec/factories/setlists.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :setlist do
+    association :stage_performance, strategy: :create
+    uuid { SecureRandom.uuid }
+  end
+end

--- a/spec/factories/songs.rb
+++ b/spec/factories/songs.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :song do
+    association :artist, strategy: :create
+    sequence(:name) { |n| "Song #{n}" }
+    spotify_id { "0OdUWJ0sBjDrqHygGUXeCF" }
+  end
+end

--- a/spec/factories/stage_performances.rb
+++ b/spec/factories/stage_performances.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :stage_performance do
+    association :festival_day, strategy: :create
+    association :artist, strategy: :create
+    status { :draft }
+
+    trait :scheduled do
+      association :stage, strategy: :create
+      status { :scheduled }
+      starts_at { festival_day.date.to_time.change(hour: 12) }
+      ends_at   { festival_day.date.to_time.change(hour: 13) }
+    end
+  end
+end

--- a/spec/factories/stages.rb
+++ b/spec/factories/stages.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :stage do
+    association :festival, strategy: :create
+    sequence(:name) { |n| "Stage #{n}" }
+    color_key { "slate" }
+  end
+end

--- a/spec/factories/user_artist_favorites.rb
+++ b/spec/factories/user_artist_favorites.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user_artist_favorite do
+    association :user, strategy: :create
+    association :artist, strategy: :create
+  end
+end

--- a/spec/factories/user_festival_favorites.rb
+++ b/spec/factories/user_festival_favorites.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user_festival_favorite do
+    association :user, strategy: :create
+    association :festival, strategy: :create
+  end
+end

--- a/spec/factories/user_timetable_entries.rb
+++ b/spec/factories/user_timetable_entries.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user_timetable_entry do
+    association :user, strategy: :create
+    association :stage_performance, strategy: :create
+  end
+end

--- a/spec/models/artist_spec.rb
+++ b/spec/models/artist_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe Artist, type: :model do
+  describe "バリデーション" do
+    it "デフォルトのファクトリは未定義なので直接指定で有効" do
+      expect(Artist.new(name: "Artist", published: true, uuid: SecureRandom.uuid)).to be_valid
+    end
+
+    it "nameは必須でユニーク" do
+      create(:artist, name: "Unique Artist")
+      dup = build(:artist, name: "Unique Artist")
+
+      expect(dup).to be_invalid
+    end
+
+    it "spotify_artist_idは22桁Base62のみ許可" do
+      ok = build(:artist, name: "OK", spotify_artist_id: "0OdUWJ0sBjDrqHygGUXeCF")
+      ng = build(:artist, name: "NG", spotify_artist_id: "invalid")
+
+      expect(ok).to be_valid
+      expect(ng).to be_invalid
+    end
+  end
+
+  describe "スコープ" do
+    it ".published は公開のみ返す" do
+      published = create(:artist, name: "Pub", published: true)
+      hidden = create(:artist, name: "Hidden", published: false)
+
+      expect(Artist.published).to include(published)
+      expect(Artist.published).not_to include(hidden)
+    end
+  end
+
+  describe "#to_param" do
+    it "uuidを返す" do
+      artist = create(:artist, name: "A")
+      expect(artist.to_param).to eq(artist.uuid)
+    end
+  end
+end

--- a/spec/models/festival_day_spec.rb
+++ b/spec/models/festival_day_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe FestivalDay, type: :model do
-  describe "#finished?" do
+  describe "開催済み判定" do
     it "フェスの終了日が今日以降ならfalse" do
       festival = create(:festival, start_date: Date.current, end_date: Date.current + 1)
       day = build(:festival_day, festival: festival, date: festival.start_date)
@@ -14,6 +14,21 @@ RSpec.describe FestivalDay, type: :model do
       day = build(:festival_day, festival: festival, date: festival.start_date)
 
       expect(day.finished?(Date.current)).to be true
+    end
+  end
+
+  describe "日付のバリデーション" do
+    it "日付は必須" do
+      day = build(:festival_day, date: nil)
+      expect(day).to be_invalid
+    end
+
+    it "同一フェス内では日付ユニーク" do
+      festival = create(:festival)
+      create(:festival_day, festival: festival, date: festival.start_date)
+      dup = build(:festival_day, festival: festival, date: festival.start_date)
+
+      expect(dup).to be_invalid
     end
   end
 end

--- a/spec/models/festival_festival_tag_spec.rb
+++ b/spec/models/festival_festival_tag_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe FestivalFestivalTag, type: :model do
+  describe "バリデーション" do
+    it "フェスとタグがあれば有効" do
+      expect(build(:festival_festival_tag)).to be_valid
+    end
+
+    it "フェスは必須" do
+      record = build(:festival_festival_tag, festival: nil)
+      expect(record).to be_invalid
+    end
+
+    it "タグは必須" do
+      record = build(:festival_festival_tag, festival_tag: nil)
+      expect(record).to be_invalid
+    end
+  end
+end

--- a/spec/models/festival_spec.rb
+++ b/spec/models/festival_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe Festival, type: :model do
+  describe "バリデーション" do
+    it "デフォルトのファクトリなら有効" do
+      expect(build(:festival)).to be_valid
+    end
+
+    it "必須項目が欠けると無効" do
+      festival = build(:festival, name: nil, slug: nil, start_date: nil, end_date: nil, timezone: nil)
+      expect(festival).to be_invalid
+      expect(festival.errors[:name]).to be_present
+      expect(festival.errors[:slug]).to be_present
+      expect(festival.errors[:start_date]).to be_present
+      expect(festival.errors[:end_date]).to be_present
+      expect(festival.errors[:timezone]).to be_present
+    end
+
+    it "slugはユニーク" do
+      create(:festival, slug: "unique-slug")
+      dup = build(:festival, slug: "unique-slug")
+
+      expect(dup).to be_invalid
+    end
+
+    it "開始日より前の終了日は不可" do
+      festival = build(:festival, start_date: Date.current, end_date: Date.current - 1)
+      expect(festival).to be_invalid
+      expect(festival.errors[:end_date]).to include("は開始日以降にしてください")
+    end
+
+    it "公式URLはhttp/httpsのみ許可" do
+      ok = build(:festival, official_url: "https://example.com")
+      ng = build(:festival, official_url: "ftp://example.com")
+
+      expect(ok).to be_valid
+      expect(ng).to be_invalid
+    end
+  end
+
+  describe "#to_param" do
+    it "slugがあればslugを返す" do
+      festival = build(:festival, slug: "awesome-fes")
+      expect(festival.to_param).to eq("awesome-fes")
+    end
+  end
+end

--- a/spec/models/festival_tag_spec.rb
+++ b/spec/models/festival_tag_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe FestivalTag, type: :model do
+  describe "バリデーション" do
+    it "名前があれば有効" do
+      expect(build(:festival_tag)).to be_valid
+    end
+
+    it "名前は必須でユニーク" do
+      create(:festival_tag, name: "Rock")
+      dup = build(:festival_tag, name: "Rock")
+
+      expect(dup).to be_invalid
+    end
+  end
+end

--- a/spec/models/setlist_song_spec.rb
+++ b/spec/models/setlist_song_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe SetlistSong, type: :model do
+  describe "バリデーション" do
+    it "セットリストと曲があれば有効" do
+      expect(build(:setlist_song)).to be_valid
+    end
+
+    it "セットリストは必須" do
+      record = build(:setlist_song, setlist: nil)
+      expect(record).to be_invalid
+    end
+
+    it "曲は必須" do
+      record = build(:setlist_song, song: nil)
+      expect(record).to be_invalid
+    end
+
+    it "positionは1以上の整数" do
+      negative = build(:setlist_song, position: 0)
+      float = build(:setlist_song, position: 1.5)
+
+      expect(negative).to be_invalid
+      expect(float).to be_invalid
+    end
+
+    it "同じセットリスト内でpositionはユニーク" do
+      setlist = create(:setlist)
+      create(:setlist_song, setlist: setlist, position: 1)
+
+      dup = build(:setlist_song, setlist: setlist, position: 1)
+      expect(dup).to be_invalid
+    end
+  end
+end

--- a/spec/models/setlist_spec.rb
+++ b/spec/models/setlist_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe Setlist, type: :model do
+  describe "バリデーション" do
+    it "出演枠があれば有効" do
+      expect(build(:setlist)).to be_valid
+    end
+
+    it "出演枠は必須" do
+      setlist = build(:setlist, stage_performance: nil)
+      expect(setlist).to be_invalid
+    end
+
+    it "出演枠ごとに1つだけ持てる" do
+      perf = create(:stage_performance)
+      create(:setlist, stage_performance: perf)
+
+      dup = build(:setlist, stage_performance: perf)
+      expect(dup).to be_invalid
+    end
+  end
+
+  describe "#to_param" do
+    it "uuidがあればuuidを返す" do
+      setlist = create(:setlist)
+      expect(setlist.to_param).to eq(setlist.uuid)
+    end
+  end
+end

--- a/spec/models/song_spec.rb
+++ b/spec/models/song_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe Song, type: :model do
+  describe "バリデーション" do
+    it "アーティストと名前があれば有効" do
+      expect(build(:song)).to be_valid
+    end
+
+    it "名前は必須で正規化後も必須" do
+      song = build(:song, name: nil)
+      expect(song).to be_invalid
+    end
+
+    it "同一アーティスト内で正規化名がユニーク" do
+      artist = create(:artist)
+      create(:song, artist: artist, name: "Hello")
+      dup = build(:song, artist: artist, name: "hello")
+
+      expect(dup).to be_invalid
+    end
+
+    it "spotify_idは22桁Base62のみ許可" do
+      ok = build(:song, spotify_id: "0OdUWJ0sBjDrqHygGUXeCF")
+      ng = build(:song, spotify_id: "invalid")
+
+      expect(ok).to be_valid
+      expect(ng).to be_invalid
+    end
+  end
+end

--- a/spec/models/stage_performance_spec.rb
+++ b/spec/models/stage_performance_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe StagePerformance, type: :model do
+  describe "バリデーション" do
+    it "draftならステージ/時間なしでも有効" do
+      expect(build(:stage_performance, status: :draft)).to be_valid
+    end
+
+    it "scheduledならステージと時間が必須" do
+      perf = build(:stage_performance, :scheduled, stage: nil, starts_at: nil, ends_at: nil)
+      expect(perf).to be_invalid
+      expect(perf.errors[:stage]).to be_present
+      expect(perf.errors[:starts_at]).to be_present
+      expect(perf.errors[:ends_at]).to be_present
+    end
+
+    it "終了時刻は開始後でないと無効" do
+      perf = build(:stage_performance, :scheduled,
+                   starts_at: Time.zone.now.change(hour: 12),
+                   ends_at: Time.zone.now.change(hour: 11))
+      expect(perf).to be_invalid
+      expect(perf.errors[:ends_at]).to include("は開始より後にしてください")
+    end
+  end
+end

--- a/spec/models/stage_spec.rb
+++ b/spec/models/stage_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe Stage, type: :model do
+  describe "バリデーション" do
+    it "名前とフェスがあれば有効" do
+      expect(build(:stage)).to be_valid
+    end
+
+    it "名前は必須" do
+      stage = build(:stage, name: nil)
+      expect(stage).to be_invalid
+    end
+
+    it "色キーは定義済みのみ許可" do
+      ok = build(:stage, color_key: "red")
+      ng = build(:stage, color_key: "unknown")
+
+      expect(ok).to be_valid
+      expect(ng).to be_invalid
+    end
+  end
+end

--- a/spec/models/user_artist_favorite_spec.rb
+++ b/spec/models/user_artist_favorite_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe UserArtistFavorite, type: :model do
+  describe "バリデーション" do
+    it "ユーザーとアーティストがあれば有効" do
+      expect(build(:user_artist_favorite)).to be_valid
+    end
+
+    it "ユーザーは必須" do
+      fav = build(:user_artist_favorite, user: nil)
+      expect(fav).to be_invalid
+    end
+
+    it "アーティストは必須" do
+      fav = build(:user_artist_favorite, artist: nil)
+      expect(fav).to be_invalid
+    end
+
+    it "同じ組み合わせは重複不可" do
+      user = create(:user)
+      artist = create(:artist)
+      create(:user_artist_favorite, user: user, artist: artist)
+
+      dup = build(:user_artist_favorite, user: user, artist: artist)
+      expect(dup).to be_invalid
+    end
+  end
+end

--- a/spec/models/user_festival_favorite_spec.rb
+++ b/spec/models/user_festival_favorite_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe UserFestivalFavorite, type: :model do
+  describe "バリデーション" do
+    it "ユーザーとフェスがあれば有効" do
+      expect(build(:user_festival_favorite)).to be_valid
+    end
+
+    it "ユーザーは必須" do
+      fav = build(:user_festival_favorite, user: nil)
+      expect(fav).to be_invalid
+    end
+
+    it "フェスは必須" do
+      fav = build(:user_festival_favorite, festival: nil)
+      expect(fav).to be_invalid
+    end
+
+    it "同じ組み合わせは重複不可" do
+      user = create(:user)
+      festival = create(:festival)
+      create(:user_festival_favorite, user: user, festival: festival)
+
+      dup = build(:user_festival_favorite, user: user, festival: festival)
+      expect(dup).to be_invalid
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe User, type: :model do
+  describe "バリデーション" do
+    it "デフォルトのファクトリなら有効" do
+      expect(build(:user)).to be_valid
+    end
+
+    it "nicknameは必須で10文字以内" do
+      user = build(:user, nickname: nil)
+      expect(user).to be_invalid
+
+      user.nickname = "a" * 11
+      expect(user).to be_invalid
+    end
+
+    it "emailはユニーク" do
+      email = "dup@example.com"
+      create(:user, email: email)
+      dup = build(:user, email: email)
+
+      expect(dup).to be_invalid
+    end
+
+    it "uidはproviderごとにユニーク" do
+      create(:user, provider: "google", uid: "123")
+      dup = build(:user, provider: "google", uid: "123")
+
+      expect(dup).to be_invalid
+    end
+  end
+
+  describe "#to_param" do
+    it "uuidを返す" do
+      user = create(:user)
+      expect(user.to_param).to eq(user.uuid)
+    end
+  end
+end

--- a/spec/models/user_timetable_entry_spec.rb
+++ b/spec/models/user_timetable_entry_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe UserTimetableEntry, type: :model do
+  describe "バリデーション" do
+    it "ユーザーと出演枠があれば有効" do
+      expect(build(:user_timetable_entry)).to be_valid
+    end
+
+    it "ユーザーは必須" do
+      entry = build(:user_timetable_entry, user: nil)
+      expect(entry).to be_invalid
+    end
+
+    it "出演枠は必須" do
+      entry = build(:user_timetable_entry, stage_performance: nil)
+      expect(entry).to be_invalid
+    end
+
+    it "同じ公演はユーザーごとに一意" do
+      user = create(:user)
+      perf = create(:stage_performance, :scheduled)
+      create(:user_timetable_entry, user: user, stage_performance: perf)
+
+      dup = build(:user_timetable_entry, user: user, stage_performance: perf)
+      expect(dup).to be_invalid
+    end
+  end
+end


### PR DESCRIPTION
## 概要
- モデルのP0/P1領域を中心にファクトリ整備とRSpec追加を進め、持ち物リスト以外の主要ドメインもカバー。
## 実施内容
- FactoryBot: artist/stage/stage_performance/user_festival_favorite/user_artist_favorite/user_timetable_entry/festival_tag/festival_festival_tag/song/setlist/setlist_song などのファクトリを追加。
- RSpec追加（日本語説明）: User/Festival/Artist、フェス日程（開催済み判定＋日付バリデーション統合）、お気に入り系、タイムテーブル系、ステージ、タグ系、セットリスト・曲のバリデーション・ユニーク制約・基本メソッドを網羅。
- テスト実行: docker compose exec web bundle exec rspec spec/models で84件すべて成功。
## 対応Issue
- #86
## 関連Issue
なし
## 特記事項