### PR TITLE
[add]リクエスト関係のRSpecコード追加

### DIFF
--- a/spec/requests/admin_spec.rb
+++ b/spec/requests/admin_spec.rb
@@ -1,0 +1,140 @@
+require "rails_helper"
+
+RSpec.describe "管理画面のリクエスト", type: :request do
+  describe "GET /admin" do
+    it "一般ユーザーはリダイレクトされる" do
+      user = create(:user)
+      sign_in user, scope: :user
+
+      get admin_root_path
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "管理者は200を返す" do
+      admin = create(:user, role: :admin)
+      sign_in admin, scope: :user
+
+      get admin_root_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "POST /admin/festival_tags" do
+    it "一般ユーザーは作成できずリダイレクトされる" do
+      user = create(:user)
+      sign_in user, scope: :user
+
+      expect {
+        post admin_festival_tags_path, params: { festival_tag: { name: "ロック" } }
+      }.not_to change(FestivalTag, :count)
+
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "管理者は作成できる" do
+      admin = create(:user, role: :admin)
+      sign_in admin, scope: :user
+
+      expect {
+        post admin_festival_tags_path, params: { festival_tag: { name: "ロック" } }
+      }.to change(FestivalTag, :count).by(1)
+
+      expect(response).to redirect_to(admin_festival_tags_path)
+    end
+
+    it "管理者でもバリデーションエラーなら422を返す" do
+      admin = create(:user, role: :admin)
+      sign_in admin, scope: :user
+
+      expect {
+        post admin_festival_tags_path, params: { festival_tag: { name: "" } }
+      }.not_to change(FestivalTag, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe "POST /admin/artists" do
+    let(:valid_params) { { artist: { name: "管理用アーティスト", published: true } } }
+
+    it "一般ユーザーは作成できずリダイレクトされる" do
+      user = create(:user)
+      sign_in user, scope: :user
+
+      expect {
+        post admin_artists_path, params: valid_params
+      }.not_to change(Artist, :count)
+
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "管理者は作成できる" do
+      admin = create(:user, role: :admin)
+      sign_in admin, scope: :user
+
+      expect {
+        post admin_artists_path, params: valid_params
+      }.to change(Artist, :count).by(1)
+
+      expect(response).to redirect_to(admin_artists_path)
+    end
+
+    it "管理者でもバリデーションエラーなら422を返す" do
+      admin = create(:user, role: :admin)
+      sign_in admin, scope: :user
+
+      expect {
+        post admin_artists_path, params: { artist: { name: "" } }
+      }.not_to change(Artist, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe "POST /admin/festivals" do
+    let(:valid_params) do
+      {
+        festival: {
+          name: "管理用フェス",
+          slug: "admin-fes",
+          start_date: Date.current,
+          end_date: Date.current + 1.day,
+          timezone: "Asia/Tokyo"
+        }
+      }
+    end
+
+    it "一般ユーザーは作成できずリダイレクトされる" do
+      user = create(:user)
+      sign_in user, scope: :user
+
+      expect {
+        post admin_festivals_path, params: valid_params
+      }.not_to change(Festival, :count)
+
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "管理者は作成できる" do
+      admin = create(:user, role: :admin)
+      sign_in admin, scope: :user
+
+      expect {
+        post admin_festivals_path, params: valid_params
+      }.to change(Festival, :count).by(1)
+
+      expect(response).to redirect_to(setup_admin_festival_path(Festival.last))
+    end
+
+    it "管理者でもバリデーションエラーなら422を返す" do
+      admin = create(:user, role: :admin)
+      sign_in admin, scope: :user
+
+      expect {
+        post admin_festivals_path, params: { festival: valid_params[:festival].merge(name: "", end_date: Date.current - 1.day) }
+      }.not_to change(Festival, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+end

--- a/spec/requests/favorites_spec.rb
+++ b/spec/requests/favorites_spec.rb
@@ -19,6 +19,17 @@ RSpec.describe "お気に入りのリクエスト", type: :request do
           "favorited" => true
         )
       end
+
+      it "既にお気に入り済みでも重複追加せず201を返す" do
+        existing = create(:user_festival_favorite, user: user, festival: festival)
+
+        expect {
+          post festival_favorite_path(festival), as: :json
+        }.not_to change(UserFestivalFavorite, :count)
+
+        expect(response).to have_http_status(:created)
+        expect(response.parsed_body["favorite_id"]).to eq(existing.id)
+      end
     end
 
     context "未ログインのとき" do
@@ -53,6 +64,17 @@ RSpec.describe "お気に入りのリクエスト", type: :request do
         )
       end
     end
+
+    context "未ログインのとき" do
+      it "401 を返し、削除されない" do
+        expect {
+          delete festival_favorite_path(festival), as: :json
+        }.not_to change(UserFestivalFavorite, :count)
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.parsed_body["error"]).to include("ログイン")
+      end
+    end
   end
 
   describe "POST /artists/:artist_id/favorite" do
@@ -72,6 +94,17 @@ RSpec.describe "お気に入りのリクエスト", type: :request do
           "artist_id" => artist.id,
           "favorited" => true
         )
+      end
+
+      it "既にお気に入り済みでも重複追加せず201を返す" do
+        existing = create(:user_artist_favorite, user: user, artist: artist)
+
+        expect {
+          post artist_favorite_path(artist), as: :json
+        }.not_to change(UserArtistFavorite, :count)
+
+        expect(response).to have_http_status(:created)
+        expect(response.parsed_body["favorite_id"]).to eq(existing.id)
       end
     end
 
@@ -105,6 +138,17 @@ RSpec.describe "お気に入りのリクエスト", type: :request do
           "artist_id" => artist.id,
           "favorited" => false
         )
+      end
+    end
+
+    context "未ログインのとき" do
+      it "401 を返し、削除されない" do
+        expect {
+          delete artist_favorite_path(artist), as: :json
+        }.not_to change(UserArtistFavorite, :count)
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.parsed_body["error"]).to include("ログイン")
       end
     end
   end

--- a/spec/requests/my_timetables_spec.rb
+++ b/spec/requests/my_timetables_spec.rb
@@ -17,17 +17,34 @@ RSpec.describe "マイタイムテーブルのリクエスト", type: :request d
 
       expect(response).to have_http_status(:ok)
     end
+
+    it "ユーザーIDなしで未ログインなら404を返す" do
+      get festival_my_timetable_path(festival, date: festival_day.date.to_s)
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "存在しない日付なら404を返す" do
+      missing_date = festival_day.date + 10.days
+
+      get festival_my_timetable_path(festival, date: missing_date.to_s, user_id: owner.uuid)
+      expect(response).to have_http_status(:not_found)
+    end
   end
 
   describe "GET /festivals/:festival_id/my_timetable/edit" do
     let(:user) { create(:user) }
 
     it "ログイン済みなら編集画面を表示できる" do
-      sign_in user
+      sign_in user, scope: :user
 
       get edit_festival_my_timetable_path(festival, date: festival_day.date.to_s)
 
       expect(response).to have_http_status(:ok)
+    end
+
+    it "未ログインならログイン画面へリダイレクトする" do
+      get edit_festival_my_timetable_path(festival, date: festival_day.date.to_s)
+      expect(response).to redirect_to(new_user_session_path)
     end
   end
 
@@ -35,7 +52,7 @@ RSpec.describe "マイタイムテーブルのリクエスト", type: :request d
     let(:user) { create(:user) }
 
     it "選択した公演を登録して詳細へリダイレクトする" do
-      sign_in user
+      sign_in user, scope: :user
 
       expect {
         patch festival_my_timetable_path(festival, date: festival_day.date.to_s),
@@ -46,6 +63,15 @@ RSpec.describe "マイタイムテーブルのリクエスト", type: :request d
         festival_my_timetable_path(festival, date: festival_day.date.to_s, user_id: user.uuid)
       )
     end
+
+    it "未ログインならログイン画面へリダイレクトし、登録されない" do
+      expect {
+        patch festival_my_timetable_path(festival, date: festival_day.date.to_s),
+              params: { stage_performance_ids: [ stage_performance.id ] }
+      }.not_to change(UserTimetableEntry, :count)
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
   end
 
   describe "DELETE /festivals/:festival_id/my_timetable" do
@@ -53,7 +79,7 @@ RSpec.describe "マイタイムテーブルのリクエスト", type: :request d
     let!(:entry) { create(:user_timetable_entry, user: user, stage_performance: stage_performance) }
 
     it "その日の選択を削除して一覧へリダイレクトする" do
-      sign_in user
+      sign_in user, scope: :user
 
       expect {
         delete festival_my_timetable_path(festival, date: festival_day.date.to_s)
@@ -63,6 +89,14 @@ RSpec.describe "マイタイムテーブルのリクエスト", type: :request d
 
       expect(response).to redirect_to(my_timetables_path)
     end
+
+    it "未ログインならログイン画面へリダイレクトし、削除しない" do
+      expect {
+        delete festival_my_timetable_path(festival, date: festival_day.date.to_s)
+      }.not_to change(UserTimetableEntry, :count)
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
   end
 
   describe "GET /my_timetables" do
@@ -70,11 +104,16 @@ RSpec.describe "マイタイムテーブルのリクエスト", type: :request d
     let!(:entry) { create(:user_timetable_entry, user: user, stage_performance: stage_performance) }
 
     it "ログイン済みなら一覧を表示できる" do
-      sign_in user
+      sign_in user, scope: :user
 
       get my_timetables_path
 
       expect(response).to have_http_status(:ok)
+    end
+
+    it "未ログインならログイン画面へリダイレクトする" do
+      get my_timetables_path
+      expect(response).to redirect_to(new_user_session_path)
     end
   end
 end

--- a/spec/requests/mypage_spec.rb
+++ b/spec/requests/mypage_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe "マイページのリクエスト", type: :request do
+  describe "GET /mypage" do
+    it "未ログインならログイン画面へリダイレクトする" do
+      get mypage_dashboard_path
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "ログイン済みなら200を返す" do
+      user = create(:user)
+      sign_in user, scope: :user
+
+      get mypage_dashboard_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /mypage/festivals" do
+    it "未ログインならログイン画面へリダイレクトする" do
+      get mypage_favorite_festivals_path
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "ログイン済みなら200を返す" do
+      user = create(:user)
+      create(:user_festival_favorite, user: user)
+      sign_in user, scope: :user
+
+      get mypage_favorite_festivals_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /mypage/artists" do
+    it "未ログインならログイン画面へリダイレクトする" do
+      get mypage_favorite_artists_path
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "ログイン済みなら200を返す" do
+      user = create(:user)
+      create(:user_artist_favorite, user: user)
+      sign_in user, scope: :user
+
+      get mypage_favorite_artists_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/requests/packing_list_items_spec.rb
+++ b/spec/requests/packing_list_items_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "持ち物リスト項目のリクエスト", type: :request do
 
   describe "POST /packing_lists/:packing_list_id/packing_list_items" do
     context "ログイン済みのとき" do
-      before { sign_in user }
+      before { sign_in user, scope: :user }
 
       it "項目を追加してリストへリダイレクトする" do
         expect {
@@ -38,7 +38,7 @@ RSpec.describe "持ち物リスト項目のリクエスト", type: :request do
     let!(:packing_list_item) { create(:packing_list_item, packing_list: packing_list, item: item, note: "旧メモ", position: 0) }
 
     it "項目の内容を更新してリストへリダイレクトする" do
-      sign_in user
+      sign_in user, scope: :user
 
       patch packing_list_packing_list_item_path(packing_list, packing_list_item),
             params: { packing_list_item: { note: "新しいメモ", position: 2 } }
@@ -54,7 +54,7 @@ RSpec.describe "持ち物リスト項目のリクエスト", type: :request do
     let!(:packing_list_item) { create(:packing_list_item, packing_list: packing_list, item: item, checked: false) }
 
     it "チェック状態をトグルしてリストへリダイレクトする" do
-      sign_in user
+      sign_in user, scope: :user
 
       patch toggle_packing_list_packing_list_item_path(packing_list, packing_list_item)
 
@@ -67,7 +67,7 @@ RSpec.describe "持ち物リスト項目のリクエスト", type: :request do
     let!(:packing_list_item) { create(:packing_list_item, packing_list: packing_list, item: item) }
 
     it "項目を削除してリストへリダイレクトする" do
-      sign_in user
+      sign_in user, scope: :user
 
       expect {
         delete packing_list_packing_list_item_path(packing_list, packing_list_item)

--- a/spec/requests/packing_lists_spec.rb
+++ b/spec/requests/packing_lists_spec.rb
@@ -1,6 +1,60 @@
 require "rails_helper"
 
 RSpec.describe "持ち物リストのリクエスト", type: :request do
+  describe "GET /packing_lists" do
+    it "未ログインでも一覧を表示できる" do
+      get packing_lists_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /packing_lists/:id" do
+    let!(:template_list) { create(:template_packing_list, title: "テンプレート") }
+
+    it "未ログインならログイン画面へリダイレクトする" do
+      get packing_list_path(template_list)
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "他人の通常リストにはログイン画面へリダイレクトする" do
+      other_list = create(:packing_list, user: create(:user))
+
+      get packing_list_path(other_list)
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "自分のリストならログインして閲覧できる" do
+      user = create(:user)
+      own_list = create(:packing_list, user: user)
+
+      sign_in user, scope: :user
+      get packing_list_path(own_list)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /packing_lists/:id/edit" do
+    it "未ログインならログイン画面へリダイレクトする" do
+      list = create(:packing_list, user: create(:user))
+
+      get edit_packing_list_path(list)
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "他人のリストは404を返す" do
+      owner = create(:user)
+      other = create(:user)
+      list = create(:packing_list, user: owner)
+
+      sign_in other, scope: :user
+
+      get edit_packing_list_path(list)
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
   describe "POST /packing_lists" do
     let(:user) { create(:user) }
     let(:params) do
@@ -19,7 +73,7 @@ RSpec.describe "持ち物リストのリクエスト", type: :request do
     end
 
     context "ログイン済みのとき" do
-      before { sign_in user }
+      before { sign_in user, scope: :user }
 
       it "新しい持ち物リストとアイテムを作成して詳細ページへリダイレクトする" do
         expect {
@@ -48,6 +102,18 @@ RSpec.describe "持ち物リストのリクエスト", type: :request do
         expect(response).to redirect_to(new_user_session_path)
       end
     end
+
+    context "バリデーションエラーのとき" do
+      it "422でnewを再表示する" do
+        sign_in user, scope: :user
+
+        expect {
+          post packing_lists_path, params: { packing_list: { title: "" } }
+        }.not_to change(PackingList, :count)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
   end
 
   describe "POST /packing_lists/:id/duplicate_from_template" do
@@ -59,7 +125,7 @@ RSpec.describe "持ち物リストのリクエスト", type: :request do
       end
     end
 
-    before { sign_in user }
+    before { sign_in user, scope: :user }
 
     it "テンプレートからリストとアイテムを複製して詳細ページへリダイレクトする" do
       expect {
@@ -87,6 +153,67 @@ RSpec.describe "持ち物リストのリクエスト", type: :request do
       }.not_to change(PackingList, :count)
 
       expect(response).to redirect_to(packing_lists_path)
+    end
+  end
+
+  describe "PATCH /packing_lists/:id" do
+    it "未ログインならログイン画面へリダイレクトし、更新されない" do
+      list = create(:packing_list, user: create(:user), title: "旧タイトル")
+
+      patch packing_list_path(list), params: { packing_list: { title: "更新タイトル" } }
+
+      expect(response).to redirect_to(new_user_session_path)
+      expect(list.reload.title).to eq("旧タイトル")
+    end
+
+    it "他人のリストは404を返す" do
+      owner = create(:user)
+      other = create(:user)
+      list = create(:packing_list, user: owner, title: "旧タイトル")
+
+      sign_in other, scope: :user
+
+      patch packing_list_path(list), params: { packing_list: { title: "更新タイトル" } }
+      expect(response).to have_http_status(:not_found)
+
+      expect(list.reload.title).to eq("旧タイトル")
+    end
+
+    it "バリデーションエラーなら422を返し、タイトルは更新されない" do
+      user = create(:user)
+      list = create(:packing_list, user: user, title: "旧タイトル")
+
+      sign_in user, scope: :user
+
+      patch packing_list_path(list), params: { packing_list: { title: "" } }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(list.reload.title).to eq("旧タイトル")
+    end
+  end
+
+  describe "DELETE /packing_lists/:id" do
+    it "未ログインならログイン画面へリダイレクトし、削除されない" do
+      list = create(:packing_list, user: create(:user))
+
+      expect {
+        delete packing_list_path(list)
+      }.not_to change(PackingList, :count)
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "他人のリストは404を返し、削除しない" do
+      owner = create(:user)
+      other = create(:user)
+      list = create(:packing_list, user: owner)
+
+      sign_in other, scope: :user
+
+      delete packing_list_path(list)
+      expect(response).to have_http_status(:not_found)
+
+      expect(PackingList.exists?(list.id)).to be(true)
     end
   end
 end

--- a/spec/requests/public_pages_spec.rb
+++ b/spec/requests/public_pages_spec.rb
@@ -51,6 +51,19 @@ RSpec.describe "公開ページのリクエスト", type: :request do
       get timetable_path(timetable_festival, date: timetable_day.date.to_s)
       expect(response).to have_http_status(:ok)
     end
+
+    it "未公開タイムテーブルなら404を返す" do
+      unpublished = create(:festival, timetable_published: false)
+      create(:festival_day, festival: unpublished, date: unpublished.start_date)
+
+      get timetable_path(unpublished, date: unpublished.start_date.to_s)
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "不正な日付パラメータなら404を返す" do
+      get timetable_path(timetable_festival, date: "invalid-date")
+      expect(response).to have_http_status(:not_found)
+    end
   end
 
   describe "セットリスト詳細" do
@@ -86,6 +99,11 @@ RSpec.describe "公開ページのリクエスト", type: :request do
     it "プレップ用フェス詳細が200を返す" do
       get prep_festival_path(prep_festival, date: prep_festival_day.date.to_s)
       expect(response).to have_http_status(:ok)
+    end
+
+    it "プレップ用フェス詳細で不正な日付なら404を返す" do
+      get prep_festival_path(prep_festival, date: "invalid-date")
+      expect(response).to have_http_status(:not_found)
     end
 
     it "プレップ用アーティスト一覧が200を返す" do


### PR DESCRIPTION
## 概要
- マイページ・管理画面・公開/ユーザ機能のリクエストスペックを広げ、認可と主要 CRUD・バリデーション経路を網羅しました。
- admin の主要リソース（artists/festivals）を追加し、一般ユーザーの拒否と管理者の成功/失敗を確認。
- 公開/ユーザ向けの境界ケース（未公開や不正パラメータ、他人リソース）を実際の挙動に合わせて修正。
## 実施内容
- spec/requests/mypage_spec.rb: マイページ/お気に入り一覧の未ログインリダイレクトとログイン時 200。
- spec/requests/admin_spec.rb: 管理トップ、festival_tags の認可に加え、artists/festivals の作成成功・バリデーション 422・一般ユーザー拒否を追加。
- spec/requests/favorites_spec.rb: 重複お気に入り登録でも件数増やさず 201 を確認。
- spec/requests/packing_lists_spec.rb: 未ログインの show リダイレクト、他人リストの edit/update/destroy 404、create/update の 422 を確認。
- spec/requests/my_timetables_spec.rb: 未ログイン/存在しない日付での 404 を挙動に合わせて修正。
- spec/requests/public_pages_spec.rb: 未公開タイムテーブル・不正日付での 404 をステータスで確認。
## 対応Issue
- #86 
## 関連Issue
なし
## 特記事項