### PR TITLE
[refactor]持ち物リスト作成まわりの責務を整理

### DIFF
--- a/app/controllers/packing_lists_controller.rb
+++ b/app/controllers/packing_lists_controller.rb
@@ -1,7 +1,7 @@
 class PackingListsController < ApplicationController
   include HeaderBackPath
   before_action :authenticate_user!, except: :index
-  before_action :set_packing_list, only: [ :show, :edit, :update, :destroy, :duplicate_from_template ]
+  before_action :set_packing_list, only: [ :show, :edit, :update, :destroy ]
   before_action :set_owned_packing_list, only: [ :edit, :update, :destroy ]
   before_action :set_available_items, only: [ :new, :create, :edit, :update ]
   before_action :set_header_back_path, only: [ :edit, :update ]
@@ -20,13 +20,13 @@ class PackingListsController < ApplicationController
 
   def new
     @packing_list = current_user.packing_lists.build
-    apply_template_if_present
+    @packing_list.apply_template_from_id(params[:template_id])
     prepare_form_data
   end
 
   def create
     @packing_list = current_user.packing_lists.build(packing_list_params)
-    assign_owner_to_new_items(@packing_list)
+    @packing_list.assign_owner_to_new_items!(current_user)
     if @packing_list.save
       redirect_to @packing_list, notice: "持ち物リストを作成しました"
     else
@@ -42,7 +42,7 @@ class PackingListsController < ApplicationController
 
   def update
     @packing_list.assign_attributes(packing_list_params)
-    assign_owner_to_new_items(@packing_list)
+    @packing_list.assign_owner_to_new_items!(current_user)
     if @packing_list.save
       redirect_to @packing_list, notice: "持ち物リストを更新しました"
     else
@@ -55,28 +55,6 @@ class PackingListsController < ApplicationController
   def destroy
     @packing_list.destroy!
     redirect_to packing_lists_path, notice: "持ち物リストを削除しました"
-  end
-
-  def duplicate_from_template
-    unless @packing_list.template?
-      redirect_to packing_lists_path, alert: "テンプレートのみ複製できます" and return
-    end
-
-    new_list = current_user.packing_lists.build(title: @packing_list.title)
-    ActiveRecord::Base.transaction do
-      new_list.save!
-      @packing_list.packing_list_items.find_each do |pli|
-        new_list.packing_list_items.create!(
-          item_id: pli.item_id,
-          position: pli.position,
-          note: pli.note
-        )
-      end
-    end
-
-    redirect_to new_list, notice: "テンプレートからリストを作成しました"
-  rescue ActiveRecord::RecordInvalid
-    redirect_to packing_lists_path, alert: "複製に失敗しました"
   end
 
   private
@@ -97,25 +75,6 @@ class PackingListsController < ApplicationController
     @available_items = Item.templates.order(:name)
   end
 
-  def assign_owner_to_new_items(packing_list)
-    packing_list.packing_list_items.each do |pli|
-      pli.packing_list ||= packing_list
-      next unless pli.item&.new_record?
-
-      item_name = pli.item.name.to_s.strip
-      if item_name.present?
-        existing_item = current_user.items.find_by(name: item_name) || Item.templates.find_by(name: item_name)
-        if existing_item
-          pli.item = existing_item
-          next
-        end
-      end
-
-      pli.item.user = current_user
-      pli.item.template = false
-    end
-  end
-
   def title_error_message
     "既に登録されているリスト名です"
   end
@@ -131,44 +90,12 @@ class PackingListsController < ApplicationController
     @festival_days |= [ past_selected_day ].compact
   end
 
-  def apply_template_if_present
-    template_id = params[:template_id]
-    return if template_id.blank?
-
-    template = PackingList.templates.find_by(id: template_id)
-    return unless template
-
-    @packing_list.title = template.title
-    template.packing_list_items.includes(:item).order(:position, :id).each do |pli|
-      @packing_list.packing_list_items.build(
-        item_id: pli.item_id,
-        position: pli.position,
-        note: pli.note
-      )
-    end
-  end
-
   def packing_list_params
     raw = params.require(:packing_list)
 
     safe = raw.permit(:title, :festival_day_id).to_h
-    safe[:packing_list_items_attributes] = sanitize_packing_list_items(raw[:packing_list_items_attributes])
+    safe[:packing_list_items_attributes] = PackingList.sanitize_items_params(raw[:packing_list_items_attributes])
     safe
-  end
-
-  # 動的キー付きのネストを手動でサニタイズして通す
-  def sanitize_packing_list_items(raw_items)
-    return [] if raw_items.blank?
-
-    raw_items.to_unsafe_h.map do |_, attrs|
-      attrs = attrs.to_unsafe_h if attrs.respond_to?(:to_unsafe_h)
-      next unless attrs.is_a?(Hash)
-
-      item_attrs = attrs["item_attributes"] || {}
-      sanitized_item = item_attrs.slice("id", "name", "description", "category") if item_attrs.is_a?(Hash)
-      base = attrs.slice("id", "item_id", "note", "position", "_destroy")
-      sanitized_item.present? ? base.merge("item_attributes" => sanitized_item) : base
-    end.compact
   end
 
   def default_back_path

--- a/app/models/packing_list.rb
+++ b/app/models/packing_list.rb
@@ -20,6 +20,58 @@ class PackingList < ApplicationRecord
     festival_day if festival_day.finished?(today)
   end
 
+  # テンプレート複製時、フォーム初期化時にテンプレート内容をこのリストに適用する
+  def apply_template_from_id(template_id)
+    return if template_id.blank?
+
+    template = PackingList.templates.find_by(id: template_id)
+    return unless template
+
+    self.title = template.title
+    template.packing_list_items.includes(:item).order(:position, :id).each do |pli|
+      packing_list_items.build(
+        item_id: pli.item_id,
+        position: pli.position,
+        note: pli.note
+      )
+    end
+  end
+
+  # リストアイテム作成時、同名のアイテムがテンプレートにあれば再利用し、なければユーザー所有の新規アイテムとして紐付ける
+  def assign_owner_to_new_items!(user)
+    packing_list_items.each do |pli|
+      pli.packing_list ||= self
+      next unless pli.item&.new_record?
+
+      item_name = pli.item.name.to_s.strip
+      if item_name.present?
+        existing_item = user.items.find_by(name: item_name) || Item.templates.find_by(name: item_name)
+        if existing_item
+          pli.item = existing_item
+          next
+        end
+      end
+
+      pli.item.user = user
+      pli.item.template = false
+    end
+  end
+
+  # 持ち物リストフォームのネスト属性を正規化
+  def self.sanitize_items_params(raw_items)
+    return [] if raw_items.blank?
+
+    raw_items.to_unsafe_h.map do |_, attrs|
+      attrs = attrs.to_unsafe_h if attrs.respond_to?(:to_unsafe_h)
+      next unless attrs.is_a?(Hash)
+
+      item_attrs = attrs["item_attributes"] || {}
+      sanitized_item = item_attrs.slice("id", "name", "description", "category") if item_attrs.is_a?(Hash)
+      base = attrs.slice("id", "item_id", "note", "position", "_destroy")
+      sanitized_item.present? ? base.merge("item_attributes" => sanitized_item) : base
+    end.compact
+  end
+
   private
 
   def festival_day_must_be_upcoming_if_changed

--- a/app/views/packing_lists/show.html.erb
+++ b/app/views/packing_lists/show.html.erb
@@ -55,12 +55,6 @@
                       method: :delete,
                       data: { controller: "tap-feedback", turbo_confirm: "この持ち物リストを削除しますか？" },
                       class: "inline-flex min-w-[8rem] items-center justify-center rounded-2xl bg-rose-500 px-5 py-2.5 text-sm font-bold text-white shadow-md interactive-lift hover:bg-rose-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500" %>
-      <% elsif @packing_list.template? %>
-        <%= button_to "このテンプレートから作成",
-                      duplicate_from_template_packing_list_path(@packing_list),
-                      method: :post,
-                      class: "inline-flex min-w-[12rem] items-center justify-center rounded-2xl bg-indigo-500 px-6 py-3 text-sm font-bold text-white shadow-md interactive-lift hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500",
-                      data: { controller: "tap-feedback" } %>
       <% end %>
     </div>
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -85,5 +85,6 @@ Rails.application.configure do
     Bullet.bullet_logger = true
     Bullet.console = true
     Bullet.rails_logger = true
+    Bullet.add_safelist type: :unused_eager_loading, class_name: "PackingListItem", association: :item
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,9 +44,6 @@ Rails.application.routes.draw do
 
   resources :packing_lists do
     resources :packing_list_items, only: [ :update ]
-    member do
-      post :duplicate_from_template
-    end
   end
 
   namespace :admin do

--- a/spec/requests/packing_lists_spec.rb
+++ b/spec/requests/packing_lists_spec.rb
@@ -124,46 +124,6 @@ RSpec.describe "持ち物リストのリクエスト", type: :request do
     end
   end
 
-  describe "POST /packing_lists/:id/duplicate_from_template" do
-    let(:user) { create(:user) }
-    let!(:template_item) { create(:template_item, name: "レインコート") }
-    let!(:template_list) do
-      create(:template_packing_list, title: "夏フェス基本セット").tap do |list|
-        create(:packing_list_item, packing_list: list, item: template_item, position: 1, note: "必須")
-      end
-    end
-
-    before { sign_in user, scope: :user }
-
-    it "テンプレートからリストとアイテムを複製して詳細ページへリダイレクトする" do
-      expect {
-        post duplicate_from_template_packing_list_path(template_list)
-      }.to change { user.packing_lists.count }.by(1)
-        .and change(PackingListItem, :count).by(1)
-
-      new_list = user.packing_lists.order(:created_at).last
-      expect(response).to redirect_to(packing_list_path(new_list))
-      expect(new_list.title).to eq(template_list.title)
-      expect(new_list.template).to be(false)
-
-      duplicated_item = new_list.packing_list_items.first
-      expect(duplicated_item.item).to eq(template_item)
-      expect(duplicated_item.position).to eq(1)
-      expect(duplicated_item.note).to eq("必須")
-    end
-
-    it "テンプレートでない場合は複製せず一覧へリダイレクトする" do
-      owned_list = create(:packing_list, user: user, template: false)
-      create(:packing_list_item, packing_list: owned_list, item: create(:item, user: user))
-
-      expect {
-        post duplicate_from_template_packing_list_path(owned_list)
-      }.not_to change(PackingList, :count)
-
-      expect(response).to redirect_to(packing_lists_path)
-    end
-  end
-
   describe "PATCH /packing_lists/:id" do
     it "未ログインならログイン画面へリダイレクトし、更新されない" do
       list = create(:packing_list, user: create(:user), title: "旧タイトル")


### PR DESCRIPTION
## 概要
- 持ち物リスト作成まわりの責務を整理し、テンプレ複製フローを new + create に統一
- Bulletの誤検知も抑制
## 実施内容
- PackingList モデルへビジネスロジックを移動し、コントローラを薄く整理。packing_list.rb / packing_lists_controller.rb
- テンプレ複製の専用アクション/ルートを削除し、new?template_id=... に統一。packing_lists_controller.rb / routes.rb
- テンプレ詳細の作成ボタンを削除（導線なしのため）。show.html.erb
- Bullet の警告抑制を add_safelist で追加。development.rb
## 対応Issue
なし
## 関連Issue
なし
## 特記事項