### PR TITLE
[refactor]テンプレート/所有者の共通化

### DIFF
--- a/app/models/concerns/template_owned.rb
+++ b/app/models/concerns/template_owned.rb
@@ -1,0 +1,11 @@
+module TemplateOwned
+  extend ActiveSupport::Concern
+
+  included do
+    scope :templates, -> { where(template: true) }
+    scope :owned_by, ->(user) { where(user_id: user.id) }
+
+    validates :user_id, presence: true, unless: :template?
+    validates :template, inclusion: { in: [ true, false ] }
+  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,13 +1,10 @@
 class Item < ApplicationRecord
+  include TemplateOwned
+
   belongs_to :user, optional: true
 
   has_many :packing_list_items, dependent: :destroy, inverse_of: :item
   has_many :packing_lists, through: :packing_list_items
 
-  scope :templates, -> { where(template: true) }
-  scope :owned_by, ->(user) { where(user_id: user.id) }
-
   validates :name, presence: true, length: { maximum: 100 }
-  validates :user_id, presence: true, unless: :template?
-  validates :template, inclusion: { in: [ true, false ] }
 end

--- a/app/models/packing_list.rb
+++ b/app/models/packing_list.rb
@@ -1,4 +1,6 @@
 class PackingList < ApplicationRecord
+  include TemplateOwned
+
   include Uuidable
 
   belongs_to :user, optional: true
@@ -9,13 +11,8 @@ class PackingList < ApplicationRecord
 
   accepts_nested_attributes_for :packing_list_items, allow_destroy: true
 
-  scope :templates, -> { where(template: true) }
-  scope :owned_by, ->(user) { where(user_id: user.id) }
-
   validates :title, presence: true, length: { maximum: 100 }
   validates :title, uniqueness: { scope: :user_id, message: "は既に存在します" }, unless: :template?
-  validates :user_id, presence: true, unless: :template?
-  validates :template, inclusion: { in: [ true, false ] }
   validate :festival_day_must_be_upcoming_if_changed
 
   def past_selected_festival_day(today = Date.current)


### PR DESCRIPTION
## 概要
- ItemとPackingListのテンプレート/所有者に関する重複ロジックをConcernへ集約し、責務を整理
## 実施内容
- template_owned.rbを新規追加し、templates/owned_byスコープとtemplate/user_idバリデーションを共通化
- item.rbで重複していたスコープとバリデーションを削除しinclude TemplateOwnedへ移行
- packing_list.rbで重複していたスコープとバリデーションを削除しinclude TemplateOwnedへ移行
## 対応Issue
なし
## 関連Issue
なし
## 特記事項