### PR TITLE
[refactor]festival関係のリファクタリング

### DIFF
--- a/app/controllers/artists/festivals_controller.rb
+++ b/app/controllers/artists/festivals_controller.rb
@@ -1,4 +1,5 @@
 class Artists::FestivalsController < ApplicationController
+  include HeaderBackPath
   before_action :set_artist
   before_action :set_header_back_path
   # 一覧→詳細で戻るときに元の一覧URLを渡すためのパラメータ
@@ -7,11 +8,11 @@ class Artists::FestivalsController < ApplicationController
   def index
     @status = Festivals::ListQuery.normalized_status(params[:status])
     @festival_tags = FestivalTag.order(:name)
-    @filter_params = filter_params
+    @filter_params = Festivals::FilterQuery.permitted_params(params)
     @selected_tag_ids = Array(@filter_params[:tag_ids]).reject(&:blank?).map(&:to_i)
 
     festival_scope = Festivals::ListQuery.call(status: @status, scope: @artist.festivals)
-    filtered_scope = apply_filters(festival_scope, @filter_params)
+    filtered_scope = Festivals::FilterQuery.call(scope: festival_scope, filters: @filter_params)
 
     @q   = filtered_scope.ransack(params[:q])
     result = @q.result(distinct: true)
@@ -28,49 +29,13 @@ class Artists::FestivalsController < ApplicationController
     @artist = Artist.find_by_identifier!(params[:artist_id])
   end
 
-  def filter_params
-    params.permit(:start_date_from, :end_date_to, :area, tag_ids: [])
-  end
-
-  def apply_filters(scope, filters)
-    filtered = scope
-
-    from_date = parse_date(filters[:start_date_from])
-    to_date   = parse_date(filters[:end_date_to])
-
-    filtered = filtered.where("start_date >= ?", from_date) if from_date
-    filtered = filtered.where("end_date <= ?", to_date) if to_date
-
-    if filters[:area].present? && Regions::AREA_PREFECTURES.key?(filters[:area])
-      prefectures = Regions::AREA_PREFECTURES[filters[:area]]
-      filtered = filtered.where(prefecture: prefectures)
-    end
-
-    tag_ids = Array(filters[:tag_ids]).reject(&:blank?).map(&:to_i)
-    if tag_ids.any?
-      filtered = filtered
-                   .joins(:festival_festival_tags)
-                   .where(festival_festival_tags: { festival_tag_id: tag_ids })
-                   .group("festivals.id")
-                   .having("COUNT(DISTINCT festival_festival_tags.festival_tag_id) = ?", tag_ids.size)
-    end
-
-    filtered
-  end
-
-  def parse_date(value)
-    return if value.blank?
-    Date.parse(value)
-  rescue ArgumentError
-    nil
-  end
-
-  def set_header_back_path
-    @header_back_path = artist_path(@artist) if @artist
-  end
-
   def set_back_to_param
     # 現在の一覧URLを保存し、詳細遷移時の戻り先として渡す
     @back_to = request.fullpath
+  end
+
+  def default_back_path
+    # back_to が無い場合はアーティスト詳細に戻す
+    artist_path(@artist) if @artist
   end
 end

--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -1,4 +1,5 @@
 class ArtistsController < ApplicationController
+  include HeaderBackPath
   before_action :set_artist, only: :show
   # 一覧から渡された戻り先があれば採用する
   before_action :set_header_back_path, only: :show
@@ -21,13 +22,5 @@ class ArtistsController < ApplicationController
 
   def set_artist
     @artist = Artist.find_published!(params[:id])
-  end
-
-  def set_header_back_path
-    back = params[:back_to].to_s
-    return if back.blank?
-    return unless back.start_with?("/")
-
-    @header_back_path = back
   end
 end

--- a/app/controllers/concerns/header_back_path.rb
+++ b/app/controllers/concerns/header_back_path.rb
@@ -1,0 +1,31 @@
+module HeaderBackPath
+  extend ActiveSupport::Concern
+
+  private
+
+  # back_to(絶対パス) > back_to(トークン) > default_back_path の順で戻り先を決める
+  def set_header_back_path
+    back = params[:back_to].to_s
+    if back.present?
+      @header_back_path =
+        if back.start_with?("/")
+          back
+        else
+          resolved_back_path(back)
+        end
+      return
+    end
+
+    @header_back_path = default_back_path
+  end
+
+  # コントローラ固有のトークン解決を上書きする
+  def resolved_back_path(_token)
+    nil
+  end
+
+  # back_to が無いときの既定の戻り先を上書きする
+  def default_back_path
+    nil
+  end
+end

--- a/app/controllers/festivals/artists_controller.rb
+++ b/app/controllers/festivals/artists_controller.rb
@@ -1,4 +1,5 @@
 class Festivals::ArtistsController < ApplicationController
+  include HeaderBackPath
   before_action :set_festival
   before_action :set_festival_days
   before_action :set_header_back_path
@@ -27,8 +28,9 @@ class Festivals::ArtistsController < ApplicationController
     @selected_festival_day = @festival_days.find_by(id: params[:festival_day_id]) || @festival_days.first
   end
 
-  def set_header_back_path
-    @header_back_path = festival_path(@festival) if @festival
+  def default_back_path
+    # back_to が無い場合はフェス詳細に戻す
+    festival_path(@festival) if @festival
   end
 
   def set_back_to_param

--- a/app/controllers/festivals_controller.rb
+++ b/app/controllers/festivals_controller.rb
@@ -1,4 +1,5 @@
 class FestivalsController < ApplicationController
+  include HeaderBackPath
   before_action :set_festival, only: :show
   # 一覧から渡された戻り先があれば採用する
   before_action :set_header_back_path, only: :show
@@ -7,11 +8,11 @@ class FestivalsController < ApplicationController
     @artist = nil
     @status = Festivals::ListQuery.normalized_status(params[:status])
     @festival_tags = FestivalTag.order(:name)
-    @filter_params = filter_params
+    @filter_params = Festivals::FilterQuery.permitted_params(params)
     @selected_tag_ids = Array(@filter_params[:tag_ids]).reject(&:blank?).map(&:to_i)
 
     festival_scope = Festivals::ListQuery.call(status: @status)
-    filtered_scope = apply_filters(festival_scope, @filter_params)
+    filtered_scope = Festivals::FilterQuery.call(scope: festival_scope, filters: @filter_params)
 
     @q     = filtered_scope.ransack(params[:q])
     result = @q.result(distinct: true)
@@ -27,50 +28,5 @@ class FestivalsController < ApplicationController
 
   def set_festival
     @festival = Festival.includes(:festival_tags).find_by_slug!(params[:id])
-  end
-
-  def filter_params
-    params.permit(:start_date_from, :end_date_to, :area, tag_ids: [])
-  end
-
-  def apply_filters(scope, filters)
-    filtered = scope
-
-    from_date = parse_date(filters[:start_date_from])
-    to_date   = parse_date(filters[:end_date_to])
-
-    filtered = filtered.where("start_date >= ?", from_date) if from_date
-    filtered = filtered.where("end_date <= ?", to_date) if to_date
-
-    if filters[:area].present? && Regions::AREA_PREFECTURES.key?(filters[:area])
-      prefectures = Regions::AREA_PREFECTURES[filters[:area]]
-      filtered = filtered.where(prefecture: prefectures)
-    end
-
-    tag_ids = Array(filters[:tag_ids]).reject(&:blank?).map(&:to_i)
-    if tag_ids.any?
-      filtered = filtered
-                   .joins(:festival_festival_tags)
-                   .where(festival_festival_tags: { festival_tag_id: tag_ids })
-                   .group("festivals.id")
-                   .having("COUNT(DISTINCT festival_festival_tags.festival_tag_id) = ?", tag_ids.size)
-    end
-
-    filtered
-  end
-
-  def parse_date(value)
-    return if value.blank?
-    Date.parse(value)
-  rescue ArgumentError
-    nil
-  end
-
-  def set_header_back_path
-    back = params[:back_to].to_s
-    return if back.blank?
-    return unless back.start_with?("/")
-
-    @header_back_path = back
   end
 end

--- a/app/controllers/packing_lists_controller.rb
+++ b/app/controllers/packing_lists_controller.rb
@@ -1,4 +1,5 @@
 class PackingListsController < ApplicationController
+  include HeaderBackPath
   before_action :authenticate_user!, except: :index
   before_action :set_packing_list, only: [ :show, :edit, :update, :destroy, :duplicate_from_template ]
   before_action :set_owned_packing_list, only: [ :edit, :update, :destroy ]
@@ -54,10 +55,6 @@ class PackingListsController < ApplicationController
   def destroy
     @packing_list.destroy!
     redirect_to packing_lists_path, notice: "持ち物リストを削除しました"
-  end
-
-  def set_header_back_path
-    @header_back_path = packing_list_path(@packing_list) if @packing_list&.persisted?
   end
 
   def duplicate_from_template
@@ -172,5 +169,10 @@ class PackingListsController < ApplicationController
       base = attrs.slice("id", "item_id", "note", "position", "_destroy")
       sanitized_item.present? ? base.merge("item_attributes" => sanitized_item) : base
     end.compact
+  end
+
+  def default_back_path
+    # 編集/更新時は編集中のリストへ戻す
+    packing_list_path(@packing_list) if @packing_list&.persisted?
   end
 end

--- a/app/controllers/prep/artists_controller.rb
+++ b/app/controllers/prep/artists_controller.rb
@@ -1,5 +1,6 @@
 module Prep
   class ArtistsController < ApplicationController
+    include HeaderBackPath
     before_action :set_artist, only: :show
 
     def index
@@ -48,9 +49,10 @@ module Prep
       @artist = Artist.find_published!(params[:id])
     end
 
-    def set_header_back_path
-      return unless params[:back_to] == "artist"
-      @header_back_path = artist_path(@artist) if @artist
+    def resolved_back_path(token)
+      # "artist" トークンは対象アーティスト詳細へ戻す
+      return artist_path(@artist) if token == "artist" && @artist
+      nil
     end
   end
 end

--- a/app/controllers/setlists_controller.rb
+++ b/app/controllers/setlists_controller.rb
@@ -1,4 +1,5 @@
 class SetlistsController < ApplicationController
+  include HeaderBackPath
   before_action :set_header_back_path, only: :show
 
   def show
@@ -13,12 +14,4 @@ class SetlistsController < ApplicationController
   end
 
   private
-
-  def set_header_back_path
-    back = params[:back_to].to_s
-    return if back.blank?
-    return unless back.start_with?("/")
-
-    @header_back_path = back
-  end
 end

--- a/app/queries/festivals/filter_query.rb
+++ b/app/queries/festivals/filter_query.rb
@@ -1,0 +1,52 @@
+module Festivals
+  # 一覧検索の共通フィルタをまとめる
+  class FilterQuery
+    def self.call(scope:, filters:)
+      new(scope: scope, filters: filters).call
+    end
+
+    def self.permitted_params(params)
+      params.permit(:start_date_from, :end_date_to, :area, tag_ids: [])
+    end
+
+    def initialize(scope:, filters:)
+      @scope = scope
+      @filters = filters
+    end
+
+    def call
+      filtered = @scope
+
+      from_date = parse_date(@filters[:start_date_from])
+      to_date   = parse_date(@filters[:end_date_to])
+
+      filtered = filtered.where("start_date >= ?", from_date) if from_date
+      filtered = filtered.where("end_date <= ?", to_date) if to_date
+
+      if @filters[:area].present? && Regions::AREA_PREFECTURES.key?(@filters[:area])
+        prefectures = Regions::AREA_PREFECTURES[@filters[:area]]
+        filtered = filtered.where(prefecture: prefectures)
+      end
+
+      tag_ids = Array(@filters[:tag_ids]).reject(&:blank?).map(&:to_i)
+      if tag_ids.any?
+        filtered = filtered
+                     .joins(:festival_festival_tags)
+                     .where(festival_festival_tags: { festival_tag_id: tag_ids })
+                     .group("festivals.id")
+                     .having("COUNT(DISTINCT festival_festival_tags.festival_tag_id) = ?", tag_ids.size)
+      end
+
+      filtered
+    end
+
+    private
+
+    def parse_date(value)
+      return if value.blank?
+      Date.parse(value)
+    rescue ArgumentError
+      nil
+    end
+  end
+end


### PR DESCRIPTION
## 概要
- 戻るボタンの設定されている親以外への挙動を HeaderBackPath に集約し、コントローラ固有の分岐は差分注入方式で整理
- フェス一覧のフィルタ処理を Festivals::FilterQuery に移して重複を削減
- 関連箇所に最小限の説明コメントを追加
## 実施内容
- HeaderBackPath にトークン解決（resolved_back_path）と既定戻り先（default_back_path）を追加し、back_to 優先の共通フローを実装
対象: header_back_path.rb
- back_to トークン対応を差分注入方式に移行
対象: timetables_controller.rb, festivals_controller.rb, artists_controller.rb
- 固定戻り先を default_back_path で共通化
対象: artists_controller.rb, festivals_controller.rb, packing_lists_controller.rb
- my_timetables の戻り先処理を HeaderBackPath に統合（index は back_to、edit は既定戻り先）
対象: my_timetables_controller.rb
- フェス一覧のフィルタ処理を Query Object 化
追加: filter_query.rb
置換: festivals_controller.rb, timetables_controller.rb, festivals_controller.rb, festivals_controller.rb
- 初見向けのコメント追加
対象: 上記関連ファイル
## 対応Issue
なし
## 関連Issue
なし
## 特記事項