### PR TITLE
[fix]XでシェアのボタンUIの修正

### DIFF
--- a/app/views/setlists/index.html.erb
+++ b/app/views/setlists/index.html.erb
@@ -14,7 +14,7 @@
                     target: "_blank",
                     rel: "noopener" do %>
           <%= image_tag "x-logo.png", alt: "X", class: "h-4 w-4" %>
-          <span>Xでシェア</span>
+          <span>でシェアする</span>
         <% end %>
       </div>
     </header>


### PR DESCRIPTION
## 概要
- セットリスト一覧ページの「Xでシェア」ボタンの文言の修正
## 実施内容
- Xの公式画像込みで「Xでシェアする」に修正（views/setlists/index.html.erb）
## 対応Issue
なし
## 関連Issue
なし
## 特記事項