### PR TITLE
[fix]ci.ymlにrspec実行時の条件を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,20 @@ jobs:
     env:
       RAILS_ENV: test
       DATABASE_URL: postgres://postgres:password@localhost:5432/myapp_test
+      TZ: Asia/Tokyo
+      SECRET_KEY_BASE: test
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with: { ruby-version: '3.3.6', bundler-cache: true }
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+      - run: corepack enable
+      - run: yarn install --frozen-lockfile
+      - run: yarn build
+      - run: yarn build:css
+      - run: bin/rails assets:precompile
       - run: bin/rails db:prepare
       - run: bundle exec rspec


### PR DESCRIPTION
## 概要
- CIのrspecジョブにアセットビルドとタイムゾーン設定を追加し、GitHub Actions環境でもローカルと同じ条件でテストが通るように改善。

## 実施内容
- Node/Yarnのセットアップと yarn build / yarn build:css を追加
- assets:precompile を追加
- TZ=Asia/Tokyo と SECRET_KEY_BASE を追加
- 対象ファイル: ci.yml
## 対応Issue
- #86 
## 関連Issue
なし
## 特記事項