### PR TITLE
[refactor]お気に入り機能のロジックの共通化

### DIFF
--- a/app/controllers/mypage/favorite_artists_controller.rb
+++ b/app/controllers/mypage/favorite_artists_controller.rb
@@ -3,7 +3,7 @@ module Mypage
     before_action :authenticate_user!
 
     def index
-      favorites_scope = Artist.favorited_by(current_user)
+      favorites_scope = Artists::FavoritesQuery.call(user: current_user)
       @pagy, @artists = pagy(favorites_scope, limit: 20)
     end
   end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -1,5 +1,7 @@
 class Artist < ApplicationRecord
+  include Favoritable
   include Uuidable
+  favoritable_by :user_artist_favorites
 
   validates :name, presence: true, uniqueness: true
 
@@ -23,11 +25,6 @@ class Artist < ApplicationRecord
   def self.ransackable_attributes(_ = nil); %w[name]; end
   def self.ransackable_associations(_ = nil); []; end
 
-  scope :favorited_by, ->(user) {
-    joins(:user_artist_favorites)
-      .where(user_artist_favorites: { user_id: user.id })
-      .order(:name)
-  }
 
   # 空文字・前後空白を取り除いて nil 正規化
   normalizes :spotify_artist_id, with: ->(v) { v&.strip.presence }
@@ -39,9 +36,4 @@ class Artist < ApplicationRecord
            uniqueness: { allow_nil: true }
 
   # 将来: has_many :performances など
-
-  def favorited_by?(user)
-    return false unless user
-    user_artist_favorites.exists?(user_id: user.id)
-  end
 end

--- a/app/models/concerns/favoritable.rb
+++ b/app/models/concerns/favoritable.rb
@@ -1,0 +1,25 @@
+module Favoritable
+  extend ActiveSupport::Concern
+
+  included do
+    # Modelごとに「お気に入り中間テーブル」の関連名を設定する
+    class_attribute :favoritable_join_association, instance_writer: false
+
+    scope :favorited_by, ->(user) {
+      joins(favoritable_join_association)
+        .where(favoritable_join_association => { user_id: user.id })
+    }
+  end
+
+  class_methods do
+    def favoritable_by(association_name)
+      self.favoritable_join_association = association_name
+    end
+  end
+
+  def favorited_by?(user)
+    return false unless user
+
+    public_send(favoritable_join_association).exists?(user_id: user.id)
+  end
+end

--- a/app/models/festival.rb
+++ b/app/models/festival.rb
@@ -1,4 +1,6 @@
 class Festival < ApplicationRecord
+  include Favoritable
+  favoritable_by :user_festival_favorites
   attribute :status_filter, :string
   enum :status_filter, { upcoming: "upcoming", past: "past" }, scopes: false
 
@@ -21,10 +23,6 @@ class Festival < ApplicationRecord
   scope :past,     ->(today = Date.current) { where("end_date < ?",  today) }
   scope :with_published_timetable, -> { where(timetable_published: true) }
   scope :with_slug, ->(slug) { where(slug: slug) }
-  scope :favorited_by, ->(user) {
-    joins(:user_festival_favorites)
-      .where(user_festival_favorites: { user_id: user.id })
-  }
 
   before_validation -> { self.official_url = official_url&.strip.presence }
 
@@ -66,12 +64,6 @@ class Festival < ApplicationRecord
       .merge(Artist.published)
       .distinct
       .order(:name)
-  end
-
-  # 指定したユーザーがお気に入り済みかどうかを判定するヘルパー
-  def favorited_by?(user)
-    return false unless user
-    user_festival_favorites.exists?(user_id: user.id)
   end
 
   private

--- a/app/queries/artists/favorites_query.rb
+++ b/app/queries/artists/favorites_query.rb
@@ -1,0 +1,18 @@
+module Artists
+  class FavoritesQuery
+    def self.call(user:, scope: Artist.all)
+      new(user: user, scope: scope).call
+    end
+
+    def initialize(user:, scope:)
+      @user = user
+      @scope = scope
+    end
+
+    def call
+      @scope
+        .favorited_by(@user)
+        .order(:name)
+    end
+  end
+end

--- a/spec/models/concerns/favoritable_spec.rb
+++ b/spec/models/concerns/favoritable_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe "Favoritable", type: :model do
+  describe ".favorited_by" do
+    it "artistでお気に入り済みのみ返す" do
+      user = create(:user)
+      other_user = create(:user)
+      artist = create(:artist)
+      other_artist = create(:artist)
+      create(:user_artist_favorite, user: user, artist: artist)
+      create(:user_artist_favorite, user: other_user, artist: other_artist)
+
+      expect(Artist.favorited_by(user)).to contain_exactly(artist)
+    end
+
+    it "festivalでお気に入り済みのみ返す" do
+      user = create(:user)
+      other_user = create(:user)
+      festival = create(:festival)
+      other_festival = create(:festival)
+      create(:user_festival_favorite, user: user, festival: festival)
+      create(:user_festival_favorite, user: other_user, festival: other_festival)
+
+      expect(Festival.favorited_by(user)).to contain_exactly(festival)
+    end
+  end
+
+  describe "#favorited_by?" do
+    it "artistのお気に入り状態を判定できる" do
+      user = create(:user)
+      other_user = create(:user)
+      artist = create(:artist)
+      create(:user_artist_favorite, user: user, artist: artist)
+
+      expect(artist.favorited_by?(user)).to be(true)
+      expect(artist.favorited_by?(other_user)).to be(false)
+      expect(artist.favorited_by?(nil)).to be(false)
+    end
+
+    it "festivalのお気に入り状態を判定できる" do
+      user = create(:user)
+      other_user = create(:user)
+      festival = create(:festival)
+      create(:user_festival_favorite, user: user, festival: festival)
+
+      expect(festival.favorited_by?(user)).to be(true)
+      expect(festival.favorited_by?(other_user)).to be(false)
+      expect(festival.favorited_by?(nil)).to be(false)
+    end
+  end
+end

--- a/spec/queries/artists/favorites_query_spec.rb
+++ b/spec/queries/artists/favorites_query_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe Artists::FavoritesQuery do
+  describe ".call" do
+    it "お気に入り済みのアーティストだけ返す" do
+      user = create(:user)
+      artist = create(:artist, name: "Artist A")
+      other_artist = create(:artist, name: "Artist B")
+      create(:user_artist_favorite, user: user, artist: artist)
+
+      result = described_class.call(user: user)
+
+      expect(result).to contain_exactly(artist)
+      expect(result).not_to include(other_artist)
+    end
+
+    it "名前順で返す" do
+      user = create(:user)
+      artist_b = create(:artist, name: "B Artist")
+      artist_a = create(:artist, name: "A Artist")
+      create(:user_artist_favorite, user: user, artist: artist_b)
+      create(:user_artist_favorite, user: user, artist: artist_a)
+
+      result = described_class.call(user: user)
+
+      expect(result.map(&:name)).to eq([ "A Artist", "B Artist" ])
+    end
+  end
+end


### PR DESCRIPTION
## 概要
- お気に入り機能のロジックの共通化
- アーティストお気に入り一覧の並び順の取得ロジックをQueryへ集約
## 実施内容
- favoritable.rbを追加し、favorited_byスコープとfavorited_by?判定を共通化
- artist.rb/festival.rbで共通ロジックに移行し、関連名を設定
- favorites_query.rbを新設し、アーティストお気に入りの並び順をQuery側で指定
- favorite_artists_controller.rbをQuery利用に変更
- テスト追加: favoritable_spec.rb と favorites_query_spec.rb
## 対応Issue
なし
## 関連Issue
なし
## 特記事項