### PR TITLE
[add]adsenseのコードを追加

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,6 +38,10 @@
       gtag('config', 'G-PB0CKT8EH2');
     </script>
     
+    <!-- Google AdSense -->
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5061776258262847"
+      crossorigin="anonymous"></script>
+
     <%# Includes all stylesheet files in app/assets/stylesheets %>
     <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>


### PR DESCRIPTION
## 概要
- Google Adsense用のscriptコードを追加
## 実施内容
- application.html.erbのheadタグ内にscriptタグを追加
## 対応Issue
なし
## 関連Issue
なし
## 特記事項