### PR TITLE
[add]サービス関係のRSpec

### DIFF
--- a/spec/services/my_timetables/updater_spec.rb
+++ b/spec/services/my_timetables/updater_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe MyTimetables::Updater do
+  describe ".call" do
+    let(:user) { create(:user) }
+    let(:festival_day) { create(:festival_day) }
+    let(:other_day) { create(:festival_day, festival: festival_day.festival, date: festival_day.date + 1.day) }
+    let!(:existing_same_day_entry) do
+      create(:user_timetable_entry, user: user, stage_performance: create(:stage_performance, :scheduled, festival_day: festival_day))
+    end
+    let!(:existing_other_day_entry) do
+      create(:user_timetable_entry, user: user, stage_performance: create(:stage_performance, :scheduled, festival_day: other_day))
+    end
+    let!(:target_performance) { create(:stage_performance, :scheduled, festival_day: festival_day) }
+
+    it "対象日の選択だけを置き換え、他の日の選択は残す" do
+      described_class.call(
+        user: user,
+        festival_day: festival_day,
+        stage_performance_ids: [ target_performance.id ]
+      )
+
+      same_day_ids = user.user_timetable_entries.joins(:stage_performance).where(stage_performances: { festival_day_id: festival_day.id }).pluck(:stage_performance_id)
+      other_day_ids = user.user_timetable_entries.joins(:stage_performance).where(stage_performances: { festival_day_id: other_day.id }).pluck(:stage_performance_id)
+
+      expect(same_day_ids).to match_array([ target_performance.id ])
+      expect(other_day_ids).to match_array([ existing_other_day_entry.stage_performance_id ])
+    end
+
+    it "重複IDや他の日のIDは無視してユニークに登録する" do
+      another_day_perf = create(:stage_performance, :scheduled)
+
+      described_class.call(
+        user: user,
+        festival_day: festival_day,
+        stage_performance_ids: [ target_performance.id, target_performance.id, another_day_perf.id, 999 ]
+      )
+
+      same_day_ids = user.user_timetable_entries.joins(:stage_performance).where(stage_performances: { festival_day_id: festival_day.id }).pluck(:stage_performance_id)
+      expect(same_day_ids).to match_array([ target_performance.id ])
+    end
+
+    it "作成時に例外が起きたらトランザクションでロールバックされる" do
+      allow_any_instance_of(UserTimetableEntry).to receive(:save!).and_raise(StandardError.new("boom"))
+
+      expect {
+        described_class.call(
+          user: user,
+          festival_day: festival_day,
+          stage_performance_ids: [ target_performance.id ]
+        )
+      }.to raise_error(StandardError)
+
+      # 例外前に削除された既存の当日分も、ロールバックで復元される
+      same_day_ids = user.user_timetable_entries.joins(:stage_performance).where(stage_performances: { festival_day_id: festival_day.id }).pluck(:stage_performance_id)
+      expect(same_day_ids).to include(existing_same_day_entry.stage_performance_id)
+    end
+  end
+end

--- a/spec/services/spotify/client_spec.rb
+++ b/spec/services/spotify/client_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe Spotify::Client do
+  before do
+    stub_const("ENV", ENV.to_hash.merge("SPOTIFY_CLIENT_ID" => "id", "SPOTIFY_CLIENT_SECRET" => "secret"))
+  end
+
+  let(:http) { instance_double(Net::HTTP) }
+  let(:client) { described_class.new }
+
+  describe "#search_artists" do
+    it "トークン取得と検索が成功したら結果をパースして返す" do
+      token_response = instance_double(Net::HTTPSuccess, body: { access_token: "tok" }.to_json, code: "200")
+      allow(token_response).to receive(:is_a?).with(Net::HTTPSuccess).and_return(true)
+
+      search_body = {
+        artists: { items: [ { "id" => "1", "name" => "Artist", "images" => [ { "url" => "img" } ], "genres" => [ "rock" ], "popularity" => 50 } ] }
+      }.to_json
+      search_response = instance_double(Net::HTTPSuccess, body: search_body, code: "200")
+      allow(search_response).to receive(:is_a?).with(Net::HTTPSuccess).and_return(true)
+
+      allow(Net::HTTP).to receive(:start).and_return(http)
+      allow(http).to receive(:request).and_return(token_response, search_response)
+
+      result = client.search_artists(query: "rock")
+
+      expect(result.first[:id]).to eq("1")
+      expect(result.first[:name]).to eq("Artist")
+      expect(result.first[:image_url]).to eq("img")
+    end
+
+    it "検索が失敗したら例外を投げる" do
+      token_response = instance_double(Net::HTTPSuccess, body: { access_token: "tok" }.to_json, code: "200")
+      allow(token_response).to receive(:is_a?).with(Net::HTTPSuccess).and_return(true)
+
+      failed_response = instance_double(Net::HTTPServerError, body: "err", code: "500")
+      allow(failed_response).to receive(:is_a?).with(Net::HTTPSuccess).and_return(false)
+
+      allow(Net::HTTP).to receive(:start).and_return(http)
+      allow(http).to receive(:request).and_return(token_response, failed_response)
+
+      expect {
+        client.search_artists(query: "rock")
+      }.to raise_error(/Spotify search failed/)
+    end
+  end
+end

--- a/spec/services/timeline_context_builder_spec.rb
+++ b/spec/services/timeline_context_builder_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe TimelineContextBuilder do
+  describe ".build" do
+    let(:festival) { create(:festival, timezone: "Asia/Tokyo") }
+    let(:festival_day) { create(:festival_day, festival: festival, date: festival.start_date) }
+
+    it "公演時間からタイムラインの開始・終了を決め、1時間刻みのマーカーを返す" do
+      stage = create(:stage, festival: festival)
+      create(:stage_performance, :scheduled, festival_day: festival_day, stage: stage,
+             starts_at: festival_day.date.to_time.change(hour: 12), ends_at: festival_day.date.to_time.change(hour: 13))
+
+      result = described_class.build(festival: festival, selected_day: festival_day, timezone: ActiveSupport::TimeZone["Asia/Tokyo"])
+
+      expect(result.timeline_start.hour).to eq(12)
+      expect(result.timeline_end.hour).to eq(13)
+      expect(result.time_markers.map(&:hour)).to include(12, 13)
+    end
+
+    it "終了時刻が開始より前なら翌日に補正してタイムラインを作る（徹夜跨ぎ）" do
+      # 22:00開始 02:00終了（同日指定だが内部で+1日される）
+      festival_day.update!(
+        start_at: festival_day.date.to_time.change(hour: 22),
+        end_at: festival_day.date.to_time.change(hour: 2)
+      )
+
+      result = described_class.build(festival: festival, selected_day: festival_day, timezone: ActiveSupport::TimeZone["Asia/Tokyo"])
+
+      expect(result.timeline_start.hour).to eq(22)
+      # 翌日の02:00になるので日付は+1、hourは2のまま
+      expect(result.timeline_end.hour).to eq(2)
+      expect(result.timeline_end.to_date).to eq(festival_day.date + 1.day)
+      expect(result.time_markers.first.hour).to eq(22)
+      expect(result.time_markers.last.hour).to eq(2)
+    end
+
+    it "公演が無い場合はデフォルトの開始(9時)と8時間後の終了になる" do
+      result = described_class.build(festival: festival, selected_day: festival_day, timezone: ActiveSupport::TimeZone["Asia/Tokyo"])
+      expect(result.timeline_start.hour).to eq(9)
+      expect(result.timeline_end.hour).to eq(17)
+    end
+
+    it "開始時刻に分が含まれていてもマーカーが正しく丸められる" do
+      festival_day.update!(start_at: festival_day.date.to_time.change(hour: 12, min: 30))
+      result = described_class.build(festival: festival, selected_day: festival_day, timezone: ActiveSupport::TimeZone["Asia/Tokyo"])
+
+      expect(result.timeline_start.min).to eq(30)
+      # 最初のマーカーは次の正時から
+      expect(result.time_markers.first.min).to eq(30)
+      expect(result.time_markers.second.min).to eq(0)
+    end
+  end
+end

--- a/spec/services/weather/festival_day_forecast_spec.rb
+++ b/spec/services/weather/festival_day_forecast_spec.rb
@@ -1,0 +1,83 @@
+require "rails_helper"
+
+RSpec.describe Weather::FestivalDayForecast do
+  let(:festival) { create(:festival, latitude: 35.0, longitude: 139.0, venue_name: "会場名") }
+  let(:festival_day) { create(:festival_day, festival: festival, date: Date.new(2025, 1, 1)) }
+  let(:cache) { ActiveSupport::Cache::MemoryStore.new }
+
+  def dummy_json(date)
+    times = []
+    temps = []
+    codes = []
+
+    Weather::FestivalDayForecast::DISPLAY_HOURS.each_with_index do |hour, idx|
+      times << "#{date.iso8601}T#{format('%02d', hour)}:00"
+      temps << (20 + idx)
+      codes << (idx.even? ? 0 : 61) # 交互に晴れ/雨
+    end
+
+    {
+      "hourly" => {
+        "time" => times,
+        "temperature_2m" => temps,
+        "weather_code" => codes
+      }
+    }
+  end
+
+  it "緯度経度がない場合はnilを返す" do
+    no_location_day = create(:festival_day, festival: create(:festival, latitude: nil, longitude: nil))
+    client = instance_double(Weather::OpenMeteo::Client)
+    mapper = instance_double(Weather::WeatherCodeMapper)
+
+    result = described_class.new(festival_day: no_location_day, client: client, mapper: mapper, cache: cache).call
+    expect(result).to be_nil
+  end
+
+  it "キャッシュ経由で予報を取得し、表示用の構造体を返す" do
+    client = instance_double(Weather::OpenMeteo::Client)
+    mapper = instance_double(Weather::WeatherCodeMapper, icon_name_for: "icon", tile_class_for: "tile")
+    allow(client).to receive(:hourly_forecast).and_return(dummy_json(festival_day.date))
+
+    result = described_class.new(festival_day: festival_day, client: client, mapper: mapper, cache: cache).call
+
+    expect(client).to have_received(:hourly_forecast).once
+    expect(result.date).to eq(festival_day.date)
+    expect(result.timezone).to eq(Weather::FestivalDayForecast::TIMEZONE)
+    expect(result.venue_name).to eq("会場名")
+    expect(result.hour_labels).to eq(Weather::FestivalDayForecast::DISPLAY_HOURS)
+    expect(result.slots.size).to eq(Weather::FestivalDayForecast::DISPLAY_HOURS.size)
+    expect(result.slots.first.temperature_label).to include("℃")
+    expect(result.slots.map(&:icon_name)).to all(eq("icon"))
+    expect(result.slots.map(&:tile_class)).to all(eq("tile"))
+  end
+
+  it "APIエラー時は例外を握りつぶしてnilを返す" do
+    client = instance_double(Weather::OpenMeteo::Client)
+    mapper = instance_double(Weather::WeatherCodeMapper)
+    allow(client).to receive(:hourly_forecast).and_raise(StandardError.new("api error"))
+
+    result = described_class.new(festival_day: festival_day, client: client, mapper: mapper, cache: cache).call
+    expect(result).to be_nil
+  end
+
+  it "同じキーではキャッシュが効き、クライアント呼び出しは1回だけ" do
+    client = instance_double(Weather::OpenMeteo::Client)
+    mapper = instance_double(Weather::WeatherCodeMapper, icon_name_for: "icon", tile_class_for: "tile")
+    allow(client).to receive(:hourly_forecast).and_return(dummy_json(festival_day.date))
+
+    service = described_class.new(festival_day: festival_day, client: client, mapper: mapper, cache: cache)
+    2.times { service.call }
+
+    expect(client).to have_received(:hourly_forecast).once
+  end
+
+  it "festival_dayやfestivalがnilならnilを返す" do
+    client = instance_double(Weather::OpenMeteo::Client)
+    mapper = instance_double(Weather::WeatherCodeMapper)
+
+    expect(described_class.new(festival_day: nil, client: client, mapper: mapper, cache: cache).call).to be_nil
+    orphan_day = FestivalDay.new(festival: nil, date: festival_day.date)
+    expect(described_class.new(festival_day: orphan_day, client: client, mapper: mapper, cache: cache).call).to be_nil
+  end
+end

--- a/spec/services/weather/open_meteo/client_spec.rb
+++ b/spec/services/weather/open_meteo/client_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe Weather::OpenMeteo::Client do
+  let(:client) { described_class.new }
+  let(:http) { instance_double(Net::HTTP) }
+
+  it "成功レスポンスをパースして返す" do
+    body = {
+      hourly: {
+        time: [ "2025-01-01T08:00" ],
+        temperature_2m: [ 20.0 ],
+        weather_code: [ 0 ]
+      }
+    }.to_json
+
+    ok_response = instance_double(Net::HTTPSuccess, body: body, code: "200")
+    allow(ok_response).to receive(:is_a?).with(Net::HTTPSuccess).and_return(true)
+
+    allow(Net::HTTP).to receive(:start).and_return(http)
+    allow(http).to receive(:request).and_return(ok_response)
+
+    json = client.hourly_forecast(latitude: 35.0, longitude: 139.0, date: Date.new(2025, 1, 1))
+    expect(json["hourly"]["temperature_2m"]).to eq([ 20.0 ])
+  end
+
+  it "失敗レスポンスなら例外を投げる" do
+    failed_response = instance_double(Net::HTTPServerError, body: "err", code: "500")
+    allow(failed_response).to receive(:is_a?).with(Net::HTTPSuccess).and_return(false)
+
+    allow(Net::HTTP).to receive(:start).and_return(http)
+    allow(http).to receive(:request).and_return(failed_response)
+
+    expect {
+      client.hourly_forecast(latitude: 35.0, longitude: 139.0, date: Date.new(2025, 1, 1))
+    }.to raise_error(/Open-Meteo forecast failed/)
+  end
+end

--- a/spec/services/weather/weather_code_mapper_spec.rb
+++ b/spec/services/weather/weather_code_mapper_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe Weather::WeatherCodeMapper do
+  describe "#kind_for / #icon_name_for / #tile_class_for" do
+    let(:mapper) { described_class.new }
+
+    it "コードを種別とアイコン・色にマッピングできる" do
+      expect(mapper.kind_for(0)).to eq(:clear)
+      expect(mapper.icon_name_for(0)).to eq("weather_sunny")
+      expect(mapper.tile_class_for(0)).to eq("bg-orange-400")
+
+      expect(mapper.kind_for(61)).to eq(:rain)
+      expect(mapper.icon_name_for(61)).to eq("weather_rainy")
+      expect(mapper.tile_class_for(61)).to eq("bg-sky-500")
+
+      expect(mapper.kind_for(99)).to eq(:thunder)
+      expect(mapper.icon_name_for(99)).to eq("weather_thunder")
+      expect(mapper.tile_class_for(99)).to eq("bg-purple-600")
+
+      expect(mapper.kind_for(999)).to eq(:unknown)
+      expect(mapper.icon_name_for(999)).to eq("weather_cloudy")
+      expect(mapper.tile_class_for(999)).to eq("bg-slate-500")
+    end
+  end
+end


### PR DESCRIPTION
## 概要
- サービス層の外部APIまわりとコアロジックに対する単体テストを拡充し、成功/失敗やトランザクション・キャッシュなどの挙動を確認できるようにしました。
## 実施内容
- spec/services/my_timetables/updater_spec.rb: 例外発生時にトランザクションでロールバックされ既存選択が戻ることを追加で確認。
- spec/services/timeline_context_builder_spec.rb: 公演なし時のデフォルト範囲(9時〜8時間)、端数開始(12:30)でもマーカーが正しく丸められることを追加。
- spec/services/weather/festival_day_forecast_spec.rb: キャッシュが効いてクライアント呼び出しが1回だけになること、festival_day/festival が無い場合は nil を返すことを追加。
- spec/services/weather/open_meteo/client_spec.rb: Open-Meteo クライアントで成功レスポンスのパースと、失敗レスポンスで例外を投げることをテスト。
- spec/services/spotify/client_spec.rb: Spotify クライアントでトークン取得→検索成功のパース結果と、検索失敗時の例外をテスト。
## 対応Issue
- #86 
## 関連Issue
なし
## 特記事項