### PR TITLE
[add]adsenseのmetaタグを追加

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,7 @@
     <%= csp_meta_tag %>
     <meta name="turbo-cache-control" content="no-preview">
     <meta name="google-site-verification" content="xNg2EK5ZIULaKlH5D5Bje-I9rxqh0AwNZnFbsfcgoXA" />
+    <meta name="google-adsense-account" content="ca-pub-5061776258262847">
 
     <meta property="og:site_name" content="FES READY">
     <meta property="og:title" content="<%= content_for(:title) || 'FES READY' %>">


### PR DESCRIPTION
## 概要
- Google Adsense用のmetaタグを追加
## 実施内容
- <head> に指定されたmetaタグを追加。
## 対応Issue
なし
## 関連Issue
なし
## 特記事項