### PR TITLE
[refactor]外部認証連携のコードの分離

### DIFF
--- a/app/services/users/from_omniauth.rb
+++ b/app/services/users/from_omniauth.rb
@@ -1,0 +1,28 @@
+module Users
+  class FromOmniauth
+    def self.call(auth)
+      new(auth).call
+    end
+
+    def initialize(auth)
+      @auth = auth
+    end
+
+    def call
+      user = User.find_by(provider: @auth.provider, uid: @auth.uid)
+      user ||= User.find_by(email: @auth.info.email)
+
+      nickname = user&.nickname.presence || User.sanitized_nickname(@auth)
+
+      user ||= User.new(
+        email: @auth.info.email,
+        password: Devise.friendly_token[0, 20],
+        nickname: nickname
+      )
+
+      user.assign_attributes(provider: @auth.provider, uid: @auth.uid, nickname: nickname)
+      user.save!
+      user
+    end
+  end
+end


### PR DESCRIPTION
## 概要
- User.from_omniauthの処理をサービスに切り出し、認証連携の責務を分離
## 実施内容
- from_omniauth.rbを追加し、外部認証ユーザー作成/更新ロジックを移動
- user.rbのfrom_omniauthはサービス委譲に変更
- sanitized_nicknameをクラスメソッドとして上部に整理し、サービスから参照できるように公開
- Deviseコメントを日本語化
## 対応Issue
なし
## 関連Issue
なし
## 特記事項