### PR TITLE
[refactor]uuidロジックの共通化

### DIFF
--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -1,6 +1,6 @@
-require "securerandom"
-
 class Artist < ApplicationRecord
+  include Uuidable
+
   validates :name, presence: true, uniqueness: true
 
   scope :published, -> { where(published: true) }
@@ -11,8 +11,6 @@ class Artist < ApplicationRecord
   has_many :songs, dependent: :restrict_with_exception
   has_many :user_artist_favorites, dependent: :destroy
   has_many :favorited_users, through: :user_artist_favorites, source: :user
-
-  before_create :ensure_uuid!
 
   def self.find_by_identifier!(identifier)
     find_by(uuid: identifier) || find(identifier)
@@ -42,18 +40,8 @@ class Artist < ApplicationRecord
 
   # 将来: has_many :performances など
 
-  def to_param
-    uuid
-  end
-
   def favorited_by?(user)
     return false unless user
     user_artist_favorites.exists?(user_id: user.id)
-  end
-
-  private
-
-  def ensure_uuid!
-    self.uuid ||= SecureRandom.uuid
   end
 end

--- a/app/models/concerns/uuidable.rb
+++ b/app/models/concerns/uuidable.rb
@@ -1,0 +1,20 @@
+require "securerandom"
+
+module Uuidable
+  extend ActiveSupport::Concern
+
+  included do
+    before_validation :ensure_uuid!, on: :create
+    validates :uuid, presence: true, uniqueness: true
+  end
+
+  def to_param
+    uuid.presence || super
+  end
+
+  private
+
+  def ensure_uuid!
+    self.uuid ||= SecureRandom.uuid
+  end
+end

--- a/app/models/packing_list.rb
+++ b/app/models/packing_list.rb
@@ -1,4 +1,6 @@
 class PackingList < ApplicationRecord
+  include Uuidable
+
   belongs_to :user, optional: true
   belongs_to :festival_day, optional: true
 
@@ -15,10 +17,6 @@ class PackingList < ApplicationRecord
   validates :user_id, presence: true, unless: :template?
   validates :template, inclusion: { in: [ true, false ] }
   validate :festival_day_must_be_upcoming_if_changed
-
-  def to_param
-    uuid.presence || super
-  end
 
   def past_selected_festival_day(today = Date.current)
     return unless festival_day

--- a/app/models/setlist.rb
+++ b/app/models/setlist.rb
@@ -1,4 +1,6 @@
 class Setlist < ApplicationRecord
+  include Uuidable
+
   belongs_to :stage_performance
 
   has_many :setlist_songs, dependent: :destroy
@@ -7,8 +9,4 @@ class Setlist < ApplicationRecord
   validates :stage_performance, presence: true, uniqueness: true
 
   accepts_nested_attributes_for :setlist_songs, allow_destroy: true
-
-  def to_param
-    uuid.presence || super
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 require "securerandom"
 
 class User < ApplicationRecord
+  include Uuidable
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
@@ -20,8 +22,6 @@ class User < ApplicationRecord
   has_many :favorite_artists, through: :user_artist_favorites, source: :artist
   has_many :items, dependent: :destroy
   has_many :packing_lists, dependent: :destroy
-
-  before_create :ensure_uuid!
 
   def self.from_omniauth(auth)
     user = find_by(provider: auth.provider, uid: auth.uid)
@@ -55,15 +55,7 @@ class User < ApplicationRecord
       .pluck(:stage_performance_id)
   end
 
-  def to_param
-    uuid
-  end
-
   private
-
-  def ensure_uuid!
-    self.uuid ||= SecureRandom.uuid
-  end
 
   def self.sanitized_nickname(auth)
     nickname = auth.info.name.presence || auth.info.first_name.presence || auth.info.email.split("@").first


### PR DESCRIPTION
## 概要
- UUID生成をバリデーション前に統一
- uuid必須化とto_paramの共通ロジックをConcernに集約
## 実施内容
- concerns/uuidable.rbを新規追加し、before_validation :ensure_uuid!, on: :createとuuidのバリデーション、to_paramを共通化
- artist.rbで個別のUUID処理を削除しinclude Uuidableへ移行
- user.rbで個別のUUID処理を削除しinclude Uuidableへ移行
- packing_list.rbで個別のto_paramを削除しinclude Uuidableへ移行
- setlist.rbで個別のto_paramを削除しinclude Uuidableへ移行
## 対応Issue
なし
## 関連Issue
なし
## 特記事項