### PR TITLE
[add]ciにrspec実行を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,29 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with: { ruby-version: '3.3.6', bundler-cache: true }
       - run: bundle exec brakeman -q -w2
+
+  rspec:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: myapp_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: postgres://postgres:password@localhost:5432/myapp_test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with: { ruby-version: '3.3.6', bundler-cache: true }
+      - run: bin/rails db:prepare
+      - run: bundle exec rspec


### PR DESCRIPTION
## 概要
- CIにrspecを追加し、push/PR時にテストが自動実行されるように変更した。
## 実施内容
- RSpec用のCIジョブを追加（PostgreSQL起動→db:prepare→bundle exec rspec）: ci.yml
## 対応Issue
- #86 
## 関連Issue
なし
## 特記事項