### PR TITLE
[update]戻るボタンの親設定の追加

### DIFF
--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -68,6 +68,14 @@ module NavigationHelper
     "admin/packing_lists#new" => -> { admin_packing_lists_path },
     "admin/packing_lists#edit" => -> { admin_packing_lists_path },
 
+    "admin/setlists#index" => -> { admin_root_path },
+    "admin/setlists#show" => -> { admin_setlists_path },
+    "admin/setlists#new" => -> { admin_setlists_path },
+    "admin/setlists#edit" => -> { admin_setlists_path },
+
+    "users/registrations#edit" => -> { mypage_dashboard_path },
+    "users/registrations#update" => -> { mypage_dashboard_path },
+
     "admin/users#index" => -> { admin_root_path }
   }.freeze
 


### PR DESCRIPTION
## 概要
- navigation_helper.rbに戻り先のルールを追加。
## 実施内容
- navigation_helper.rbで以下を追加
  - admin/setlists（index→admin_root、それ以外   →admin_setlists_path）
  - users/registrations#edit/#updateの戻り先をmypage_dashboard_pathとして追加。
## 対応Issue
なし
## 関連Issue
なし
## 特記事項