### PR TITLE
[fix]チェックボックスの付け外し機能の改善

### DIFF
--- a/app/views/packing_list_items/update.turbo_stream.erb
+++ b/app/views/packing_list_items/update.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "packing_list_item_#{@packing_list_item.id}" do %>
+  <%= render "packing_lists/item", packing_list: @packing_list, pli: @packing_list_item, owned_list: true %>
+<% end %>

--- a/app/views/packing_lists/_item.html.erb
+++ b/app/views/packing_lists/_item.html.erb
@@ -1,0 +1,32 @@
+<turbo-frame id="packing_list_item_<%= pli.id %>">
+  <li class="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 shadow-sm">
+    <% if owned_list %>
+      <%# packing_list配下のpacking_list_item更新URLに送信する %>
+      <%= form_with model: [ packing_list, pli ],
+                    method: :patch,
+                    class: "flex items-start gap-3" do |f| %>
+        <%= f.check_box :checked,
+                        class: "mt-1 h-5 w-5 rounded border-slate-400 text-indigo-500 focus:ring-indigo-500",
+                        data: { controller: "auto-submit", action: "change->auto-submit#submit" } %>
+        <div class="min-w-0 space-y-1">
+          <p class="break-words text-sm font-semibold <%= pli.checked ? 'text-slate-500' : 'text-slate-900' %>">
+            <%= pli.item.name %>
+          </p>
+          <% if pli.note.present? %>
+            <p class="break-words text-xs text-slate-600"><%= pli.note %></p>
+          <% end %>
+        </div>
+      <% end %>
+    <% else %>
+      <div class="flex items-start gap-3">
+        <div class="mt-1 h-5 w-5 rounded border border-slate-300 bg-white"></div>
+        <div class="min-w-0 space-y-1">
+          <p class="break-words text-sm font-semibold text-slate-900"><%= pli.item.name %></p>
+          <% if pli.note.present? %>
+            <p class="break-words text-xs text-slate-600"><%= pli.note %></p>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  </li>
+</turbo-frame>

--- a/app/views/packing_lists/show.html.erb
+++ b/app/views/packing_lists/show.html.erb
@@ -34,37 +34,7 @@
       <% if @packing_list_items.any? %>
         <ul class="space-y-3">
           <% @packing_list_items.each do |pli| %>
-            <li class="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 shadow-sm">
-              <% if owned_list %>
-                <%= form_with url: toggle_packing_list_packing_list_item_path(@packing_list, pli),
-                              method: :patch,
-                              class: "flex items-start gap-3" do %>
-                  <%= check_box_tag "checked",
-                                    "1",
-                                    pli.checked,
-                                    class: "mt-1 h-5 w-5 rounded border-slate-400 text-indigo-500 focus:ring-indigo-500",
-                                    data: { controller: "auto-submit", action: "change->auto-submit#submit" } %>
-                  <div class="min-w-0 space-y-1">
-                    <p class="break-words text-sm font-semibold <%= pli.checked ? 'text-slate-500' : 'text-slate-900' %>">
-                      <%= pli.item.name %>
-                    </p>
-                    <% if pli.note.present? %>
-                      <p class="break-words text-xs text-slate-600"><%= pli.note %></p>
-                    <% end %>
-                  </div>
-                <% end %>
-              <% else %>
-                <div class="flex items-start gap-3">
-                  <div class="mt-1 h-5 w-5 rounded border border-slate-300 bg-white"></div>
-                  <div class="min-w-0 space-y-1">
-                    <p class="break-words text-sm font-semibold text-slate-900"><%= pli.item.name %></p>
-                    <% if pli.note.present? %>
-                      <p class="break-words text-xs text-slate-600"><%= pli.note %></p>
-                    <% end %>
-                  </div>
-                </div>
-              <% end %>
-            </li>
+            <%= render "packing_lists/item", packing_list: @packing_list, pli: pli, owned_list: owned_list %>
           <% end %>
         </ul>
       <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,11 +43,7 @@ Rails.application.routes.draw do
   end
 
   resources :packing_lists do
-    resources :packing_list_items, only: [ :create, :update, :destroy ] do
-      member do
-        patch :toggle
-      end
-    end
+    resources :packing_list_items, only: [ :update ]
     member do
       post :duplicate_from_template
     end

--- a/spec/requests/packing_list_items_spec.rb
+++ b/spec/requests/packing_list_items_spec.rb
@@ -5,48 +5,18 @@ RSpec.describe "持ち物リスト項目のリクエスト", type: :request do
   let(:packing_list) { create(:packing_list, user: user) }
   let(:item) { create(:item, user: user) }
 
-  describe "POST /packing_lists/:packing_list_id/packing_list_items" do
-    context "ログイン済みのとき" do
-      before { sign_in user, scope: :user }
-
-      it "項目を追加してリストへリダイレクトする" do
-        expect {
-          post packing_list_packing_list_items_path(packing_list),
-               params: { packing_list_item: { item_id: item.id, note: "メモ", position: 1 } }
-        }.to change { packing_list.packing_list_items.count }.by(1)
-
-        expect(response).to redirect_to(packing_list_path(packing_list))
-        created_item = packing_list.packing_list_items.order(:created_at).last
-        expect(created_item.note).to eq("メモ")
-        expect(created_item.position).to eq(1)
-      end
-    end
-
-    context "未ログインのとき" do
-      it "ログイン画面へリダイレクトし、追加されない" do
-        expect {
-          post packing_list_packing_list_items_path(packing_list),
-               params: { packing_list_item: { item_id: item.id } }
-        }.not_to change(PackingListItem, :count)
-
-        expect(response).to redirect_to(new_user_session_path)
-      end
-    end
-  end
-
   describe "PATCH /packing_lists/:packing_list_id/packing_list_items/:id" do
     let!(:packing_list_item) { create(:packing_list_item, packing_list: packing_list, item: item, note: "旧メモ", position: 0) }
 
-    it "項目の内容を更新してリストへリダイレクトする" do
+    it "チェック状態を更新してリストへリダイレクトする" do
       sign_in user, scope: :user
 
       patch packing_list_packing_list_item_path(packing_list, packing_list_item),
-            params: { packing_list_item: { note: "新しいメモ", position: 2 } }
+            params: { packing_list_item: { checked: true } }
 
       expect(response).to redirect_to(packing_list_path(packing_list))
       packing_list_item.reload
-      expect(packing_list_item.note).to eq("新しいメモ")
-      expect(packing_list_item.position).to eq(2)
+      expect(packing_list_item.checked).to be(true)
     end
 
     it "更新に失敗したら内容は変わらない" do
@@ -68,54 +38,6 @@ RSpec.describe "持ち物リスト項目のリクエスト", type: :request do
 
       expect(response).to have_http_status(:not_found)
       expect(packing_list_item.reload.note).to eq("旧メモ")
-    end
-  end
-
-  describe "PATCH /packing_lists/:packing_list_id/packing_list_items/:id/toggle" do
-    let!(:packing_list_item) { create(:packing_list_item, packing_list: packing_list, item: item, checked: false) }
-
-    it "チェック状態をトグルしてリストへリダイレクトする" do
-      sign_in user, scope: :user
-
-      patch toggle_packing_list_packing_list_item_path(packing_list, packing_list_item)
-
-      expect(response).to redirect_to(packing_list_path(packing_list))
-      expect(packing_list_item.reload.checked).to be(true)
-    end
-
-    it "他人のリストは404を返す" do
-      other_user = create(:user)
-      sign_in other_user, scope: :user
-
-      patch toggle_packing_list_packing_list_item_path(packing_list, packing_list_item)
-
-      expect(response).to have_http_status(:not_found)
-      expect(packing_list_item.reload.checked).to be(false)
-    end
-  end
-
-  describe "DELETE /packing_lists/:packing_list_id/packing_list_items/:id" do
-    let!(:packing_list_item) { create(:packing_list_item, packing_list: packing_list, item: item) }
-
-    it "項目を削除してリストへリダイレクトする" do
-      sign_in user, scope: :user
-
-      expect {
-        delete packing_list_packing_list_item_path(packing_list, packing_list_item)
-      }.to change { packing_list.packing_list_items.count }.by(-1)
-
-      expect(response).to redirect_to(packing_list_path(packing_list))
-    end
-
-    it "他人のリストは404を返す" do
-      other_user = create(:user)
-      sign_in other_user, scope: :user
-
-      expect {
-        delete packing_list_packing_list_item_path(packing_list, packing_list_item)
-      }.not_to change(PackingListItem, :count)
-
-      expect(response).to have_http_status(:not_found)
     end
   end
 end


### PR DESCRIPTION
## 概要
- チェックボックスの付け外しを、ページ全体リロードなしで行えるように改善
- 更新専用の仕様に合わせてルーティング・コントローラ・テストを整理
## 実施内容
- チェック行をパーシャル化し、各行を turbo-frame で囲むように変更
- packing_list_items#update を Turbo Stream 対応にし、行だけ差し替えるように変更
- update.turbo_stream.erb を追加
- packing_list_items のルーティングを更新専用に整理
- PackingListItemsController の create / destroy を削除し、チェック更新に特化
- 仕様変更に合わせて packing_list_items_spec.rb を更新
## 対応Issue
- close #357 
## 関連Issue
なし
## 特記事項
Turbo Streamで行単位の更新に切り替え、スクロール位置が戻る問題を解消。