### PR TITLE
[refactor]管理画面のセットリストフォーム生成ロジックをサービス化

### DIFF
--- a/app/controllers/admin/setlists_controller.rb
+++ b/app/controllers/admin/setlists_controller.rb
@@ -13,7 +13,7 @@ class Admin::SetlistsController < Admin::BaseController
 
   def new
     @setlist = Setlist.new
-    build_setlist_songs(@setlist)
+    Admin::Setlists::FormBuilder.build(@setlist)
   end
 
   def create
@@ -21,20 +21,20 @@ class Admin::SetlistsController < Admin::BaseController
     if @setlist.save
       redirect_to admin_setlists_path, notice: "セットリストを作成しました"
     else
-      build_missing_setlist_songs
+      Admin::Setlists::FormBuilder.build(@setlist)
       render :new, status: :unprocessable_entity
     end
   end
 
   def edit
-    build_missing_setlist_songs
+    Admin::Setlists::FormBuilder.build(@setlist)
   end
 
   def update
     if @setlist.update(setlist_params)
       redirect_to admin_setlists_path, notice: "セットリストを更新しました"
     else
-      build_missing_setlist_songs
+      Admin::Setlists::FormBuilder.build(@setlist)
       render :edit, status: :unprocessable_entity
     end
   end
@@ -75,19 +75,6 @@ class Admin::SetlistsController < Admin::BaseController
     # 曲のプルダウンは全曲だと大きくなるので、選択したアーティストの曲だけをJSで絞る運用を想定
     # ここでは全曲を渡す
     @songs_by_artist = Song.includes(:artist).order(:name).group_by(&:artist_id)
-  end
-
-  def build_setlist_songs(setlist)
-    # nilが紛れ込んでいる場合を排除
-    setlist.setlist_songs.target.compact!
-
-    (1..20).each do |pos|
-      setlist.setlist_songs.build(position: pos) unless setlist.setlist_songs.any? { |s| s.position == pos }
-    end
-  end
-
-  def build_missing_setlist_songs
-    build_setlist_songs(@setlist)
   end
 
   def set_artists

--- a/app/services/admin/setlists/form_builder.rb
+++ b/app/services/admin/setlists/form_builder.rb
@@ -1,0 +1,29 @@
+module Admin
+  module Setlists
+    class FormBuilder
+      ENTRY_LIMIT = 20
+
+      def self.build(setlist, limit: ENTRY_LIMIT)
+        new(setlist, limit: limit).build
+      end
+
+      def initialize(setlist, limit:)
+        @setlist = setlist
+        @limit = limit
+      end
+
+      def build
+        # nilが紛れ込んでいる場合を排除
+        setlist.setlist_songs.target.compact!
+
+        (1..limit).each do |pos|
+          setlist.setlist_songs.build(position: pos) unless setlist.setlist_songs.any? { |s| s.position == pos }
+        end
+      end
+
+      private
+
+      attr_reader :setlist, :limit
+    end
+  end
+end

--- a/spec/requests/admin_setlists_spec.rb
+++ b/spec/requests/admin_setlists_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe "管理画面のセットリスト管理", type: :request do
+  let(:admin) { create(:user, role: :admin) }
+
+  before { sign_in admin, scope: :user }
+
+  describe "POST /admin/setlists" do
+    let(:stage_performance) { create(:stage_performance) }
+    let(:song) { create(:song, artist: stage_performance.artist) }
+
+    it "作成できる" do
+      params = {
+        setlist: {
+          stage_performance_id: stage_performance.id,
+          setlist_songs_attributes: {
+            "0" => { song_id: song.id, position: 1, note: "" }
+          }
+        }
+      }
+
+      expect {
+        post admin_setlists_path, params: params
+      }.to change(Setlist, :count).by(1)
+
+      expect(response).to redirect_to(admin_setlists_path)
+    end
+  end
+
+  describe "PATCH /admin/setlists/:id" do
+    let(:setlist) { create(:setlist) }
+    let(:song) { create(:song, artist: setlist.stage_performance.artist) }
+
+    it "編集できる" do
+      params = {
+        setlist: {
+          setlist_songs_attributes: {
+            "0" => { song_id: song.id, position: 1, note: "更新" }
+          }
+        }
+      }
+
+      patch admin_setlist_path(setlist), params: params
+
+      expect(response).to redirect_to(admin_setlists_path)
+    end
+  end
+
+  describe "DELETE /admin/setlists/:id" do
+    let!(:setlist) { create(:setlist) }
+
+    it "削除できる" do
+      expect {
+        delete admin_setlist_path(setlist)
+      }.to change(Setlist, :count).by(-1)
+
+      expect(response).to redirect_to(admin_setlists_path)
+    end
+  end
+end


### PR DESCRIPTION
## 概要
- 管理画面のセットリストフォーム生成ロジックをサービス化。
- 作成・編集・削除の挙動を担保するリクエストspecを追加。
## 実施内容
- フォーム行生成をサービスに切り出し、コントローラから呼ぶ形に整理。form_builder.rb / setlists_controller.rb
- 管理画面セットリストの作成・編集・削除のリクエストspecを追加。admin_setlists_spec.rb
## 対応Issue
なし
## 関連Issue
なし
## 特記事項