### PR TITLE
[fix]タイムテーブル一覧のフォーマット変更

### DIFF
--- a/app/views/setlists/index.html.erb
+++ b/app/views/setlists/index.html.erb
@@ -39,7 +39,7 @@
           <h2 class="text-lg font-semibold" style="color: <%= stage.color_hex %>;">
             <%= stage.name.presence || "(未定)" %>
           </h2>
-          <div class="space-y-3">
+          <div class="space-y-3 md:grid md:grid-cols-2 md:gap-3 md:space-y-0">
             <% performances.each do |performance| %>
               <% label = performance.artist&.name || "(未定)" %>
               <% subtext = performance_time_range(performance, timezone: @timezone) %>


### PR DESCRIPTION
## 概要
- セットリスト一覧のステージ内リストをPC時のみ2列表示に変更し、視認性を向上
## 実施内容
- ステージ内のnav-stack-buttonリストにmd:grid md:grid-cols-2を追加（index.html.erb）
## 対応Issue
なし
## 関連Issue
- #415
## 特記事項
モバイル時のフォーマットは変更なし