### PR TITLE
[add]運営者情報とそれにともなうspecコードを追加

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -7,4 +7,7 @@ class HomeController < ApplicationController
 
   def privacy
   end
+
+  def operator
+  end
 end

--- a/app/views/home/operator.html.erb
+++ b/app/views/home/operator.html.erb
@@ -1,0 +1,46 @@
+<% content_for :title, "運営者情報 | FES READY" %>
+
+<main
+  class="box-border flex items-center justify-center px-4 py-6 md:py-8"
+  style="height: calc(100vh - var(--header-offset) - var(--footer-offset));"
+>
+  <div class="box-border flex h-full w-full max-w-4xl flex-col rounded-3xl bg-white/95 p-6 shadow-xl ring-1 ring-slate-200 backdrop-blur lg:p-8">
+    <header class="space-y-2 text-center shrink-0">
+      <h1 class="text-2xl font-black text-slate-900">運営者情報</h1>
+    </header>
+
+    <div class="mt-6 h-px w-full bg-gradient-to-r from-transparent via-[#F95858]/40 to-transparent"></div>
+
+    <div class="mt-6 flex-1 space-y-6 overflow-y-auto pr-2 text-sm leading-relaxed text-slate-700 md:text-base">
+      <p class="text-base font-semibold text-slate-900 md:text-lg">運営者：hinata</p>
+
+      <div class="space-y-4">
+        <p>
+          本サイト「FES READY」は、音楽フェスの準備を楽しく・スマートにすることを目的としたWebアプリです。
+          <br>個人開発として、RUNTEQでの学習・卒業制作の一環で制作・運営しています。
+        </p>
+      </div>
+
+      <div class="space-y-2">
+        <ul class="list-disc space-y-2 pl-5">
+          <li>
+            X（旧Twitter）：
+            <%= link_to "https://x.com/hinanata72",
+                        "https://x.com/hinanata72",
+                        class: "text-slate-900 underline decoration-slate-300 underline-offset-4 transition hover:text-[#F95858] hover:decoration-[#F95858]",
+                        target: "_blank",
+                        rel: "noopener" %>
+          </li>
+          <li>
+            GitHub：
+            <%= link_to "https://github.com/hinata7777",
+                        "https://github.com/hinata7777",
+                        class: "text-slate-900 underline decoration-slate-300 underline-offset-4 transition hover:text-[#F95858] hover:decoration-[#F95858]",
+                        target: "_blank",
+                        rel: "noopener" %>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</main>

--- a/app/views/shared/_side_menu.html.erb
+++ b/app/views/shared/_side_menu.html.erb
@@ -8,6 +8,7 @@
 <% secondary_links = [
   { label: "利用規約", href: terms_path },
   { label: "プライバシーポリシー", href: privacy_path },
+  { label: "運営者情報", href: operator_path },
   { label: "お問い合わせ", href: "https://forms.gle/N9j4cZw7xPhbsHZE8", external: true }
 ] %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   root "home#top"
   get "/terms", to: "home#terms", as: :terms
   get "/privacy", to: "home#privacy", as: :privacy
+  get "/operator", to: "home#operator", as: :operator
   resource :prep, only: [ :show ], controller: "prep"
   namespace :prep, path: "prep" do
     resources :festivals, only: [ :index, :show ]

--- a/spec/requests/public_pages_spec.rb
+++ b/spec/requests/public_pages_spec.rb
@@ -6,6 +6,21 @@ RSpec.describe "公開ページのリクエスト", type: :request do
       get root_path
       expect(response).to have_http_status(:ok)
     end
+
+    it "利用規約ページが200を返す" do
+      get terms_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "プライバシーポリシーページが200を返す" do
+      get privacy_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "運営者情報ページが200を返す" do
+      get operator_path
+      expect(response).to have_http_status(:ok)
+    end
   end
 
   describe "フェス・アーティストの一覧/詳細" do


### PR DESCRIPTION
## 概要
- 「運営者情報」ページを新規追加しサイドメニューからの導線を追加
- 基本アクセスのRSpecを整備
## 実施内容
- top.html.erb で font-hero 適用、字間・太さ・改行挙動を調整
- routes.rb に /operator ルートを追加、home_controller.rb に operator アクションを追加
- operator.html.erb を新規作成し、運営者情報の本文と外部リンクを実装
- _side_menu.html.erb に「運営者情報」リンクを追加
- public_pages_spec.rb に terms_path/privacy_path/operator_path のアクセス確認を追加
## 対応Issue
なし
## 関連Issue
なし
## 特記事項