### PR TITLE
[add]未ログイン時のログイン導線の追加

### DIFF
--- a/app/controllers/artists/favorites_controller.rb
+++ b/app/controllers/artists/favorites_controller.rb
@@ -6,6 +6,7 @@ module Artists
     def create
       favorite = current_user.user_artist_favorites.find_or_create_by!(artist: @artist)
 
+      # JSONはStimulus用、HTMLはJSが無効な場合のフォールバック
       respond_to do |format|
         format.html { redirect_back fallback_location: artist_path(@artist), notice: "お気に入りに追加しました" }
         format.json { render json: favorite_payload(favorited: true, favorite_id: favorite.id), status: :created }
@@ -21,6 +22,7 @@ module Artists
       favorite = current_user.user_artist_favorites.find_by(artist: @artist)
       favorite&.destroy
 
+      # JSONはStimulus用、HTMLはJSが無効な場合のフォールバック
       respond_to do |format|
         format.html { redirect_back fallback_location: artist_path(@artist), notice: "お気に入りを解除しました" }
         format.json { render json: favorite_payload(favorited: false), status: :ok }

--- a/app/views/prep/artists/index.html.erb
+++ b/app/views/prep/artists/index.html.erb
@@ -5,6 +5,12 @@
       <p class="text-sm text-slate-600">
         予習したいアーティストを選んで、効率よく聴き込みましょう。<br>予習したいアーティスト名で検索できます。
       </p>
+      <% unless user_signed_in? %>
+        <%= render "shared/login_callout",
+                   title: "ログインして予習するフェスを保存しましょう",
+                   description: "お気に入り登録で、気になるアーティストをすぐに見返せます。",
+                   cta_label: "ログイン" %>
+      <% end %>
     </header>
 
     <%= render Shared::SearchFormComponent.new(

--- a/app/views/prep/festivals/index.html.erb
+++ b/app/views/prep/festivals/index.html.erb
@@ -3,6 +3,12 @@
     <header class="space-y-4">
       <h1 class="text-2xl font-bold text-slate-900">フェス予習一覧</h1>
       <p class="text-sm text-slate-600">フェスごとの予習ページをまとめています。<br>参加予定のフェスから曲をチェックしましょう。</p>
+      <% unless user_signed_in? %>
+        <%= render "shared/login_callout",
+                   title: "ログインして予習するアーティストを保存しましょう",
+                   description: "お気に入り登録で、気になるフェスをすぐに見返せます。",
+                   cta_label: "ログイン" %>
+      <% end %>
       <% preserved_query = request.query_parameters.except(:page, :status) %>
       <div class="flex justify-center">
         <%= render "shared/segmented_tabs",
@@ -51,7 +57,11 @@
             <%= render "shared/nav_stack_button",
                        label: festival.name,
                        subtext: festival_date_and_location(festival),
-                       url: prep_festival_path(festival) %>
+                       url: prep_festival_path(festival),
+                       trailing: favorite_button_for(
+                         favorited: festival_favorited?(festival),
+                         toggle_url: festival_favorite_path(festival)
+                       ) %>
           </div>
         <% end %>
       <% else %>


### PR DESCRIPTION
## 概要
- 予習系一覧にログイン導線とお気に入り導線を追加し、操作性を向上
- お気に入りAPIのHTML/JSON分岐にフォールバック意図を明記
## 実施内容
- 予習一覧にログイン導線を追加（index.html.erb, index.html.erb）
- 予習フェス一覧にお気に入りハートを追加（index.html.erb）
- お気に入りコントローラにフォールバック意図のコメント追加（favorites_controller.rb）
## 対応Issue
なし
## 関連Issue
なし
## 特記事項
