### PR TITLE
[update]戻るボタンの挙動条件追加

### DIFF
--- a/app/components/stage_columns/festival_component.rb
+++ b/app/components/stage_columns/festival_component.rb
@@ -1,14 +1,15 @@
 module StageColumns
   class FestivalComponent < BaseComponent
-    def initialize(stage:, performances:, time_markers:, timeline_layout:, festival:, selected_day: nil)
+    def initialize(stage:, performances:, time_markers:, timeline_layout:, festival:, selected_day: nil, back_to: nil)
       super(stage: stage, performances: performances, time_markers: time_markers, timeline_layout: timeline_layout)
       @festival = festival
       @selected_day = selected_day
+      @back_to = back_to
     end
 
     private
 
-    attr_reader :festival, :selected_day
+    attr_reader :festival, :selected_day, :back_to
 
     def render_block(performance, block)
       block_body = default_block_content(block, block.artist_name, canceled: canceled?(performance))
@@ -19,7 +20,8 @@ module StageColumns
                          class: default_block_classes,
                          style: block_style_rules) unless performance.artist.published?
 
-      link_to(helpers.artist_path(performance.artist),
+      artist_url = back_to.present? ? helpers.artist_path(performance.artist, back_to: back_to) : helpers.artist_path(performance.artist)
+      link_to(artist_url,
               class: default_block_classes,
               data: { controller: "tap-feedback" },
               style: block_style_rules) do

--- a/app/components/stage_columns/show_component.rb
+++ b/app/components/stage_columns/show_component.rb
@@ -1,16 +1,17 @@
 module StageColumns
   class ShowComponent < BaseComponent
-    def initialize(stage:, performances:, time_markers:, timeline_layout:, festival:, selected_day:, selected_ids:, owner_identifier: nil)
+    def initialize(stage:, performances:, time_markers:, timeline_layout:, festival:, selected_day:, selected_ids:, owner_identifier: nil, back_to: nil)
       super(stage: stage, performances: performances, time_markers: time_markers, timeline_layout: timeline_layout)
       @festival = festival
       @selected_day = selected_day
       @selected_ids = Array(selected_ids)
       @owner_identifier = owner_identifier
+      @back_to = back_to
     end
 
     private
 
-    attr_reader :festival, :selected_day, :selected_ids, :owner_identifier
+    attr_reader :festival, :selected_day, :selected_ids, :owner_identifier, :back_to
 
     def render_block(performance, block)
       selected = selected_ids.include?(performance.id)
@@ -29,7 +30,8 @@ module StageColumns
                          class: classes,
                          style: block_style_rules) unless performance.artist.published?
 
-      link_to(helpers.artist_path(performance.artist),
+      artist_url = back_to.present? ? helpers.artist_path(performance.artist, back_to: back_to) : helpers.artist_path(performance.artist)
+      link_to(artist_url,
               class: classes,
               data: { controller: "tap-feedback" },
               style: block_style_rules

--- a/app/controllers/my_timetables_controller.rb
+++ b/app/controllers/my_timetables_controller.rb
@@ -3,6 +3,7 @@ class MyTimetablesController < ApplicationController
   before_action :set_festival!, except: :index
   before_action :set_selected_day!, except: :index
   before_action :prepare_timetable_context!, only: [ :edit, :show ]
+  before_action :set_index_header_back_path, only: :index
   before_action :set_header_back_path, only: :edit
   before_action :set_timetable_owner!, only: :show
 
@@ -101,6 +102,14 @@ class MyTimetablesController < ApplicationController
     options[:date] = @selected_day.date.to_s if @selected_day&.date
     options[:user_id] = current_user&.uuid if user_signed_in?
     @header_back_path = festival_my_timetable_path(@festival, options)
+  end
+
+  def set_index_header_back_path
+    back = params[:back_to].to_s
+    return if back.blank?
+    return unless back.start_with?("/")
+
+    @header_back_path = back
   end
 
   def prepare_timetable_context!

--- a/app/controllers/setlists_controller.rb
+++ b/app/controllers/setlists_controller.rb
@@ -1,4 +1,6 @@
 class SetlistsController < ApplicationController
+  before_action :set_header_back_path, only: :show
+
   def show
     @setlist = Setlist
                 .includes(stage_performance: [ :artist, :stage, { festival_day: :festival } ],
@@ -8,5 +10,15 @@ class SetlistsController < ApplicationController
     @stage_performance = @setlist.stage_performance
     @festival_day      = @stage_performance.festival_day
     @setlist_songs     = @setlist.setlist_songs.includes(:song).order(:position)
+  end
+
+  private
+
+  def set_header_back_path
+    back = params[:back_to].to_s
+    return if back.blank?
+    return unless back.start_with?("/")
+
+    @header_back_path = back
   end
 end

--- a/app/controllers/timetables_controller.rb
+++ b/app/controllers/timetables_controller.rb
@@ -134,7 +134,12 @@ class TimetablesController < ApplicationController
 
   def set_header_back_path
     return unless @festival
-    return unless params[:back_to] == "festival"
+    back = params[:back_to].to_s
+    if back.start_with?("/")
+      @header_back_path = back
+      return
+    end
+    return unless back == "festival"
 
     @header_back_path = festival_path(@festival)
   end

--- a/app/views/my_timetables/show.html.erb
+++ b/app/views/my_timetables/show.html.erb
@@ -49,7 +49,8 @@
              festival: @festival,
              selected_day: @selected_day,
              selected_ids: @selected_performance_ids,
-             owner_identifier: timetable_owner_identifier
+             owner_identifier: timetable_owner_identifier,
+             back_to: request.fullpath
            )
          end %>
 

--- a/app/views/mypage/dashboard/show.html.erb
+++ b/app/views/mypage/dashboard/show.html.erb
@@ -26,7 +26,7 @@
                   url: mypage_favorite_artists_path %>
         <%= render "shared/nav_stack_button",
                   label: "マイタイムテーブル",
-                  url: my_timetables_path %>       
+                  url: my_timetables_path(back_to: mypage_dashboard_path) %>       
       </div>
     </section>
   </div>

--- a/app/views/prep/artists/show.html.erb
+++ b/app/views/prep/artists/show.html.erb
@@ -60,7 +60,7 @@
             <%= render "shared/nav_stack_button",
                        label: setlist_label(setlist),
                        subtext: setlist_subtext(setlist),
-                       url: setlist_path(setlist) %>
+                       url: setlist_path(setlist, back_to: request.fullpath) %>
           <% end %>
         </div>
       <% else %>

--- a/app/views/timetables/index.html.erb
+++ b/app/views/timetables/index.html.erb
@@ -57,14 +57,15 @@
 
     <section class="grid gap-3 md:grid-cols-2 md:gap-4">
       <% if @festivals.any? %>
-        <% @festivals.each do |festival| %>
-          <div class="w-full">
-            <%= render "shared/nav_stack_button",
-                       label: festival.name,
-                       subtext: festival_date_and_location(festival),
-                       url: timetable_path(festival) %>
-          </div>
-        <% end %>
+          <% back_to = params[:back_to].presence %>
+          <% @festivals.each do |festival| %>
+            <div class="w-full">
+              <%= render "shared/nav_stack_button",
+                         label: festival.name,
+                         subtext: festival_date_and_location(festival),
+                         url: (back_to ? timetable_path(festival, back_to: back_to) : timetable_path(festival)) %>
+            </div>
+          <% end %>
       <% else %>
         <p class="rounded-xl bg-white px-4 py-12 text-center text-sm text-slate-500 shadow md:col-span-2">
           公開中のタイムテーブルはありません

--- a/app/views/timetables/show.html.erb
+++ b/app/views/timetables/show.html.erb
@@ -43,7 +43,8 @@
            time_markers: @time_markers,
            timeline_layout: @timeline_layout,
            festival: @festival,
-           selected_day: @selected_day
+           selected_day: @selected_day,
+           back_to: request.fullpath
          )
        end %>
 


### PR DESCRIPTION
## 概要
- 戻るボタンが「直前の画面」に戻るよう、タイムテーブル・セットリスト・マイタイムテーブル周りの遷移時に back_to を引き継ぎ、ヘッダーの戻り先を適切に設定した。
- これにより、「タイムテーブル詳細/マイタイムテーブル詳細→アーティスト詳細」、「予習→セットリスト詳細」、「マイページ→マイタイムテーブル一覧」の戻り挙動が改善された。
## 実施内容
- タイムテーブル/マイタイムテーブルのアーティストリンクに back_to を付与: festival_component.rb show_component.rb
- タイムテーブル/マイタイムテーブル詳細から現在URLを back_to として渡す: show.html.erb show.html.erb
- タイムテーブル詳細で back_to(パス) を戻り先に採用: timetables_controller.rb
- タイムテーブル一覧→詳細のリンクで back_to を引き継ぎ: index.html.erb
- アーティスト予習→セットリスト詳細の戻り先を設定: show.html.erb setlists_controller.rb
- マイページ→マイタイムテーブル一覧の戻り先を設定: show.html.erb my_timetables_controller.rb
## 対応Issue
- #268 
## 関連Issue
なし
## 特記事項