### PR TITLE
[add]specコードの追加

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,9 @@ Rails.application.routes.draw do
     omniauth_callbacks: "users/omniauth_callbacks",
     passwords: "users/passwords"
   }
+  devise_scope :user do
+    get "/users/auth/failure", to: "users/omniauth_callbacks#failure"
+  end
 
   root "home#top"
   get "/terms", to: "home#terms", as: :terms

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -1,0 +1,105 @@
+require "rails_helper"
+require "omniauth"
+
+RSpec.describe "認証のリクエスト", type: :request do
+  describe "PATCH /users" do
+    let(:user) { create(:user, nickname: "旧ニックネーム") }
+
+    before { sign_in user, scope: :user }
+
+    it "パスワードなしでプロフィール更新できる" do
+      patch user_registration_path, params: { user: { nickname: "新ニックネーム" } }
+
+      expect(response).to have_http_status(:see_other)
+      expect(user.reload.nickname).to eq("新ニックネーム")
+    end
+
+    it "パスワード変更は現在のパスワードが必要" do
+      patch user_registration_path, params: {
+        user: { password: "newpass123", password_confirmation: "newpass123" }
+      }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(user.reload.valid_password?("newpass123")).to be(false)
+    end
+  end
+
+  describe "GET /users/auth/google_oauth2/callback" do
+    around do |example|
+      OmniAuth.config.test_mode = true
+      example.run
+    ensure
+      OmniAuth.config.test_mode = false
+      OmniAuth.config.mock_auth[:google_oauth2] = nil
+      Rails.application.env_config["omniauth.auth"] = nil
+    end
+
+    it "Google認証でユーザーを作成してログインする" do
+      OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
+        provider: "google_oauth2",
+        uid: "12345",
+        info: { email: "test@example.com", name: "Test User" }
+      )
+      Rails.application.env_config["omniauth.auth"] = OmniAuth.config.mock_auth[:google_oauth2]
+
+      expect {
+        get "/users/auth/google_oauth2/callback"
+      }.to change(User, :count).by(1)
+
+      user = User.find_by(email: "test@example.com")
+      expect(user.provider).to eq("google_oauth2")
+      expect(user.uid).to eq("12345")
+      expect(response).to have_http_status(:found)
+    end
+  end
+
+  describe "GET /users/auth/failure" do
+    it "OAuth失敗時はトップへリダイレクトする" do
+      get "/users/auth/failure"
+
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  describe "POST /users/password" do
+    before { ActionMailer::Base.deliveries.clear }
+
+    it "ログイン済みなら自分宛に送信しマイページへリダイレクトする" do
+      user = create(:user)
+      sign_in user, scope: :user
+
+      post user_password_path, params: { user: { email: "ignored@example.com" } }
+
+      expect(response).to redirect_to(mypage_dashboard_path)
+      expect(ActionMailer::Base.deliveries).not_to be_empty
+      expect(ActionMailer::Base.deliveries.last.to).to include(user.email)
+    end
+
+    it "未ログインでも送信できる" do
+      user = create(:user)
+
+      post user_password_path, params: { user: { email: user.email } }
+
+      expect(response).to have_http_status(:found)
+      expect(ActionMailer::Base.deliveries).not_to be_empty
+      expect(ActionMailer::Base.deliveries.last.to).to include(user.email)
+    end
+
+    it "未登録メールなら送信されない" do
+      post user_password_path, params: { user: { email: "unknown@example.com" } }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(ActionMailer::Base.deliveries).to be_empty
+    end
+  end
+
+  describe "POST /users" do
+    it "バリデーションエラーなら作成されない" do
+      expect {
+        post user_registration_path, params: { user: { email: "", password: "short", nickname: "" } }
+      }.not_to change(User, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+  end
+end

--- a/spec/services/weather/open_meteo/client_spec.rb
+++ b/spec/services/weather/open_meteo/client_spec.rb
@@ -1,8 +1,10 @@
 require "rails_helper"
+require "cgi"
 
 RSpec.describe Weather::OpenMeteo::Client do
   let(:client) { described_class.new }
   let(:http) { instance_double(Net::HTTP) }
+  let(:date) { Date.new(2025, 1, 1) }
 
   it "成功レスポンスをパースして返す" do
     body = {
@@ -19,7 +21,7 @@ RSpec.describe Weather::OpenMeteo::Client do
     allow(Net::HTTP).to receive(:start).and_return(http)
     allow(http).to receive(:request).and_return(ok_response)
 
-    json = client.hourly_forecast(latitude: 35.0, longitude: 139.0, date: Date.new(2025, 1, 1))
+    json = client.hourly_forecast(latitude: 35.0, longitude: 139.0, date: date)
     expect(json["hourly"]["temperature_2m"]).to eq([ 20.0 ])
   end
 
@@ -31,7 +33,70 @@ RSpec.describe Weather::OpenMeteo::Client do
     allow(http).to receive(:request).and_return(failed_response)
 
     expect {
-      client.hourly_forecast(latitude: 35.0, longitude: 139.0, date: Date.new(2025, 1, 1))
+      client.hourly_forecast(latitude: 35.0, longitude: 139.0, date: date)
     }.to raise_error(/Open-Meteo forecast failed/)
+  end
+
+  it "デフォルトのtimezoneでクエリを組み立てる" do
+    ok_response = instance_double(Net::HTTPSuccess, body: "{}", code: "200")
+    allow(ok_response).to receive(:is_a?).with(Net::HTTPSuccess).and_return(true)
+
+    captured_uri = nil
+    allow(Net::HTTP).to receive(:start).and_return(http)
+    allow(http).to receive(:request) do |req|
+      captured_uri = req.uri
+      ok_response
+    end
+
+    client.hourly_forecast(latitude: 35.0, longitude: 139.0, date: date)
+
+    params = CGI.parse(captured_uri.query)
+    expect(params["latitude"]).to eq([ "35.0" ])
+    expect(params["longitude"]).to eq([ "139.0" ])
+    expect(params["hourly"]).to eq([ "temperature_2m,weather_code" ])
+    expect(params["start_date"]).to eq([ "2025-01-01" ])
+    expect(params["end_date"]).to eq([ "2025-01-01" ])
+    expect(params["timezone"]).to eq([ "Asia/Tokyo" ])
+  end
+
+  it "timezoneを上書きできる" do
+    ok_response = instance_double(Net::HTTPSuccess, body: "{}", code: "200")
+    allow(ok_response).to receive(:is_a?).with(Net::HTTPSuccess).and_return(true)
+
+    captured_uri = nil
+    allow(Net::HTTP).to receive(:start).and_return(http)
+    allow(http).to receive(:request) do |req|
+      captured_uri = req.uri
+      ok_response
+    end
+
+    client.hourly_forecast(latitude: 35.0, longitude: 139.0, date: date, timezone: "UTC")
+
+    params = CGI.parse(captured_uri.query)
+    expect(params["timezone"]).to eq([ "UTC" ])
+  end
+
+  it "成功レスポンスでもJSONが壊れていたら例外を投げる" do
+    ok_response = instance_double(Net::HTTPSuccess, body: "{bad json", code: "200")
+    allow(ok_response).to receive(:is_a?).with(Net::HTTPSuccess).and_return(true)
+
+    allow(Net::HTTP).to receive(:start).and_return(http)
+    allow(http).to receive(:request).and_return(ok_response)
+
+    expect {
+      client.hourly_forecast(latitude: 35.0, longitude: 139.0, date: date)
+    }.to raise_error(JSON::ParserError)
+  end
+
+  it "例外メッセージにステータスとボディが含まれる" do
+    failed_response = instance_double(Net::HTTPServerError, body: "err", code: "500")
+    allow(failed_response).to receive(:is_a?).with(Net::HTTPSuccess).and_return(false)
+
+    allow(Net::HTTP).to receive(:start).and_return(http)
+    allow(http).to receive(:request).and_return(failed_response)
+
+    expect {
+      client.hourly_forecast(latitude: 35.0, longitude: 139.0, date: date)
+    }.to raise_error("Open-Meteo forecast failed: 500 err")
   end
 end


### PR DESCRIPTION
## 概要
認証フローと持ち物リスト関連の不足していたrequest specを補完し、本リリース前の主要ユーザーフローの退行検知を強化した。
## 実施内容
- 認証まわりのrequest spec追加（プロフィール更新、パスワード変更制約、OAuth成功/失敗、パスワード再設定、登録失敗）: authentication_spec.rb
- 持ち物リストの更新/削除成功ケースの追加: packing_lists_spec.rb
- 持ち物リスト項目の更新失敗・他人アクセスの404検証追加: packing_list_items_spec.rb
- OAuth失敗のルーティング追加: routes.rb
## 対応Issue
- close #86 
## 関連Issue
なし
## 特記事項
本リリース提出後も、機能追加や不具合に対応してspecファイルを追加。