### PR TITLE
[refactor]予習（prep）系の集計ロジック部分の切り離し

### DIFF
--- a/app/controllers/prep/artists_controller.rb
+++ b/app/controllers/prep/artists_controller.rb
@@ -12,33 +12,15 @@ module Prep
     end
 
     def show
-      @setlist_scope = Setlist
-                        .joins(stage_performance: :festival_day)
-                        .includes(stage_performance: [ :artist, :stage, { festival_day: :festival } ])
-                        .where(stage_performances: { artist_id: @artist.id })
-                        .order("festival_days.date DESC")
+      @setlists = Setlist
+                    .joins(stage_performance: :festival_day)
+                    .includes(stage_performance: [ :artist, :stage, { festival_day: :festival } ])
+                    .where(stage_performance: { artist_id: @artist.id })
+                    .order("festival_days.date DESC")
 
-      @setlists_count = @setlist_scope.count
-      @setlists = @setlist_scope
-
-      @ranking_entries =
-        if @setlists_count >= 3
-          ranked_songs = Song
-                         .joins(setlist_songs: :setlist)
-                         .where(artist_id: @artist.id, setlists: { id: @setlist_scope.select(:id) })
-                         .select("songs.*", "COUNT(DISTINCT setlist_songs.setlist_id) AS appearances_count")
-                         .group("songs.id")
-                         .order("appearances_count DESC", "songs.name ASC")
-                         .limit(5)
-
-          ranked_songs.map do |song|
-            count = song.read_attribute(:appearances_count).to_i
-            rate  = ((count.to_f / @setlists_count) * 100).round(1)
-            { song: song, count: count, rate: rate }
-          end
-        else
-          []
-        end
+      ranking = Prep::SongRankingBuilder.build(artist: @artist, setlist_scope: @setlists)
+      @setlists_count = ranking.setlists_count
+      @ranking_entries = ranking.entries
 
       set_header_back_path
     end

--- a/app/controllers/prep/festivals_controller.rb
+++ b/app/controllers/prep/festivals_controller.rb
@@ -23,7 +23,8 @@ module Prep
       raise ActiveRecord::RecordNotFound if @festival_days.blank?
 
       resolve_selected_day
-      build_song_entries
+      entries = Prep::FestivalSongEntriesBuilder.build(festival: @festival, selected_day: @selected_day)
+      @pagy, @song_entries = pagy_array(entries, limit: 10, page: params[:page])
       set_header_back_path
     end
 
@@ -43,47 +44,6 @@ module Prep
         else
           @festival_days.first
         end
-    end
-
-    def build_song_entries
-      performing_artists = Artist
-                             .joins(stage_performances: :festival_day)
-                             .where(stage_performances: { status: StagePerformance.statuses[:scheduled] },
-                                    festival_days: { id: @selected_day.id, festival_id: @festival.id })
-                             .merge(Artist.published)
-                             .distinct
-                             .order(:name)
-
-      entries = performing_artists.flat_map do |artist|
-        setlist_scope = Setlist
-                         .joins(:stage_performance)
-                         .where(stage_performances: { artist_id: artist.id })
-
-        setlists_count = setlist_scope.count
-        next if setlists_count < 3
-
-        ranked_songs = Song
-                        .joins(setlist_songs: :setlist)
-                        .where(artist_id: artist.id, setlists: { id: setlist_scope.select(:id) })
-                        .select("songs.*", "COUNT(DISTINCT setlist_songs.setlist_id) AS appearances_count")
-                        .group("songs.id")
-                        .order("appearances_count DESC", "songs.name ASC")
-                        .limit(5)
-
-        spotify_pick = ranked_songs
-                        .select { |song| song.spotify_id.present? }
-                        .first(2)
-
-        next if spotify_pick.empty?
-
-        spotify_pick.map do |song|
-          count = song.read_attribute(:appearances_count).to_i
-          rate  = ((count.to_f / setlists_count) * 100).round(1)
-          { artist: artist, song: song, count: count, rate: rate }
-        end
-      end.compact
-
-      @pagy, @song_entries = pagy_array(entries, limit: 10, page: params[:page])
     end
 
     def resolved_back_path(token)

--- a/app/services/prep/festival_song_entries_builder.rb
+++ b/app/services/prep/festival_song_entries_builder.rb
@@ -1,0 +1,45 @@
+module Prep
+  class FestivalSongEntriesBuilder
+    def self.build(festival:, selected_day:)
+      new(festival: festival, selected_day: selected_day).build
+    end
+
+    def initialize(festival:, selected_day:)
+      @festival = festival
+      @selected_day = selected_day
+    end
+
+    def build
+      performing_artists = Artist
+                             .joins(stage_performances: :festival_day)
+                             .where(stage_performances: { status: StagePerformance.statuses[:scheduled] },
+                                    festival_days: { id: @selected_day.id, festival_id: @festival.id })
+                             .merge(Artist.published)
+                             .distinct
+                             .order(:name)
+
+      entries = performing_artists.flat_map do |artist|
+        setlist_scope = Setlist
+                         .joins(:stage_performance)
+                         .where(stage_performances: { artist_id: artist.id })
+
+        ranking = Prep::SongRankingBuilder.build(artist: artist, setlist_scope: setlist_scope)
+        next if ranking.entries.empty?
+
+        spotify_pick = ranking.entries
+                               .select { |entry| entry[:song].spotify_id.present? }
+                               .first(2)
+
+        next if spotify_pick.empty?
+
+        spotify_pick.map { |entry| entry.merge(artist: artist) }
+      end.compact
+
+      entries
+    end
+
+    private
+
+    attr_reader :festival, :selected_day
+  end
+end

--- a/app/services/prep/song_ranking_builder.rb
+++ b/app/services/prep/song_ranking_builder.rb
@@ -1,0 +1,46 @@
+module Prep
+  class SongRankingBuilder
+    Result = Struct.new(:entries, :setlists_count, keyword_init: true)
+
+    def self.build(artist:, setlist_scope:, min_setlists: 3, limit: 5)
+      new(
+        artist: artist,
+        setlist_scope: setlist_scope,
+        min_setlists: min_setlists,
+        limit: limit
+      ).build
+    end
+
+    def initialize(artist:, setlist_scope:, min_setlists:, limit:)
+      @artist = artist
+      @setlist_scope = setlist_scope
+      @min_setlists = min_setlists
+      @limit = limit
+    end
+
+    def build
+      setlists_count = setlist_scope.count
+      return Result.new(entries: [], setlists_count: setlists_count) if setlists_count < min_setlists
+
+      ranked_songs = Song
+                      .joins(setlist_songs: :setlist)
+                      .where(artist_id: artist.id, setlists: { id: setlist_scope.select(:id) })
+                      .select("songs.*", "COUNT(DISTINCT setlist_songs.setlist_id) AS appearances_count")
+                      .group("songs.id")
+                      .order("appearances_count DESC", "songs.name ASC")
+                      .limit(limit)
+
+      entries = ranked_songs.map do |song|
+        count = song.read_attribute(:appearances_count).to_i
+        rate  = ((count.to_f / setlists_count) * 100).round(1)
+        { song: song, count: count, rate: rate }
+      end
+
+      Result.new(entries: entries, setlists_count: setlists_count)
+    end
+
+    private
+
+    attr_reader :artist, :setlist_scope, :min_setlists, :limit
+  end
+end


### PR DESCRIPTION
## 概要
- 予習（prep）系の集計ロジックをサービスに切り出し、ランキング生成の共通化とコントローラの責務分離を進めた
## 実施内容
- フェス予習の曲エントリ生成をサービス化。festival_song_entries_builder.rb / festivals_controller.rb
- アーティスト予習のランキング生成をサービス化・共通化。song_ranking_builder.rb / artists_controller.rb / festival_song_entries_builder.rb
- prep/artists の @setlists に統一して冗長性を削減。artists_controller.rb
## 対応Issue
なし
## 関連Issue
なし
## 特記事項