### PR TITLE
[fix]draft状態の出演枠でもフェス予習曲に反映

### DIFF
--- a/app/services/prep/festival_song_entries_builder.rb
+++ b/app/services/prep/festival_song_entries_builder.rb
@@ -12,8 +12,7 @@ module Prep
     def build
       performing_artists = Artist
                              .joins(stage_performances: :festival_day)
-                             .where(stage_performances: { status: StagePerformance.statuses[:scheduled] },
-                                    festival_days: { id: @selected_day.id, festival_id: @festival.id })
+                             .where(festival_days: { id: @selected_day.id, festival_id: @festival.id })
                              .merge(Artist.published)
                              .distinct
                              .order(:name)

--- a/spec/services/prep/festival_song_entries_builder_spec.rb
+++ b/spec/services/prep/festival_song_entries_builder_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe Prep::FestivalSongEntriesBuilder do
+  describe "予習曲エントリの生成" do
+    let(:festival) { create(:festival) }
+    let(:festival_day) { create(:festival_day, festival: festival) }
+    let(:artist) { create(:artist, published: true) }
+
+    it "draftの出演枠でも予習曲エントリを返す" do
+      other_days = [
+        create(:festival_day, festival: festival, date: festival.start_date + 1.day),
+        create(:festival_day, festival: festival, date: festival.start_date + 2.days)
+      ]
+      stage_performances = [
+        create(:stage_performance, festival_day: festival_day, artist: artist, status: :draft),
+        create(:stage_performance, festival_day: other_days.first, artist: artist, status: :draft),
+        create(:stage_performance, festival_day: other_days.last, artist: artist, status: :draft)
+      ]
+      song_one = create(:song, artist: artist, spotify_id: "0OdUWJ0sBjDrqHygGUXeC1")
+      song_two = create(:song, artist: artist, spotify_id: "0OdUWJ0sBjDrqHygGUXeC2")
+
+      stage_performances.each do |stage_performance|
+        setlist = create(:setlist, stage_performance: stage_performance)
+        create(:setlist_song, setlist: setlist, song: song_one, position: 1)
+        create(:setlist_song, setlist: setlist, song: song_two, position: 2)
+      end
+
+      result = described_class.build(festival: festival, selected_day: festival_day)
+
+      expect(result.size).to eq(2)
+      expect(result.map { |entry| entry[:artist] }.uniq).to eq([ artist ])
+      expect(result.map { |entry| entry[:song] }).to include(song_one, song_two)
+    end
+  end
+end


### PR DESCRIPTION
## 概要
- フェス予習詳細の出演アーティスト抽出条件から scheduled 限定を外し、draft も対象に変更。
- Prep::FestivalSongEntriesBuilder の挙動を担保するサービスspecを追加。
## 実施内容
- festival_song_entries_builder.rb で stage_performances.status = scheduled 条件を削除。
- festival_song_entries_builder_spec.rb を新規追加し、draft の出演枠でも予習曲エントリが返ることを検証。
## 対応Issue
なし
## 関連Issue
なし
## 特記事項
タイムテーブルが未定のフェスでも予習リストが確認できるように改善。