### PR TITLE
[add]リクエストスペックを追加

### DIFF
--- a/spec/requests/favorites_spec.rb
+++ b/spec/requests/favorites_spec.rb
@@ -1,0 +1,111 @@
+require "rails_helper"
+
+RSpec.describe "お気に入りのリクエスト", type: :request do
+  describe "POST /festivals/:festival_id/favorite" do
+    let(:user) { create(:user) }
+    let(:festival) { create(:festival) }
+
+    context "ログイン済みのとき" do
+      before { sign_in user, scope: :user }
+
+      it "フェスのお気に入りを登録し、JSONで201を返す" do
+        expect {
+          post festival_favorite_path(festival), as: :json
+        }.to change { user.user_festival_favorites.count }.by(1)
+
+        expect(response).to have_http_status(:created)
+        expect(response.parsed_body).to include(
+          "festival_id" => festival.id,
+          "favorited" => true
+        )
+      end
+    end
+
+    context "未ログインのとき" do
+      it "401 を返し、登録されない" do
+        expect {
+          post festival_favorite_path(festival), as: :json
+        }.not_to change(UserFestivalFavorite, :count)
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.parsed_body["error"]).to include("ログイン")
+      end
+    end
+  end
+
+  describe "DELETE /festivals/:festival_id/favorite" do
+    let(:user) { create(:user) }
+    let(:festival) { create(:festival) }
+    let!(:favorite) { create(:user_festival_favorite, user: user, festival: festival) }
+
+    context "ログイン済みのとき" do
+      before { sign_in user, scope: :user }
+
+      it "フェスのお気に入りを削除し、JSONで200を返す" do
+        expect {
+          delete festival_favorite_path(festival), as: :json
+        }.to change { user.user_festival_favorites.count }.by(-1)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to include(
+          "festival_id" => festival.id,
+          "favorited" => false
+        )
+      end
+    end
+  end
+
+  describe "POST /artists/:artist_id/favorite" do
+    let(:user) { create(:user) }
+    let(:artist) { create(:artist) }
+
+    context "ログイン済みのとき" do
+      before { sign_in user, scope: :user }
+
+      it "アーティストのお気に入りを登録し、JSONで201を返す" do
+        expect {
+          post artist_favorite_path(artist), as: :json
+        }.to change { user.user_artist_favorites.count }.by(1)
+
+        expect(response).to have_http_status(:created)
+        expect(response.parsed_body).to include(
+          "artist_id" => artist.id,
+          "favorited" => true
+        )
+      end
+    end
+
+    context "未ログインのとき" do
+      it "401 を返し、登録されない" do
+        expect {
+          post artist_favorite_path(artist), as: :json
+        }.not_to change(UserArtistFavorite, :count)
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.parsed_body["error"]).to include("ログイン")
+      end
+    end
+  end
+
+  describe "DELETE /artists/:artist_id/favorite" do
+    let(:user) { create(:user) }
+    let(:artist) { create(:artist) }
+    let!(:favorite) { create(:user_artist_favorite, user: user, artist: artist) }
+
+    context "ログイン済みのとき" do
+      before { sign_in user, scope: :user }
+
+      it "アーティストのお気に入りを削除し、JSONで200を返す" do
+        expect {
+          delete artist_favorite_path(artist), as: :json
+        }.to change { user.user_artist_favorites.count }.by(-1)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to include(
+          "artist_id" => artist.id,
+          "favorited" => false
+        )
+      end
+    end
+  end
+end

--- a/spec/requests/my_timetables_spec.rb
+++ b/spec/requests/my_timetables_spec.rb
@@ -1,0 +1,80 @@
+require "rails_helper"
+
+RSpec.describe "マイタイムテーブルのリクエスト", type: :request do
+  let(:festival) { create(:festival) }
+  let!(:festival_day) { create(:festival_day, festival: festival, date: festival.start_date) }
+  let!(:stage) { create(:stage, festival: festival) }
+  let!(:stage_performance) do
+    create(:stage_performance, :scheduled, festival_day: festival_day, stage: stage, artist: create(:artist))
+  end
+
+  describe "GET /festivals/:festival_id/my_timetable" do
+    let(:owner) { create(:user) }
+    let!(:entry) { create(:user_timetable_entry, user: owner, stage_performance: stage_performance) }
+
+    it "ユーザーID付きで閲覧でき、200を返す" do
+      get festival_my_timetable_path(festival, date: festival_day.date.to_s, user_id: owner.uuid)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /festivals/:festival_id/my_timetable/edit" do
+    let(:user) { create(:user) }
+
+    it "ログイン済みなら編集画面を表示できる" do
+      sign_in user
+
+      get edit_festival_my_timetable_path(festival, date: festival_day.date.to_s)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "PATCH /festivals/:festival_id/my_timetable" do
+    let(:user) { create(:user) }
+
+    it "選択した公演を登録して詳細へリダイレクトする" do
+      sign_in user
+
+      expect {
+        patch festival_my_timetable_path(festival, date: festival_day.date.to_s),
+              params: { stage_performance_ids: [ stage_performance.id ] }
+      }.to change { user.user_timetable_entries.count }.by(1)
+
+      expect(response).to redirect_to(
+        festival_my_timetable_path(festival, date: festival_day.date.to_s, user_id: user.uuid)
+      )
+    end
+  end
+
+  describe "DELETE /festivals/:festival_id/my_timetable" do
+    let(:user) { create(:user) }
+    let!(:entry) { create(:user_timetable_entry, user: user, stage_performance: stage_performance) }
+
+    it "その日の選択を削除して一覧へリダイレクトする" do
+      sign_in user
+
+      expect {
+        delete festival_my_timetable_path(festival, date: festival_day.date.to_s)
+      }.to change {
+        user.user_timetable_entries.joins(:stage_performance).where(stage_performances: { festival_day_id: festival_day.id }).count
+      }.from(1).to(0)
+
+      expect(response).to redirect_to(my_timetables_path)
+    end
+  end
+
+  describe "GET /my_timetables" do
+    let(:user) { create(:user) }
+    let!(:entry) { create(:user_timetable_entry, user: user, stage_performance: stage_performance) }
+
+    it "ログイン済みなら一覧を表示できる" do
+      sign_in user
+
+      get my_timetables_path
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/requests/packing_list_items_spec.rb
+++ b/spec/requests/packing_list_items_spec.rb
@@ -1,0 +1,79 @@
+require "rails_helper"
+
+RSpec.describe "持ち物リスト項目のリクエスト", type: :request do
+  let(:user) { create(:user) }
+  let(:packing_list) { create(:packing_list, user: user) }
+  let(:item) { create(:item, user: user) }
+
+  describe "POST /packing_lists/:packing_list_id/packing_list_items" do
+    context "ログイン済みのとき" do
+      before { sign_in user }
+
+      it "項目を追加してリストへリダイレクトする" do
+        expect {
+          post packing_list_packing_list_items_path(packing_list),
+               params: { packing_list_item: { item_id: item.id, note: "メモ", position: 1 } }
+        }.to change { packing_list.packing_list_items.count }.by(1)
+
+        expect(response).to redirect_to(packing_list_path(packing_list))
+        created_item = packing_list.packing_list_items.order(:created_at).last
+        expect(created_item.note).to eq("メモ")
+        expect(created_item.position).to eq(1)
+      end
+    end
+
+    context "未ログインのとき" do
+      it "ログイン画面へリダイレクトし、追加されない" do
+        expect {
+          post packing_list_packing_list_items_path(packing_list),
+               params: { packing_list_item: { item_id: item.id } }
+        }.not_to change(PackingListItem, :count)
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "PATCH /packing_lists/:packing_list_id/packing_list_items/:id" do
+    let!(:packing_list_item) { create(:packing_list_item, packing_list: packing_list, item: item, note: "旧メモ", position: 0) }
+
+    it "項目の内容を更新してリストへリダイレクトする" do
+      sign_in user
+
+      patch packing_list_packing_list_item_path(packing_list, packing_list_item),
+            params: { packing_list_item: { note: "新しいメモ", position: 2 } }
+
+      expect(response).to redirect_to(packing_list_path(packing_list))
+      packing_list_item.reload
+      expect(packing_list_item.note).to eq("新しいメモ")
+      expect(packing_list_item.position).to eq(2)
+    end
+  end
+
+  describe "PATCH /packing_lists/:packing_list_id/packing_list_items/:id/toggle" do
+    let!(:packing_list_item) { create(:packing_list_item, packing_list: packing_list, item: item, checked: false) }
+
+    it "チェック状態をトグルしてリストへリダイレクトする" do
+      sign_in user
+
+      patch toggle_packing_list_packing_list_item_path(packing_list, packing_list_item)
+
+      expect(response).to redirect_to(packing_list_path(packing_list))
+      expect(packing_list_item.reload.checked).to be(true)
+    end
+  end
+
+  describe "DELETE /packing_lists/:packing_list_id/packing_list_items/:id" do
+    let!(:packing_list_item) { create(:packing_list_item, packing_list: packing_list, item: item) }
+
+    it "項目を削除してリストへリダイレクトする" do
+      sign_in user
+
+      expect {
+        delete packing_list_packing_list_item_path(packing_list, packing_list_item)
+      }.to change { packing_list.packing_list_items.count }.by(-1)
+
+      expect(response).to redirect_to(packing_list_path(packing_list))
+    end
+  end
+end

--- a/spec/requests/packing_lists_spec.rb
+++ b/spec/requests/packing_lists_spec.rb
@@ -1,0 +1,92 @@
+require "rails_helper"
+
+RSpec.describe "持ち物リストのリクエスト", type: :request do
+  describe "POST /packing_lists" do
+    let(:user) { create(:user) }
+    let(:params) do
+      {
+        packing_list: {
+          title: "遠征用リスト",
+          packing_list_items_attributes: {
+            "0" => {
+              position: 0,
+              note: "雨用の装備",
+              item_attributes: { name: "タオル" }
+            }
+          }
+        }
+      }
+    end
+
+    context "ログイン済みのとき" do
+      before { sign_in user }
+
+      it "新しい持ち物リストとアイテムを作成して詳細ページへリダイレクトする" do
+        expect {
+          post packing_lists_path, params: params
+        }.to change(PackingList, :count).by(1)
+          .and change(Item, :count).by(1)
+
+        created_list = PackingList.order(:created_at).last
+        expect(response).to redirect_to(packing_list_path(created_list))
+        expect(created_list.user).to eq(user)
+        expect(created_list.template).to be(false)
+
+        created_item = created_list.packing_list_items.first.item
+        expect(created_item.user).to eq(user)
+        expect(created_item.template).to be(false)
+        expect(created_item.name).to eq("タオル")
+      end
+    end
+
+    context "未ログインのとき" do
+      it "ログイン画面へリダイレクトし、作成されない" do
+        expect {
+          post packing_lists_path, params: params
+        }.not_to change(PackingList, :count)
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "POST /packing_lists/:id/duplicate_from_template" do
+    let(:user) { create(:user) }
+    let!(:template_item) { create(:template_item, name: "レインコート") }
+    let!(:template_list) do
+      create(:template_packing_list, title: "夏フェス基本セット").tap do |list|
+        create(:packing_list_item, packing_list: list, item: template_item, position: 1, note: "必須")
+      end
+    end
+
+    before { sign_in user }
+
+    it "テンプレートからリストとアイテムを複製して詳細ページへリダイレクトする" do
+      expect {
+        post duplicate_from_template_packing_list_path(template_list)
+      }.to change { user.packing_lists.count }.by(1)
+        .and change(PackingListItem, :count).by(1)
+
+      new_list = user.packing_lists.order(:created_at).last
+      expect(response).to redirect_to(packing_list_path(new_list))
+      expect(new_list.title).to eq(template_list.title)
+      expect(new_list.template).to be(false)
+
+      duplicated_item = new_list.packing_list_items.first
+      expect(duplicated_item.item).to eq(template_item)
+      expect(duplicated_item.position).to eq(1)
+      expect(duplicated_item.note).to eq("必須")
+    end
+
+    it "テンプレートでない場合は複製せず一覧へリダイレクトする" do
+      owned_list = create(:packing_list, user: user, template: false)
+      create(:packing_list_item, packing_list: owned_list, item: create(:item, user: user))
+
+      expect {
+        post duplicate_from_template_packing_list_path(owned_list)
+      }.not_to change(PackingList, :count)
+
+      expect(response).to redirect_to(packing_lists_path)
+    end
+  end
+end

--- a/spec/requests/public_pages_spec.rb
+++ b/spec/requests/public_pages_spec.rb
@@ -1,0 +1,101 @@
+require "rails_helper"
+
+RSpec.describe "公開ページのリクエスト", type: :request do
+  describe "トップと基本ページ" do
+    it "トップページが200を返す" do
+      get root_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "フェス・アーティストの一覧/詳細" do
+    let!(:festival) { create(:festival) }
+    let!(:festival_day) { create(:festival_day, festival: festival) }
+    let!(:artist) { create(:artist) }
+
+    it "フェス一覧が200を返す" do
+      get festivals_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "フェス詳細が200を返す" do
+      get festival_path(festival)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "アーティスト一覧が200を返す" do
+      get artists_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "アーティスト詳細が200を返す" do
+      get artist_path(artist)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "タイムテーブルの一覧/詳細" do
+    let!(:timetable_festival) { create(:festival, timetable_published: true) }
+    let!(:timetable_day) { create(:festival_day, festival: timetable_festival, date: timetable_festival.start_date) }
+    let!(:stage) { create(:stage, festival: timetable_festival) }
+    let!(:performance) do
+      create(:stage_performance, :scheduled, festival_day: timetable_day, stage: stage, artist: create(:artist))
+    end
+
+    it "タイムテーブル一覧が200を返す" do
+      get timetables_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "タイムテーブル詳細が200を返す" do
+      get timetable_path(timetable_festival, date: timetable_day.date.to_s)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "セットリスト詳細" do
+    let!(:festival) { create(:festival, timetable_published: true) }
+    let!(:festival_day) { create(:festival_day, festival: festival, date: festival.start_date) }
+    let!(:stage) { create(:stage, festival: festival) }
+    let!(:performance) do
+      create(:stage_performance, :scheduled, festival_day: festival_day, stage: stage, artist: create(:artist))
+    end
+    let!(:setlist) { create(:setlist, stage_performance: performance) }
+
+    it "セットリスト詳細が200を返す" do
+      get setlist_path(setlist)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "準備ページとプレップ用一覧/詳細" do
+    let!(:prep_festival) { create(:festival, timetable_published: true) }
+    let!(:prep_festival_day) { create(:festival_day, festival: prep_festival, date: prep_festival.start_date) }
+    let!(:prep_artist) { create(:artist) }
+
+    it "準備トップが200を返す" do
+      get prep_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "プレップ用フェス一覧が200を返す" do
+      get prep_festivals_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "プレップ用フェス詳細が200を返す" do
+      get prep_festival_path(prep_festival, date: prep_festival_day.date.to_s)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "プレップ用アーティスト一覧が200を返す" do
+      get prep_artists_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "プレップ用アーティスト詳細が200を返す" do
+      get prep_artist_path(prep_artist)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -1,0 +1,4 @@
+RSpec.configure do |config|
+  # Devise のログインヘルパーをリクエストスペックで使う
+  config.include Devise::Test::IntegrationHelpers, type: :request
+end


### PR DESCRIPTION
## 概要
- リクエストスペックを追加し、主要ユーザ向け機能のエンドツーエンド動作（ルーティング/認証/副作用）を網羅的に検証できるようにした。
## 実施内容
- spec/support/devise.rb: Devise::Test::IntegrationHelpers をリクエストスペックにインクルード。
- spec/requests/packing_lists_spec.rb: 持ち物リスト作成とテンプレート複製のリクエストテストを追加。
- spec/requests/favorites_spec.rb: フェス/アーティストのお気に入り登録・解除を JSON で検証、sign_in scope: :user に修正、未ログイン時は 401 を期待。
- spec/requests/my_timetables_spec.rb: マイタイムテーブルの表示・編集・保存・削除・一覧をカバー。
- spec/requests/packing_list_items_spec.rb: 持ち物リスト項目の追加/更新/削除/チェック切替を検証。
- spec/requests/public_pages_spec.rb: トップ/フェス・アーティスト一覧と詳細/タイムテーブル一覧と詳細/セットリスト詳細/prep 系ページの 200 応答確認。
## 対応Issue
- #86 
## 関連Issue
なし
## 特記事項