### PR TITLE
[refactor]Stageの色定義部分を切り離し

### DIFF
--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -3,18 +3,9 @@ class Stage < ApplicationRecord
   has_many :stage_performances, dependent: :destroy
   validates :name, presence: true
 
-  COLOR_PALETTE = {
-    "red"      => "#F95858",
-    "emerald"  => "#10B981",
-    "blue"     => "#3B82F6",
-    "amber"    => "#F59E0B",
-    "violet"   => "#8B5CF6",
-    "slate"    => "#64748B"
-  }.freeze
-
-  validates :color_key, inclusion: { in: COLOR_PALETTE.keys }, allow_nil: true
+  validates :color_key, inclusion: { in: StageColor.valid_keys }, allow_nil: true
 
   def color_hex
-    COLOR_PALETTE[color_key.presence || "slate"]
+    StageColor.hex_for(color_key)
   end
 end

--- a/app/models/stage_color.rb
+++ b/app/models/stage_color.rb
@@ -1,0 +1,21 @@
+class StageColor
+  # ActiveRecordではなく、色定義だけを持つ値オブジェクト
+  PALETTE = {
+    "red"      => "#F95858",
+    "emerald"  => "#10B981",
+    "blue"     => "#3B82F6",
+    "amber"    => "#F59E0B",
+    "violet"   => "#8B5CF6",
+    "slate"    => "#64748B"
+  }.freeze
+
+  DEFAULT_KEY = "slate"
+
+  def self.valid_keys
+    PALETTE.keys
+  end
+
+  def self.hex_for(color_key)
+    PALETTE[color_key.presence || DEFAULT_KEY]
+  end
+end


### PR DESCRIPTION
## 概要
- Stageの色定義を値オブジェクトに切り出し、表示寄りのロジックを分離
## 実施内容
- stage_color.rbを新規追加し、色パレットとデフォルト色の解決ロジックを集約
- stage.rbのCOLOR_PALETTEを削除し、バリデーションとcolor_hexをStageColor参照に変更
- StageColorがActiveRecordではない旨のコメントを追加
## 対応Issue
なし
## 関連Issue
なし
## 特記事項