### PR TITLE
[refactor]文字列正規化処理の切り出し

### DIFF
--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -27,7 +27,7 @@ class Artist < ApplicationRecord
 
 
   # 空文字・前後空白を取り除いて nil 正規化
-  normalizes :spotify_artist_id, with: ->(v) { v&.strip.presence }
+  normalizes :spotify_artist_id, with: ->(v) { NameNormalizer.strip_presence(v) }
 
   # SpotifyのIDは Base62 22文字（例: 0OdUWJ0sBjDrqHygGUXeCF）
   validates :spotify_artist_id,

--- a/app/models/name_normalizer.rb
+++ b/app/models/name_normalizer.rb
@@ -1,0 +1,19 @@
+class NameNormalizer
+  # ActiveRecordではなく、文字列正規化を担当する値オブジェクト
+  # normalize: Song の名前正規化用
+  # strip_presence: Artist のID整形用
+  def self.strip_presence(value)
+    value&.strip.presence
+  end
+
+  def self.normalize(value)
+    base = value.to_s.strip
+    # Unicode正規化が利用可能なら実行（環境によってunicode_normalize拡張が無い場合がある）
+    base = base.unicode_normalize(:nfkc) if base.respond_to?(:unicode_normalize)
+
+    base.mb_chars
+        .downcase
+        .to_s
+        .gsub(/\s+/, " ")
+  end
+end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -19,14 +19,7 @@ class Song < ApplicationRecord
   validates :normalized_name, uniqueness: { scope: :artist_id }
 
   def self.normalize_name(value)
-    base = value.to_s.strip
-    # Unicode正規化が利用可能なら実行（環境によってunicode_normalize拡張が無い場合がある）
-    base = base.unicode_normalize(:nfkc) if base.respond_to?(:unicode_normalize)
-
-    base.mb_chars
-        .downcase
-        .to_s
-        .gsub(/\s+/, " ")
+    NameNormalizer.normalize(value)
   end
 
   private


### PR DESCRIPTION
## 概要
- 文字列正規化処理をNameNormalizerへ切り出し、モデルの責務を整理
## 実施内容
- name_normalizer.rbを新規追加し、normalize/strip_presenceを集約
- song.rbのnormalize_nameはNameNormalizer.normalizeを利用
- artist.rbのspotify_artist_id整形はNameNormalizer.strip_presenceに置き換え
- NameNormalizerに用途コメントを追加
## 対応Issue
なし
## 関連Issue
なし
## 特記事項