### PR TITLE
[add]各ビューに説明文を追加

### DIFF
--- a/app/views/artists/index.html.erb
+++ b/app/views/artists/index.html.erb
@@ -2,9 +2,12 @@
   <div class="mx-auto max-w-6xl space-y-6">
     <header class="space-y-4">
       <h1 class="text-2xl font-bold text-slate-900">
-        <%= @festival ? "#{@festival.name} の出演アーティスト" : "アーティスト一覧" %>
+        <%= @festival ? "#{@festival.name} の出演アーティスト" : "登録アーティスト一覧" %>
       </h1>
-      <p class="text-sm text-slate-600">アプリに登録されているアーティスト一覧です。</p>
+      <p class="text-sm text-slate-600">
+        FES READYに登録されているアーティスト一覧です。
+        <% if @festival.present? && @festival_days.any? %><br>出演日を切り替えると、その日のアーティストだけに絞り込めます。<% end %>
+      </p>
       <% unless user_signed_in? %>
         <%= render "shared/login_callout",
                    title: "ログインしてお気に入りアーティストを登録しましょう",
@@ -53,8 +56,10 @@
           <% end %>
         </div>
       <% else %>
-        <p class="rounded-3xl border border-dashed border-slate-300 bg-white px-6 py-16 text-center text-sm text-slate-500">
-          表示できるアーティストがありません
+        <p class="rounded-3xl border border-dashed border-slate-300 bg-white px-6 py-16 text-center text-sm text-slate-500 space-y-1">
+          <span class="block">表示できるアーティストがありません。</span>
+          <span class="block">条件に合う出演アーティストが見つかりませんでした。</span>
+          <span class="block">日程を切り替えるか、検索条件を調整してください。</span>
         </p>
       <% end %>
     </section>

--- a/app/views/artists/show.html.erb
+++ b/app/views/artists/show.html.erb
@@ -36,6 +36,10 @@
         </div>
       </div>
 
+      <p class="mt-6 text-sm text-slate-600">
+        出演フェスや予習ページをチェックできます。
+      </p>
+
       <hr class="my-8 border-slate-200" />
 
       <div class="space-y-3">

--- a/app/views/festivals/index.html.erb
+++ b/app/views/festivals/index.html.erb
@@ -2,8 +2,9 @@
   <div class="mx-auto max-w-5xl space-y-6">
     <header class="space-y-4">
       <h1 class="text-2xl font-bold text-slate-900">
-        <%= @artist ? "#{@artist.name} の出演フェス" : "フェスを選択" %>
+        <%= @artist ? "#{@artist.name} の出演フェス" : "登録フェス一覧" %>
       </h1>
+      <p class="text-sm text-slate-600">開催予定・開催済の登録フェスを確認できます。<br>気になる条件で絞り込んでください。</p>
       <% unless user_signed_in? %>
         <%= render "shared/login_callout",
                    title: "ログインしてお気に入りフェスを登録しましょう",
@@ -66,8 +67,10 @@
           </div>
         <% end %>
       <% else %>
-        <p class="rounded-xl bg-white px-4 py-12 text-center text-sm text-slate-500 shadow md:col-span-2">
-          表示できるフェスがありません
+        <p class="rounded-xl bg-white px-4 py-12 text-center text-sm text-slate-500 shadow md:col-span-2 space-y-1">
+          <span class="block">表示できるフェスがありません。</span>
+          <span class="block">条件に合う開催予定が見つかりませんでした。</span>
+          <span class="block">日程・エリア・タグを変えて再検索してください。</span>
         </p>
       <% end %>
     </section>

--- a/app/views/festivals/show.html.erb
+++ b/app/views/festivals/show.html.erb
@@ -12,8 +12,12 @@
               </span>
             <% end %>
           </div>
-        <% end %>
+      <% end %>
       </header>
+
+      <p class="mt-4 text-sm text-slate-600">
+        公式発表の情報をもとに、フェスの基本情報を整理しています。
+      </p>
 
       <dl class="mt-4 space-y-3 text-sm text-slate-600">
         <div class="flex flex-col gap-1">

--- a/app/views/prep/artists/index.html.erb
+++ b/app/views/prep/artists/index.html.erb
@@ -3,7 +3,7 @@
     <header class="space-y-4">
       <h1 class="text-2xl font-bold text-slate-900">アーティスト予習一覧</h1>
       <p class="text-sm text-slate-600">
-        予習したいアーティストを選んで、効率よく聴き込みましょう。
+        予習したいアーティストを選んで、効率よく聴き込みましょう。<br>予習したいアーティスト名で検索できます。
       </p>
     </header>
 
@@ -21,8 +21,10 @@
           <% end %>
         </div>
       <% else %>
-        <p class="rounded-3xl border border-dashed border-slate-300 bg-white px-6 py-16 text-center text-sm text-slate-500">
-          表示できるアーティストがありません
+        <p class="rounded-3xl border border-dashed border-slate-300 bg-white px-6 py-16 text-center text-sm text-slate-500 space-y-1">
+          <span class="block">表示できるアーティストがありません。</span>
+          <span class="block">検索条件に合うアーティストが見つかりませんでした。</span>
+          <span class="block">キーワードを短くするか別の表記で試してください。</span>
         </p>
       <% end %>
     </section>

--- a/app/views/prep/artists/show.html.erb
+++ b/app/views/prep/artists/show.html.erb
@@ -10,8 +10,9 @@
       <% share_href = artist_prep_share_url(@artist) %>
       <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <p class="text-sm text-slate-600">
-          過去のセットリストから集計した演奏率をもとに、予習すべき曲をチェックしましょう。
+          過去のセットリストから集計した演奏率をもとに、予習すべき曲をチェックしましょう。<br>上位5曲から予習を始めるのがおすすめです。
         </p>
+        
         <%= link_to share_href,
                     class: "inline-flex items-center justify-center gap-2 rounded-2xl bg-black px-5 py-2.5 text-sm font-bold text-white shadow-md interactive-lift hover:bg-neutral-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black",
                     target: "_blank",
@@ -64,8 +65,9 @@
           <% end %>
         </div>
       <% else %>
-        <div class="rounded-2xl border border-slate-200 bg-white px-4 py-6 text-center text-sm text-slate-600 shadow">
-          まだセットリストがありません。
+        <div class="rounded-2xl border border-slate-200 bg-white px-4 py-6 text-center text-sm text-slate-600 shadow space-y-1">
+          <span class="block">まだセットリストがありません。</span>
+          <span class="block">今後追加される可能性があるため、時間をおいて再度ご確認ください。</span>
         </div>
       <% end %>
     </section>

--- a/app/views/prep/festivals/index.html.erb
+++ b/app/views/prep/festivals/index.html.erb
@@ -2,6 +2,7 @@
   <div class="mx-auto max-w-5xl space-y-6">
     <header class="space-y-4">
       <h1 class="text-2xl font-bold text-slate-900">フェス予習一覧</h1>
+      <p class="text-sm text-slate-600">フェスごとの予習ページをまとめています。<br>参加予定のフェスから曲をチェックしましょう。</p>
       <% preserved_query = request.query_parameters.except(:page, :status) %>
       <div class="flex justify-center">
         <%= render "shared/segmented_tabs",
@@ -54,8 +55,10 @@
           </div>
         <% end %>
       <% else %>
-        <p class="rounded-xl bg-white px-4 py-12 text-center text-sm text-slate-500 shadow md:col-span-2">
-          表示できるフェスがありません
+        <p class="rounded-xl bg-white px-4 py-12 text-center text-sm text-slate-500 shadow md:col-span-2 space-y-1">
+          <span class="block">表示できるフェスがありません。</span>
+          <span class="block">予習対象のフェスが見つかりませんでした。</span>
+          <span class="block">開催時期やタグを変えて再検索してください。</span>
         </p>
       <% end %>
     </section>

--- a/app/views/prep/festivals/show.html.erb
+++ b/app/views/prep/festivals/show.html.erb
@@ -22,7 +22,7 @@
       <h2 class="text-lg font-semibold text-slate-900">
         <%= @selected_day.date.strftime("%-m/%-d") %> 出演アーティストの予習曲
       </h2>
-      <p class="text-sm text-slate-600">各アーティストの演奏率が高い上位2曲を表示しています。</p>
+      <p class="text-sm text-slate-600">各アーティストの演奏率が高い上位2曲を表示しています。<br>出演日のアーティストを広く予習したい場合のオススメ曲です。</p>
 
       <% if @song_entries.any? %>
         <div class="grid gap-3 md:grid-cols-2">
@@ -44,8 +44,10 @@
         </div>
         <%= render "shared/pagination", pagy: @pagy %>
       <% else %>
-        <div class="rounded-2xl bg-white px-4 py-12 text-center text-sm text-slate-600 shadow">
-          表示できるアーティストがいません
+        <div class="rounded-2xl bg-white px-4 py-12 text-center text-sm text-slate-600 shadow space-y-1">
+          <span class="block">表示できるアーティストがいません。</span>
+          <span class="block">セットリストが十分に集まっていない、出演アーティストが未定の可能性があります。</span>
+          <span class="block">日程を切り替えるか、後日もう一度確認してください。</span>
         </div>
       <% end %>
     </section>

--- a/app/views/setlists/show.html.erb
+++ b/app/views/setlists/show.html.erb
@@ -79,8 +79,9 @@
           <% end %>
         </div>
       <% else %>
-        <div class="rounded-2xl border border-dashed border-slate-200 bg-white px-4 py-6 text-center text-sm text-slate-600 shadow">
-          まだセットリストが登録されていません。
+        <div class="rounded-2xl border border-dashed border-slate-200 bg-white px-4 py-6 text-center text-sm text-slate-600 shadow space-y-1">
+          <span class="block">まだセットリストが登録されていません。</span>
+          <span class="block">公式発表やファン投稿の反映に時間がかかる場合があります。</span>
         </div>
       <% end %>
     </section>

--- a/app/views/timetables/index.html.erb
+++ b/app/views/timetables/index.html.erb
@@ -2,6 +2,9 @@
   <div class="mx-auto max-w-5xl space-y-6">
     <header class="space-y-4">
       <h1 class="text-2xl font-bold text-slate-900">タイムテーブルを見たいフェスを選択</h1>
+      <p class="text-sm text-slate-600">
+        公開中のタイムテーブルのみ表示しています。<br>タイムテーブルから、当日の流れを確認できます。
+      </p>
       <% unless user_signed_in? %>
         <%= render "shared/login_callout",
                    title: "ログインしてマイタイムテーブルを作成しましょう",
@@ -9,7 +12,6 @@
                    cta_label: "ログイン" %>
       <% end %>
       <div class="flex flex-col gap-3 text-sm text-slate-600 sm:flex-row sm:items-center sm:justify-between">
-        <p>公開中のタイムテーブルのみ表示しています。</p>
         <% if user_signed_in? %>
           <%= link_to "マイタイムテーブル一覧へ",
                       my_timetables_path,
@@ -66,8 +68,9 @@
             </div>
           <% end %>
       <% else %>
-        <p class="rounded-xl bg-white px-4 py-12 text-center text-sm text-slate-500 shadow md:col-span-2">
-          公開中のタイムテーブルはありません
+        <p class="rounded-xl bg-white px-4 py-12 text-center text-sm text-slate-500 shadow md:col-span-2 space-y-1">
+          <span class="block">公開中のタイムテーブルはありません。</span>
+          <span class="block">公開準備中のフェスがあるため、日程・エリアを変えて再検索してください。</span>
         </p>
       <% end %>
     </section>


### PR DESCRIPTION
## 概要
- 空状態メッセージを具体化して、検索結果0件でも内容量を確保
- 説明文を追加し、一覧/詳細ページの情報量を補強
- 文章の改行と行間を調整してモバイルでも読みやすく改善
## 実施内容
- 空状態文言の拡充と整形（index.html.erb, index.html.erb, index.html.erb, index.html.erb, index.html.erb, show.html.erb, show.html.erb, show.html.erb）
- 空状態メッセージを<span class="block">に分割し、space-y-1で行間調整
- 一覧/詳細ページに短い説明文を追加（index.html.erb, index.html.erb, index.html.erb, index.html.erb, index.html.erb, show.html.erb, show.html.erb, show.html.erb, show.html.erb, show.html.erb）
- アーティスト一覧の補足文を条件付き表示に調整（index.html.erb）
## 対応Issue
なし
## 関連Issue
なし
## 特記事項
Google Adsenseの審査に落ちたため、コンテンツの文章量を改善