### PR TITLE
[refactor]タイムテーブル関連の処理を整理

### DIFF
--- a/app/services/my_timetables/conflict_detector.rb
+++ b/app/services/my_timetables/conflict_detector.rb
@@ -1,0 +1,18 @@
+module MyTimetables
+  class ConflictDetector
+    def self.call(list)
+      conflicts = Set.new
+      last_end = nil
+      last_id  = nil
+      list.each do |sp|
+        if last_end && sp.starts_at && sp.ends_at && sp.starts_at < last_end
+          conflicts << last_id
+          conflicts << sp.id
+        end
+        last_end = sp.ends_at || last_end
+        last_id  = sp.id
+      end
+      conflicts
+    end
+  end
+end

--- a/app/services/timetables/view_context_builder.rb
+++ b/app/services/timetables/view_context_builder.rb
@@ -1,0 +1,38 @@
+module Timetables
+  class ViewContextBuilder
+    Result = Struct.new(
+      :timezone,
+      :timeline_start,
+      :timeline_end,
+      :time_markers,
+      :timeline_layout,
+      keyword_init: true
+    )
+
+    def self.build(festival:, selected_day:)
+      new(festival: festival, selected_day: selected_day).build
+    end
+
+    def initialize(festival:, selected_day:)
+      @festival = festival
+      @selected_day = selected_day
+    end
+
+    def build
+      timezone = ActiveSupport::TimeZone[@festival.timezone] || Time.zone
+      timeline_context = TimelineContextBuilder.build(
+        festival: @festival,
+        selected_day: @selected_day,
+        timezone: timezone
+      )
+
+      Result.new(
+        timezone: timezone,
+        timeline_start: timeline_context.timeline_start,
+        timeline_end: timeline_context.timeline_end,
+        time_markers: timeline_context.time_markers,
+        timeline_layout: timeline_context.timeline_layout
+      )
+    end
+  end
+end


### PR DESCRIPTION
## 概要
- タイムテーブル詳細表示の準備処理を共通化し、コントローラ責務を整理
## 実施内容
- タイムテーブル表示用の共通サービスを追加。view_context_builder.rb
- TimetablesController で選択日処理を整理し、show 内の流れを明確化。timetables_controller.rb
- MyTimetablesController の準備処理を分割し、before_action で明示。my_timetables_controller.rb
- マイタイムテーブルのパフォーマンス時間衝突検知ロジックをサービスへ移動。conflict_detector.rb / my_timetables_controller.rb
## 対応Issue
なし
## 関連Issue
なし
## 特記事項