### PR TITLE
[update]戻るボタンで一覧の検索条件が保持される

### DIFF
--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -14,6 +14,7 @@ class ArtistsController < ApplicationController
     result = @q.result(distinct: true)
 
     @pagy, @artists = pagy(result, params: request.query_parameters)
+    @back_to = request.fullpath
   end
 
   def show; end

--- a/app/controllers/festivals_controller.rb
+++ b/app/controllers/festivals_controller.rb
@@ -19,6 +19,7 @@ class FestivalsController < ApplicationController
 
     pagy_params = request.query_parameters.merge(status: @status)
     @pagy, @festivals = pagy(result, limit: 20, params: pagy_params)
+    @back_to = request.fullpath
   end
 
   def show

--- a/app/controllers/timetables_controller.rb
+++ b/app/controllers/timetables_controller.rb
@@ -21,6 +21,7 @@ class TimetablesController < ApplicationController
 
     pagy_params = request.query_parameters.merge(status: @status)
     @pagy, @festivals = pagy(result, limit: 20, params: pagy_params)
+    @back_to = request.fullpath
   end
 
   def show

--- a/app/views/timetables/index.html.erb
+++ b/app/views/timetables/index.html.erb
@@ -57,7 +57,7 @@
 
     <section class="grid gap-3 md:grid-cols-2 md:gap-4">
       <% if @festivals.any? %>
-          <% back_to = params[:back_to].presence %>
+          <% back_to = params[:back_to].presence || @back_to %>
           <% @festivals.each do |festival| %>
             <div class="w-full">
               <%= render "shared/nav_stack_button",


### PR DESCRIPTION
## 概要
- 検索・絞り込み後に詳細へ遷移しても、戻るボタンで一覧の検索条件が保持されるように改善
## 実施内容
- 一覧の現在URLを back_to として保持するように追加。festivals_controller.rb
- アーティスト一覧でも同様に back_to を保持。artists_controller.rb
- タイムテーブル一覧でも back_to を保持。timetables_controller.rb
- タイムテーブル一覧の詳細リンクで params[:back_to] を優先しつつ一覧の @back_to をフォールバックに。index.html.erb
## 対応Issue
- close #397 
## 関連Issue
なし
## 特記事項