### PR TITLE
[add]フェスごとのセットリストページの追加に伴う軽修正

### DIFF
--- a/app/controllers/festivals_controller.rb
+++ b/app/controllers/festivals_controller.rb
@@ -23,6 +23,7 @@ class FestivalsController < ApplicationController
   end
 
   def show
+    @show_setlists_link = @festival.past? && @festival.setlists_available?
   end
 
   private

--- a/app/controllers/my_timetables_controller.rb
+++ b/app/controllers/my_timetables_controller.rb
@@ -58,14 +58,7 @@ class MyTimetablesController < ApplicationController
 
   def set_selected_day!
     @festival_days = @festival.timetable_days
-    raise ActiveRecord::RecordNotFound if @festival_days.blank?
-
-    @selected_day =
-      if params[:date].present?
-        @festival.festival_days.find_by!(date: Date.parse(params[:date]))
-      else
-        @festival_days.first
-      end
+    @selected_day = @festival.select_day(params[:date], days: @festival_days)
   end
 
   def set_timetable_owner!

--- a/app/controllers/prep/festivals_controller.rb
+++ b/app/controllers/prep/festivals_controller.rb
@@ -20,9 +20,7 @@ module Prep
     def show
       @festival = find_festival
       @festival_days = @festival.timetable_days
-      raise ActiveRecord::RecordNotFound if @festival_days.blank?
-
-      resolve_selected_day
+      @selected_day = @festival.select_day(params[:date], days: @festival_days)
       entries = Prep::FestivalSongEntriesBuilder.build(festival: @festival, selected_day: @selected_day)
       @pagy, @song_entries = pagy_array(entries, limit: 10, page: params[:page])
       set_header_back_path
@@ -33,17 +31,6 @@ module Prep
     def find_festival
       festival_relation = Festival.includes(:festival_days)
       Festival.find_by_slug!(params[:id], scope: festival_relation)
-    end
-
-    def resolve_selected_day
-      @selected_day =
-        if params[:date].present?
-          parsed = Date.parse(params[:date]) rescue nil
-          raise ActiveRecord::RecordNotFound unless parsed
-          @festival.festival_days.find_by!(date: parsed)
-        else
-          @festival_days.first
-        end
     end
 
     def resolved_back_path(token)

--- a/app/controllers/setlists_controller.rb
+++ b/app/controllers/setlists_controller.rb
@@ -1,6 +1,24 @@
 class SetlistsController < ApplicationController
   include HeaderBackPath
+  before_action :set_festival, only: :index
   before_action :set_header_back_path, only: :show
+
+  def index
+    raise ActiveRecord::RecordNotFound unless @festival.past?
+
+    @festival_days = @festival.timetable_days
+    @selected_day = @festival.select_day(params[:date], days: @festival_days)
+
+    @timezone = ActiveSupport::TimeZone[@festival.timezone] || Time.zone
+
+    @performances = @festival
+                      .stage_performances_on(@selected_day)
+                      .scheduled
+                      .includes(:artist, :stage, :setlist)
+                      .order(:starts_at, :ends_at, :id)
+    @stages = @festival.stages.order(:sort_order, :id)
+    @performances_by_stage = @performances.group_by(&:stage)
+  end
 
   def show
     @setlist = Setlist
@@ -10,8 +28,17 @@ class SetlistsController < ApplicationController
 
     @stage_performance = @setlist.stage_performance
     @festival_day      = @stage_performance.festival_day
+    @festival          = @festival_day.festival
     @setlist_songs     = @setlist.setlist_songs.includes(:song).order(:position)
+
+    if params[:festival_id].present? && @festival.slug != params[:festival_id]
+      raise ActiveRecord::RecordNotFound
+    end
   end
 
   private
+
+  def set_festival
+    @festival = Festival.find_by_slug!(params[:festival_id])
+  end
 end

--- a/app/controllers/timetables_controller.rb
+++ b/app/controllers/timetables_controller.rb
@@ -58,20 +58,8 @@ class TimetablesController < ApplicationController
 
   def load_selected_day
     # 選択可能な開催日（タブ）を並び替えた一覧として保持
-    @festival_days = @festival.festival_days.sort_by(&:date)
-    raise ActiveRecord::RecordNotFound if @festival_days.blank?
-
-    @selected_day =
-      if params[:date].present?
-        begin
-          parsed = Date.parse(params[:date])
-        rescue ArgumentError
-          raise ActiveRecord::RecordNotFound
-        end
-        @festival.festival_days.find_by!(date: parsed)
-      else
-        @festival_days.first
-      end
+    @festival_days = @festival.timetable_days
+    @selected_day = @festival.select_day(params[:date], days: @festival_days)
   end
 
   def performances_by_stage

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -18,6 +18,9 @@ module NavigationHelper
     "timetables#index" => -> { root_path },
     "timetables#show" => -> { timetables_path },
 
+    "setlists#index" => -> { festival_path(@festival) },
+    "setlists#show" => -> { festival_setlists_path(@festival, date: @festival_day.date.to_s) },
+
     "my_timetables#index" => -> { timetables_path },
     "my_timetables#show" => -> { my_timetables_path },
     "my_timetables#edit" => -> { my_timetables_path },

--- a/app/helpers/setlists_helper.rb
+++ b/app/helpers/setlists_helper.rb
@@ -1,4 +1,19 @@
 module SetlistsHelper
+  def performance_time_range(stage_performance, timezone:)
+    return "未定" if stage_performance.blank?
+
+    starts_at = stage_performance.starts_at&.in_time_zone(timezone)
+    ends_at   = stage_performance.ends_at&.in_time_zone(timezone)
+
+    if starts_at.present? && ends_at.present?
+      "#{starts_at.strftime('%H:%M')}〜#{ends_at.strftime('%H:%M')}"
+    elsif starts_at.present?
+      "#{starts_at.strftime('%H:%M')}〜"
+    else
+      "未定"
+    end
+  end
+
   def stage_time_label(stage_performance)
     return "未定" if stage_performance.blank?
 

--- a/app/helpers/x_share_helper.rb
+++ b/app/helpers/x_share_helper.rb
@@ -21,6 +21,6 @@ module XShareHelper
     festival = stage_performance.festival_day.festival
     hashtag_artist = artist.name.to_s.gsub(/\s+/, "")
     text = "#{artist.name} の #{festival.name} でのセットリストを公開中！\n#FESREADY ##{hashtag_artist}"
-    x_intent_url(text: text, url: setlist_url(setlist))
+    x_intent_url(text: text, url: festival_setlist_url(festival, setlist))
   end
 end

--- a/app/views/festivals/show.html.erb
+++ b/app/views/festivals/show.html.erb
@@ -89,6 +89,13 @@
                     data: { controller: "tap-feedback" } do %>
           フェス予習リストへ
         <% end %>
+        <% if @show_setlists_link %>
+          <%= link_to festival_setlists_path(@festival),
+                      class: "block w-full rounded-2xl bg-indigo-500 py-3 text-center text-sm font-bold text-white shadow-md interactive-lift hover:bg-indigo-400",
+                      data: { controller: "tap-feedback" } do %>
+            セットリストへ
+          <% end %>
+        <% end %>
       </div>
     </article>
   </div>

--- a/app/views/prep/artists/show.html.erb
+++ b/app/views/prep/artists/show.html.erb
@@ -58,10 +58,11 @@
       <% if @setlists.any? %>
         <div class="grid gap-3">
           <% @setlists.each do |setlist| %>
+            <% festival = setlist.stage_performance.festival_day.festival %>
             <%= render "shared/nav_stack_button",
                        label: setlist_label(setlist),
                        subtext: setlist_subtext(setlist),
-                       url: setlist_path(setlist, back_to: request.fullpath) %>
+                       url: festival_setlist_path(festival, setlist, back_to: request.fullpath) %>
           <% end %>
         </div>
       <% else %>

--- a/app/views/setlists/index.html.erb
+++ b/app/views/setlists/index.html.erb
@@ -1,0 +1,69 @@
+<div class="min-h-screen px-4 py-6">
+  <div class="mx-auto max-w-5xl space-y-6">
+    <header class="space-y-3">
+      <p class="text-sm font-semibold text-rose-500">セットリスト</p>
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div class="space-y-1">
+          <h1 class="text-2xl font-bold text-slate-900"><%= @festival.name %> のセットリスト</h1>
+          <p class="text-sm text-slate-600"><%= festival_date_and_location(@festival) %></p>
+        </div>
+        <% share_text = "#{@festival.name} のセットリストを公開中！\n#FESREADY" %>
+        <% share_url = festival_setlists_url(@festival, date: @selected_day.date.to_s) %>
+        <%= link_to x_intent_url(text: share_text, url: share_url),
+                    class: "inline-flex items-center justify-center gap-2 rounded-2xl bg-black px-5 py-2.5 text-sm font-bold text-white shadow-md interactive-lift hover:bg-neutral-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black",
+                    target: "_blank",
+                    rel: "noopener" do %>
+          <%= image_tag "x-logo.png", alt: "X", class: "h-4 w-4" %>
+          <span>Xでシェア</span>
+        <% end %>
+      </div>
+    </header>
+
+    <% day_lookup = @festival_days.index_by(&:id) %>
+    <% tab_items = day_lookup.transform_values { |day| day.date.strftime("%-m/%-d") } %>
+    <div class="flex justify-center">
+      <%= render "shared/segmented_tabs",
+            tabs: tab_items,
+            active_tab_key: @selected_day.id,
+            url_builder: ->(festival_day_id) do
+              day = day_lookup[festival_day_id]
+              festival_setlists_path(@festival, date: day.date.to_s)
+            end %>
+    </div>
+
+    <section class="space-y-6">
+      <% @stages.each do |stage| %>
+        <% performances = @performances_by_stage[stage] || [] %>
+        <% next if performances.blank? %>
+        <div class="space-y-3">
+          <h2 class="text-lg font-semibold" style="color: <%= stage.color_hex %>;">
+            <%= stage.name.presence || "(未定)" %>
+          </h2>
+          <div class="space-y-3">
+            <% performances.each do |performance| %>
+              <% label = performance.artist&.name || "(未定)" %>
+              <% subtext = performance_time_range(performance, timezone: @timezone) %>
+              <% if performance.setlist.present? %>
+                <%= render "shared/nav_stack_button",
+                           label: label,
+                           subtext: subtext,
+                           url: festival_setlist_path(@festival, performance.setlist, back_to: request.fullpath) %>
+              <% else %>
+                <%= render "shared/nav_stack_button",
+                           label: label,
+                           subtext: subtext,
+                           disabled: true %>
+              <% end %>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+
+      <% if @performances.blank? %>
+        <div class="rounded-2xl bg-white px-4 py-12 text-center text-sm text-slate-600 shadow">
+          表示できる出演枠がありません。
+        </div>
+      <% end %>
+    </section>
+  </div>
+</div>

--- a/app/views/shared/_nav_stack_button.html.erb
+++ b/app/views/shared/_nav_stack_button.html.erb
@@ -1,13 +1,30 @@
-<%= link_to url, class: "nav-stack-button interactive-lift", data: { controller: "tap-feedback" } do %>
-  <span class="flex w-full items-start justify-between gap-3">
-    <span class="min-w-0 space-y-1 leading-tight">
-      <span class="block text-base font-semibold leading-snug text-slate-900 line-clamp-2"><%= label %></span>
-      <% if local_assigns[:subtext].present? %>
-        <span class="block text-xs font-medium text-slate-500"><%= subtext %></span>
+<% wrapper_classes = "nav-stack-button interactive-lift" %>
+<% if local_assigns[:disabled] %>
+  <div class="<%= "#{wrapper_classes} opacity-50 cursor-not-allowed" %>" aria-disabled="true">
+    <span class="flex w-full items-start justify-between gap-3">
+      <span class="min-w-0 space-y-1 leading-tight">
+        <span class="block text-base font-semibold leading-snug text-slate-900 line-clamp-2"><%= label %></span>
+        <% if local_assigns[:subtext].present? %>
+          <span class="block text-xs font-medium text-slate-500"><%= subtext %></span>
+        <% end %>
+      </span>
+      <% if local_assigns[:trailing].present? %>
+        <span class="shrink-0"><%= trailing %></span>
       <% end %>
     </span>
-    <% if local_assigns[:trailing].present? %>
-      <span class="shrink-0"><%= trailing %></span>
-    <% end %>
-  </span>
+  </div>
+<% else %>
+  <%= link_to url, class: wrapper_classes, data: { controller: "tap-feedback" } do %>
+    <span class="flex w-full items-start justify-between gap-3">
+      <span class="min-w-0 space-y-1 leading-tight">
+        <span class="block text-base font-semibold leading-snug text-slate-900 line-clamp-2"><%= label %></span>
+        <% if local_assigns[:subtext].present? %>
+          <span class="block text-xs font-medium text-slate-500"><%= subtext %></span>
+        <% end %>
+      </span>
+      <% if local_assigns[:trailing].present? %>
+        <span class="shrink-0"><%= trailing %></span>
+      <% end %>
+    </span>
+  <% end %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ Rails.application.routes.draw do
 
   resources :festivals, only: [ :index, :show ] do
     resources :artists, only: [ :index ], module: :festivals
+    resources :setlists, only: [ :index, :show ], controller: :setlists
     resource :my_timetable, only: [ :show, :edit, :update, :destroy ], controller: :my_timetables
     resource :favorite, only: [ :create, :destroy ], module: :festivals
   end


### PR DESCRIPTION
## 概要
- フェス別セットリスト一覧の新設
- 日程選択ロジックの集約で責務分離と可読性を改善
## 実施内容
- セットリスト一覧の新規追加と日程タブ/ステージ別表示（index.html.erb, setlists_controller.rb, routes.rb）
- セットリスト詳細を /festivals/:slug/setlists/:uuid に統一し、リンク/共有URLを更新（routes.rb, index.html.erb, show.html.erb, x_share_helper.rb, setlists_controller.rb）
- フェス詳細からのセットリスト導線表示と判定の整理（festivals_controller.rb, show.html.erb, festival.rb）
nav_stack_button の無効表示対応（_nav_stack_button.html.erb）
- 日程選択をモデルに集約し各コントローラで再利用（festival.rb, setlists_controller.rb, festivals_controller.rb, timetables_controller.rb, my_timetables_controller.rb)
- 戻り先の既定値と back_to 併用で戻り挙動を改善（index.html.erb, navigation_helper.rb)
## 対応Issue
- close #415 
## 関連Issue
なし
## 特記事項
フェスごとのセットリストページを作成し、Xでシェアすることでフェス後のアクセス増加を狙った設計に