### PR TITLE
[update]TOPページのh1タグのフォントを変更

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,6 +1,6 @@
-@import "tailwindcss";
+@import url("https://fonts.googleapis.com/css2?family=Climate+Crisis&family=Noto+Sans+JP:wght@300;400;500;700;900&family=Zen+Kaku+Gothic+New:wght@500;700;900&display=swap");
 
-@import url("https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;500;700;900&family=Zen+Kaku+Gothic+New:wght@500;700;900&display=swap");
+@import "tailwindcss";
 
 @theme {
   --font-sans: "Noto Sans JP", system-ui, -apple-system, "Segoe UI",
@@ -8,14 +8,23 @@
                "BIZ UDPGothic", "Yu Gothic UI", "YuGothic", Meiryo, sans-serif;
 
   --font-display: "Zen Kaku Gothic New", "Noto Sans JP", system-ui, sans-serif;
+  --font-hero: "Climate Crisis", "Noto Sans JP", system-ui, sans-serif;
 }
 
-@utility fontDisplay {
-  font-family: var(--font-display);
+@layer base {
+  h1, h2, h3, h4 {
+    font-family: var(--font-display);
+  }
 }
 
-h1, h2, h3, h4 {
-  font-family: var(--font-display);
+@layer utilities {
+  .font-display {
+    font-family: var(--font-display);
+  }
+
+  .font-hero {
+    font-family: var(--font-hero);
+  }
 }
 
 @layer components {
@@ -76,7 +85,7 @@ h1, h2, h3, h4 {
     }
   }
 
-  @screen sm {
+  @media (min-width: 640px) {
     .interactive-lift {
       @apply hover:-translate-y-1 hover:shadow-lg active:-translate-y-1 active:shadow-lg;
     }

--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -8,7 +8,7 @@
       data: { reveal_on_scroll_target: "item" }
     ) %>
     <h1
-      class="absolute left-1/2 top-[34%] -translate-x-1/2 -translate-y-1/2 text-4xl md:text-6xl font-black tracking-tight text-red-600 drop-shadow-[0_6px_12px_rgba(15,23,42,0.25)] opacity-0 translate-y-6 transition duration-700 ease-out"
+      class="absolute left-1/2 top-[34%] -translate-x-1/2 -translate-y-1/2 whitespace-nowrap text-4xl md:text-6xl font-normal font-hero tracking-wide text-red-600 drop-shadow-[0_6px_12px_rgba(15,23,42,0.25)] opacity-0 translate-y-6 transition duration-700 ease-out"
       data-reveal-on-scroll-target="item"
     >
       FES READY


### PR DESCRIPTION
## 概要
- トップの「FES READY」見出し専用にロゴ向けフォント設定を追加し、フォント切替・レイヤー優先順位を整備して反映されるようにした
- 見出しの可読性を上げるために字間と太さ、改行挙動を調整した
## 実施内容
- application.tailwind.css に Google Fonts の読み込み整理、--font-hero の追加、.font-hero/.font-display ユーティリティ化、h1–h4 の @layer base 移動
- top.html.erb の h1 に font-hero と tracking-wide、whitespace-nowrap を付与し、太さを font-normal に調整
## 対応Issue
なし
## 関連Issue
なし
## 特記事項