### PR TITLE
[refactor]管理者の持ち物リストコントローラのサービスへの切り離し

### DIFF
--- a/app/controllers/admin/packing_lists_controller.rb
+++ b/app/controllers/admin/packing_lists_controller.rb
@@ -61,19 +61,8 @@ class Admin::PackingListsController < Admin::BaseController
     raw = params.require(:packing_list)
 
     safe = raw.permit(:title, :festival_day_id).to_h
-    safe[:packing_list_items_attributes] = sanitize_packing_list_items(raw[:packing_list_items_attributes])
+    safe[:packing_list_items_attributes] =
+      Admin::PackingLists::ParamsSanitizer.call(raw[:packing_list_items_attributes])
     safe
-  end
-
-  # 動的キー付きのネストを手動でサニタイズ
-  def sanitize_packing_list_items(raw_items)
-    return [] if raw_items.blank?
-
-    raw_items.to_unsafe_h.map do |_, attrs|
-      attrs = attrs.to_unsafe_h if attrs.respond_to?(:to_unsafe_h)
-      next unless attrs.is_a?(Hash)
-
-      attrs.slice("id", "item_id", "note", "position", "_destroy")
-    end.compact
   end
 end

--- a/app/services/admin/packing_lists/params_sanitizer.rb
+++ b/app/services/admin/packing_lists/params_sanitizer.rb
@@ -1,0 +1,18 @@
+module Admin
+  module PackingLists
+    class ParamsSanitizer
+      def self.call(raw_items)
+        return [] if raw_items.blank?
+
+        # 動的キー付きの入力をハッシュ配列に正規化する
+        raw_items.to_unsafe_h.map do |_, attrs|
+          attrs = attrs.to_unsafe_h if attrs.respond_to?(:to_unsafe_h)
+          next unless attrs.is_a?(Hash)
+
+          # 保存に必要なキーだけを抽出する
+          attrs.slice("id", "item_id", "note", "position", "_destroy")
+        end.compact
+      end
+    end
+  end
+end

--- a/spec/requests/admin_packing_lists_spec.rb
+++ b/spec/requests/admin_packing_lists_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe "管理画面の持ち物テンプレート管理", type: :request do
+  let(:admin) { create(:user, role: :admin) }
+
+  before { sign_in admin, scope: :user }
+
+  describe "POST /admin/packing_lists" do
+    let(:festival_day) { create(:festival_day) }
+    let(:item) { create(:item) }
+
+    it "テンプレートを作成できる" do
+      params = {
+        packing_list: {
+          title: "テンプレ",
+          festival_day_id: festival_day.id,
+          packing_list_items_attributes: {
+            "0" => { item_id: item.id, note: "必須", position: 0 }
+          }
+        }
+      }
+
+      expect {
+        post admin_packing_lists_path, params: params
+      }.to change(PackingList, :count).by(1)
+         .and change(PackingListItem, :count).by(1)
+
+      expect(response).to redirect_to(admin_packing_lists_path)
+    end
+  end
+
+  describe "PATCH /admin/packing_lists/:id" do
+    let(:packing_list) { create(:template_packing_list) }
+
+    it "テンプレートを更新できる" do
+      params = {
+        packing_list: {
+          title: "更新後テンプレ"
+        }
+      }
+
+      patch admin_packing_list_path(packing_list), params: params
+
+      expect(response).to redirect_to(admin_packing_lists_path)
+      expect(packing_list.reload.title).to eq("更新後テンプレ")
+    end
+  end
+
+  describe "DELETE /admin/packing_lists/:id" do
+    let!(:packing_list) { create(:template_packing_list) }
+
+    it "テンプレートを削除できる" do
+      expect {
+        delete admin_packing_list_path(packing_list)
+      }.to change(PackingList, :count).by(-1)
+
+      expect(response).to redirect_to(admin_packing_lists_path)
+    end
+  end
+end


### PR DESCRIPTION
## 概要
- コントローラのデータ整形メソッドをサービス化して責務分離を進めた。
- 管理画面の持ち物テンプレート作成/更新/削除をカバーするリクエストspecを追加。
## 実施内容
- パラメータの手動サニタイズ用のメソッドをサービスに切り出し。params_sanitizer.rb / packing_lists_controller.rb
- 管理画面の持ち物テンプレート作成・更新・削除のリクエストspecを追加。admin_packing_lists_spec.rb
## 対応Issue
なし
## 関連Issue
なし
## 特記事項