### PR TITLE
[refactor]コンポーネントのメソッドの共通化

### DIFF
--- a/app/components/stage_columns/my_timetable_picker_column_component.rb
+++ b/app/components/stage_columns/my_timetable_picker_column_component.rb
@@ -1,30 +1,13 @@
 module StageColumns
   class MyTimetablePickerColumnComponent < TimetableColumnBaseComponent
     def initialize(stage:, performances:, time_markers:, timeline_layout:, picked_ids: [])
-      @stage = stage
-      @performances = Array(performances)
-      @time_markers = Array(time_markers)
-      @timeline_layout = timeline_layout
+      super(stage: stage, performances: performances, time_markers: time_markers, timeline_layout: timeline_layout)
       @picked_ids = Array(picked_ids)
-    end
-
-    def call
-      render base_component
     end
 
     private
 
-    attr_reader :stage, :performances, :time_markers, :timeline_layout, :picked_ids
-
-    def base_component
-      TimetableColumnBaseComponent.new(
-        stage: stage,
-        performances: performances,
-        time_markers: time_markers,
-        timeline_layout: timeline_layout,
-        block_renderer_callback: method(:render_block)
-      )
-    end
+    attr_reader :picked_ids
 
     def render_block(performance, block)
       input_id = "stage-performance-#{performance.id}"

--- a/app/components/stage_columns/my_timetable_view_column_component.rb
+++ b/app/components/stage_columns/my_timetable_view_column_component.rb
@@ -1,10 +1,7 @@
 module StageColumns
   class MyTimetableViewColumnComponent < TimetableColumnBaseComponent
     def initialize(stage:, performances:, time_markers:, timeline_layout:, festival:, selected_day:, selected_ids:, owner_identifier: nil, back_to: nil)
-      @stage = stage
-      @performances = Array(performances)
-      @time_markers = Array(time_markers)
-      @timeline_layout = timeline_layout
+      super(stage: stage, performances: performances, time_markers: time_markers, timeline_layout: timeline_layout)
       @festival = festival
       @selected_day = selected_day
       @selected_ids = Array(selected_ids)
@@ -12,24 +9,9 @@ module StageColumns
       @back_to = back_to
     end
 
-    def call
-      render base_component
-    end
-
     private
 
-    attr_reader :stage, :performances, :time_markers, :timeline_layout,
-                :festival, :selected_day, :selected_ids, :owner_identifier, :back_to
-
-    def base_component
-      TimetableColumnBaseComponent.new(
-        stage: stage,
-        performances: performances,
-        time_markers: time_markers,
-        timeline_layout: timeline_layout,
-        block_renderer_callback: method(:render_block)
-      )
-    end
+    attr_reader :festival, :selected_day, :selected_ids, :owner_identifier, :back_to
 
     def render_block(performance, block)
       selected = selected_ids.include?(performance.id)

--- a/app/components/stage_columns/public_timetable_column_component.rb
+++ b/app/components/stage_columns/public_timetable_column_component.rb
@@ -1,32 +1,15 @@
 module StageColumns
   class PublicTimetableColumnComponent < TimetableColumnBaseComponent
     def initialize(stage:, performances:, time_markers:, timeline_layout:, festival:, selected_day: nil, back_to: nil)
-      @stage = stage
-      @performances = Array(performances)
-      @time_markers = Array(time_markers)
-      @timeline_layout = timeline_layout
+      super(stage: stage, performances: performances, time_markers: time_markers, timeline_layout: timeline_layout)
       @festival = festival
       @selected_day = selected_day
       @back_to = back_to
     end
 
-    def call
-      render base_component
-    end
-
     private
 
-    attr_reader :stage, :performances, :time_markers, :timeline_layout, :festival, :selected_day, :back_to
-
-    def base_component
-      TimetableColumnBaseComponent.new(
-        stage: stage,
-        performances: performances,
-        time_markers: time_markers,
-        timeline_layout: timeline_layout,
-        block_renderer_callback: method(:render_block)
-      )
-    end
+    attr_reader :festival, :selected_day, :back_to
 
     def render_block(performance, block)
       block_body = default_block_content(block, block.artist_name, canceled: canceled?(performance))

--- a/app/components/stage_columns/timetable_column_base_component.html.erb
+++ b/app/components/stage_columns/timetable_column_base_component.html.erb
@@ -10,6 +10,7 @@
 
     <div class="relative h-full w-full">
       <% performance_blocks.each do |performance, block| %>
+        <%# 子コンポーネントのrender_blockが呼ばれる %>
         <%= render_block(performance, block) %>
       <% end %>
     </div>

--- a/app/components/stage_columns/timetable_column_base_component.rb
+++ b/app/components/stage_columns/timetable_column_base_component.rb
@@ -1,12 +1,11 @@
 module StageColumns
   class TimetableColumnBaseComponent < ViewComponent::Base
-    # 子コンポーネントのrender_blockを呼ぶためのコールバックを受け取る
-    def initialize(stage:, performances:, time_markers:, timeline_layout:, block_renderer_callback:)
+    # 共通の入力だけを受け取り、描画は子のrender_blockに委譲する
+    def initialize(stage:, performances:, time_markers:, timeline_layout:)
       @stage = stage
       @performances = Array(performances)
       @time_markers = Array(time_markers)
       @timeline_layout = timeline_layout
-      @block_renderer_callback = block_renderer_callback
     end
 
     private
@@ -15,11 +14,6 @@ module StageColumns
 
     def timeline_layout
       @timeline_layout || raise(ArgumentError, "timeline_layout is required")
-    end
-
-    # 子の描画処理を呼び出すためのコールバック
-    def block_renderer_callback
-      @block_renderer_callback || raise(ArgumentError, "block_renderer_callback is required")
     end
 
     # ブロック共通のコンテナクラス
@@ -98,7 +92,7 @@ module StageColumns
 
     # ブロック描画は呼び出し側に委譲
     def render_block(performance, block)
-      block_renderer_callback.call(performance, block)
+      raise NotImplementedError, "Subclasses must implement #render_block"
     end
   end
 end


### PR DESCRIPTION
## 概要
- コードを「親が描画、子は render_block だけ実装」に整理し、StageColumnsの描画フローをテンプレートメソッド方式へ統一
## 実施内容
- timetable_column_base_component.rb を「共通描画 + render_block委譲」型に変更し、block_renderer_callback を削除
- public_timetable_column_component.rb の base_component / call を削除し、render_block のみ実装
- my_timetable_view_column_component.rb の base_component / call を削除し、render_block のみ実装
- my_timetable_picker_column_component.rb の base_component / call を削除し、render_block のみ実装
## 対応Issue
なし
## 関連Issue
なし
## 特記事項
base_component の重複を排除し、責務が「親＝枠」「子＝中身」に明確化した。