### PR TITLE
[refactor]表示寄りのクエリの切り出し

### DIFF
--- a/app/models/festival.rb
+++ b/app/models/festival.rb
@@ -47,23 +47,17 @@ class Festival < ApplicationRecord
   end
 
   def stage_performances_on(festival_day)
-    return StagePerformance.none if festival_day.blank?
-    raise ArgumentError, "festival_day must belong to festival" if festival_day.festival_id != id
-
-    festival_day.stage_performances
-                .includes(:stage, :artist)
-                .order(:starts_at)
+    Festivals::StagePerformancesForDayQuery.call(
+      festival: self,
+      festival_day: festival_day
+    )
   end
 
   def artists_for_day(festival_day)
-    return Artist.none if festival_day.blank? || festival_day.festival_id != id
-
-    Artist
-      .joins(stage_performances: :festival_day)
-      .where(stage_performances: { festival_day_id: festival_day.id })
-      .merge(Artist.published)
-      .distinct
-      .order(:name)
+    Festivals::ArtistsForDayQuery.call(
+      festival: self,
+      festival_day: festival_day
+    )
   end
 
   private

--- a/app/models/festival_day.rb
+++ b/app/models/festival_day.rb
@@ -5,13 +5,7 @@ class FestivalDay < ApplicationRecord
   validates :date, presence: true
   validates :date, uniqueness: { scope: :festival_id }
 
-  scope :for_user, ->(user) {
-    joins(:festival, stage_performances: :user_timetable_entries)
-      .where(user_timetable_entries: { user_id: user.id })
-      .includes(:festival)
-      .distinct
-      .order("festivals.start_date ASC", "festival_days.date ASC")
-  }
+  scope :for_user, ->(user) { FestivalDays::ForUserQuery.call(user: user) }
 
   scope :upcoming, ->(today = Date.current) {
     joins(:festival).where("festivals.end_date >= ?", today)

--- a/app/queries/festival_days/for_user_query.rb
+++ b/app/queries/festival_days/for_user_query.rb
@@ -1,0 +1,21 @@
+module FestivalDays
+  class ForUserQuery
+    def self.call(user:)
+      new(user: user).call
+    end
+
+    def initialize(user:)
+      @user = user
+    end
+
+    def call
+      FestivalDay
+        .joins(:festival, stage_performances: :user_timetable_entries)
+        .where(user_timetable_entries: { user_id: @user.id })
+        .includes(:festival)
+        .distinct
+        # 一覧表示で「フェス開始日 → 日程」の順に揃える
+        .order("festivals.start_date ASC", "festival_days.date ASC")
+    end
+  end
+end

--- a/app/queries/festivals/artists_for_day_query.rb
+++ b/app/queries/festivals/artists_for_day_query.rb
@@ -1,0 +1,24 @@
+module Festivals
+  class ArtistsForDayQuery
+    def self.call(festival:, festival_day:)
+      new(festival: festival, festival_day: festival_day).call
+    end
+
+    def initialize(festival:, festival_day:)
+      @festival = festival
+      @festival_day = festival_day
+    end
+
+    def call
+      return Artist.none if @festival_day.blank? || @festival_day.festival_id != @festival.id
+
+      Artist
+        .joins(stage_performances: :festival_day)
+        .where(stage_performances: { festival_day_id: @festival_day.id })
+        .merge(Artist.published)
+        .distinct
+        # 表示用にアーティスト名で並べる
+        .order(:name)
+    end
+  end
+end

--- a/app/queries/festivals/stage_performances_for_day_query.rb
+++ b/app/queries/festivals/stage_performances_for_day_query.rb
@@ -1,0 +1,22 @@
+module Festivals
+  class StagePerformancesForDayQuery
+    def self.call(festival:, festival_day:)
+      new(festival: festival, festival_day: festival_day).call
+    end
+
+    def initialize(festival:, festival_day:)
+      @festival = festival
+      @festival_day = festival_day
+    end
+
+    def call
+      return StagePerformance.none if @festival_day.blank?
+      raise ArgumentError, "festival_day must belong to festival" if @festival_day.festival_id != @festival.id
+
+      @festival_day.stage_performances
+                   .includes(:stage, :artist)
+                   # 表示用に開始時刻順
+                   .order(:starts_at)
+    end
+  end
+end


### PR DESCRIPTION
## 概要
- Festival/FestivalDayの複雑な表示用クエリをQuery Objectへ切り出し、モデルの責務を整理
## 実施内容
- Festivals::StagePerformancesForDayQueryを追加し、出演枠取得のクエリを分離
- Festivals::ArtistsForDayQueryを追加し、日別アーティスト取得のクエリを分離
- FestivalDays::ForUserQueryを追加し、ユーザー別日程取得のクエリを分離
- festival.rbは上記Queryを呼ぶ形に変更
- festival_day.rbのfor_userスコープをQuery呼び出しに変更
- 並び順の意図が分かるよう、Query内にコメントを追加
## 対応Issue
なし
## 関連Issue
なし
## 特記事項