### PR TITLE
[add]セットリストページのXでシェア機能

### DIFF
--- a/app/helpers/x_share_helper.rb
+++ b/app/helpers/x_share_helper.rb
@@ -14,4 +14,13 @@ module XShareHelper
     url  = festival_my_timetable_url(festival, date: day.to_s, user_id: owner_uuid)
     x_intent_url(text: text, url: url)
   end
+
+  def setlist_share_url(setlist)
+    stage_performance = setlist.stage_performance
+    artist = stage_performance.artist
+    festival = stage_performance.festival_day.festival
+    hashtag_artist = artist.name.to_s.gsub(/\s+/, "")
+    text = "#{artist.name} の #{festival.name} でのセットリストを公開中！\n#FESREADY ##{hashtag_artist}"
+    x_intent_url(text: text, url: setlist_url(setlist))
+  end
 end

--- a/app/views/setlists/show.html.erb
+++ b/app/views/setlists/show.html.erb
@@ -2,7 +2,17 @@
   <div class="mx-auto max-w-5xl space-y-8">
     <header class="space-y-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-lg shadow-slate-200/70">
       <p class="text-xs font-semibold tracking-wide text-indigo-600"><%= @stage_performance.artist.name %></p>
-      <h1 class="text-2xl font-bold text-slate-900"><%= "#{@festival_day.festival.name} のセットリスト" %></h1>
+      <% share_href = setlist_share_url(@setlist) %>
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <h1 class="text-2xl font-bold text-slate-900"><%= "#{@festival_day.festival.name} のセットリスト" %></h1>
+        <%= link_to share_href,
+                    class: "inline-flex items-center justify-center gap-2 rounded-2xl bg-black px-5 py-2.5 text-sm font-bold text-white shadow-md interactive-lift hover:bg-neutral-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black",
+                    target: "_blank",
+                    rel: "noopener" do %>
+          <%= image_tag "x-logo.png", alt: "X", class: "h-4 w-4" %>
+          <span>でシェアする</span>
+        <% end %>
+      </div>
 
       <dl class="grid grid-cols-1 gap-4 text-sm text-slate-600 sm:grid-cols-3">
         <div class="flex flex-col gap-1">


### PR DESCRIPTION
## 概要
- セットリスト詳細ページに「Xでシェアする」ボタンを追加し、指定の文言で共有できるように追加
## 実施内容
- x_share_helper.rb にセットリスト用の共有URL生成メソッドを追加。
- show.html.erb の見出し右側にシェアボタンを配置。
## 対応Issue
なし
## 関連Issue
なし
## 特記事項
セットリスト閲覧からアプリへのアクセス数を増やすため。