### PR TITLE
[refactor]Festivalモデルファイルのリファクタリング

### DIFF
--- a/app/controllers/artists/festivals_controller.rb
+++ b/app/controllers/artists/festivals_controller.rb
@@ -5,13 +5,12 @@ class Artists::FestivalsController < ApplicationController
   before_action :set_back_to_param
 
   def index
-    @status = Festival.normalized_status(params[:status])
-    @status_labels = Festival.status_labels
+    @status = Festivals::ListQuery.normalized_status(params[:status])
     @festival_tags = FestivalTag.order(:name)
     @filter_params = filter_params
     @selected_tag_ids = Array(@filter_params[:tag_ids]).reject(&:blank?).map(&:to_i)
 
-    festival_scope = @artist.festivals.merge(Festival.for_status(@status))
+    festival_scope = Festivals::ListQuery.call(status: @status, scope: @artist.festivals)
     filtered_scope = apply_filters(festival_scope, @filter_params)
 
     @q   = filtered_scope.ransack(params[:q])

--- a/app/controllers/festivals_controller.rb
+++ b/app/controllers/festivals_controller.rb
@@ -5,13 +5,12 @@ class FestivalsController < ApplicationController
 
   def index
     @artist = nil
-    @status = Festival.normalized_status(params[:status])
-    @status_labels = Festival.status_labels
+    @status = Festivals::ListQuery.normalized_status(params[:status])
     @festival_tags = FestivalTag.order(:name)
     @filter_params = filter_params
     @selected_tag_ids = Array(@filter_params[:tag_ids]).reject(&:blank?).map(&:to_i)
 
-    festival_scope = Festival.for_status(@status)
+    festival_scope = Festivals::ListQuery.call(status: @status)
     filtered_scope = apply_filters(festival_scope, @filter_params)
 
     @q     = filtered_scope.ransack(params[:q])

--- a/app/controllers/mypage/favorite_festivals_controller.rb
+++ b/app/controllers/mypage/favorite_festivals_controller.rb
@@ -3,7 +3,7 @@ module Mypage
     before_action :authenticate_user!
 
     def index
-      favorites_scope = Festival.favorited_by(current_user)
+      favorites_scope = Festivals::FavoritesQuery.call(user: current_user)
       @pagy, @festivals = pagy(favorites_scope, limit: 20)
     end
   end

--- a/app/controllers/prep/festivals_controller.rb
+++ b/app/controllers/prep/festivals_controller.rb
@@ -1,13 +1,12 @@
 module Prep
   class FestivalsController < ApplicationController
     def index
-      @status = Festival.normalized_status(params[:status])
-      @status_labels = Festival.status_labels
+      @status = Festivals::ListQuery.normalized_status(params[:status])
       @festival_tags = FestivalTag.order(:name)
       @filter_params = filter_params
       @selected_tag_ids = Array(@filter_params[:tag_ids]).reject(&:blank?).map(&:to_i)
 
-      scoped = Festival.for_status(@status)
+      scoped = Festivals::ListQuery.call(status: @status)
       filtered_scope = apply_filters(scoped, @filter_params)
 
       @q = filtered_scope.ransack(params[:q])

--- a/app/controllers/timetables_controller.rb
+++ b/app/controllers/timetables_controller.rb
@@ -5,14 +5,13 @@ class TimetablesController < ApplicationController
   before_action :set_header_back_path, only: :show
 
   def index
-    @status = Festival.normalized_status(params[:status])
-    @status_labels = Festival.status_labels
+    @status = Festivals::ListQuery.normalized_status(params[:status])
     @festival_tags = FestivalTag.order(:name)
     @filter_params = filter_params
     @selected_tag_ids = Array(@filter_params[:tag_ids]).reject(&:blank?).map(&:to_i)
 
     published_festivals = Festival.with_published_timetable
-    scoped = published_festivals.merge(Festival.for_status(@status))
+    scoped = Festivals::ListQuery.call(status: @status, scope: published_festivals)
 
     filtered_scope = apply_filters(scoped, @filter_params)
 

--- a/app/helpers/festivals_helper.rb
+++ b/app/helpers/festivals_helper.rb
@@ -1,0 +1,8 @@
+module FestivalsHelper
+  def status_labels
+    # enumのキーをUI表示用ラベルに変換する（I18nがなければhumanizeにフォールバック）
+    Festival.status_filters.keys.index_with do |key|
+      I18n.t("enums.festival.status_filter.#{key}", default: key.humanize)
+    end
+  end
+end

--- a/app/queries/festivals/favorites_query.rb
+++ b/app/queries/festivals/favorites_query.rb
@@ -1,0 +1,20 @@
+module Festivals
+  class FavoritesQuery
+    def self.call(user:, scope: Festival.all)
+      new(user: user, scope: scope).call
+    end
+
+    def initialize(user:, scope:)
+      @user = user
+      @scope = scope
+    end
+
+    def call
+      # 一覧表示で必要な関連を先読みしてN+1を避ける。
+      @scope
+        .favorited_by(@user)
+        .includes(:festival_days, :stages)
+        .order(start_date: :asc, name: :asc)
+    end
+  end
+end

--- a/app/queries/festivals/list_query.rb
+++ b/app/queries/festivals/list_query.rb
@@ -1,0 +1,30 @@
+module Festivals
+  class ListQuery
+    def self.call(status:, reference_date: Date.current, scope: Festival.all)
+      new(status: status, reference_date: reference_date, scope: scope).call
+    end
+
+    def self.default_status
+      Festival.status_filters.keys.first
+    end
+
+    def self.normalized_status(value)
+      candidate = value.to_s
+      Festival.status_filters.key?(candidate) ? candidate : default_status
+    end
+
+    def initialize(status:, reference_date:, scope:)
+      @status = status
+      @reference_date = reference_date
+      @scope = scope
+    end
+
+    def call
+      normalized = self.class.normalized_status(@status)
+      relation = normalized == "past" ? @scope.past(@reference_date) : @scope.upcoming(@reference_date)
+      # 開催済みは新しい日付を上、開催前は古い日付を上に並べる。
+      order_direction = normalized == "past" ? :desc : :asc
+      relation.order(start_date: order_direction, name: :asc)
+    end
+  end
+end

--- a/app/views/festivals/index.html.erb
+++ b/app/views/festivals/index.html.erb
@@ -13,7 +13,7 @@
       <% preserved_query = request.query_parameters.except(:page, :status) %>
       <div class="flex justify-center">
         <%= render Shared::SegmentedTabsComponent.new(
-              tabs: @status_labels,
+              tabs: status_labels,
               active_tab_key: @status,
               url_builder: ->(key) do
                 path_options = preserved_query.merge(status: key)

--- a/app/views/prep/festivals/index.html.erb
+++ b/app/views/prep/festivals/index.html.erb
@@ -5,7 +5,7 @@
       <% preserved_query = request.query_parameters.except(:page, :status) %>
       <div class="flex justify-center">
         <%= render Shared::SegmentedTabsComponent.new(
-              tabs: @status_labels,
+              tabs: status_labels,
               active_tab_key: @status,
               url_builder: ->(key) do
                 path_options = preserved_query.merge(status: key)

--- a/app/views/timetables/index.html.erb
+++ b/app/views/timetables/index.html.erb
@@ -20,7 +20,7 @@
       <% preserved_query = request.query_parameters.except(:page, :status) %>
       <div class="flex justify-center">
         <%= render Shared::SegmentedTabsComponent.new(
-              tabs: @status_labels,
+              tabs: status_labels,
               active_tab_key: @status,
               url_builder: ->(key) { timetables_path(preserved_query.merge(status: key)) }
             ) %>


### PR DESCRIPTION
## 概要
- フェス一覧系の検索・表示責務をモデルから分離し、Query Object/Helperへ移動。
- お気に入り一覧も取得ロジックを整理。
## 実施内容
- festivals_helper.rb に status_labels を移動し、ビュー側で利用。
- list_query.rb を新規作成し、一覧のステータス正規化と並び順ロジックを移管。
- フェス一覧系コントローラ/ビューを Festivals::ListQuery と status_labels に差し替え。
- festival.rb の favorited_by を「意味だけ」のスコープに整理。
- favorites_query.rb を追加し、includes/order をクエリ側へ移管。
- favorite_festivals_controller.rb を Festivals::FavoritesQuery 利用に変更。
## 対応Issue
なし
## 関連Issue
なし
## 特記事項