### PR TITLE
157 adsenseコードの修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,7 +9,7 @@
     <%= csp_meta_tag %>
     <meta name="turbo-cache-control" content="no-preview">
     <meta name="google-site-verification" content="xNg2EK5ZIULaKlH5D5Bje-I9rxqh0AwNZnFbsfcgoXA" />
-    <meta name="google-adsense-account" content="ca-pub-5061776258262847">
+    <meta name="google-adsense-account" content="ca-pub-5061776256826847">
 
     <meta property="og:site_name" content="FES READY">
     <meta property="og:title" content="<%= content_for(:title) || 'FES READY' %>">
@@ -39,11 +39,10 @@
       gtag('config', 'G-PB0CKT8EH2');
     </script>
     
-    <%# <!-- Google AdSense -->
-    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5061776258262847"
-      crossorigin="anonymous"></script>
-    %>
-    
+    <!-- Google AdSense -->
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5061776256826847"
+     crossorigin="anonymous"></script>
+
     <%# Includes all stylesheet files in app/assets/stylesheets %>
     <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>


### PR DESCRIPTION
## 概要
- adsense用のコードの変更
## 実施内容
- 数値が間違っており認証できていなかったため、修正。
## 対応Issue
なし
## 関連Issue
なし
## 特記事項