### PR TITLE
[refactor]フェス詳細（公開/管理）の表示ロジックを整理

### DIFF
--- a/app/controllers/admin/festivals_controller.rb
+++ b/app/controllers/admin/festivals_controller.rb
@@ -9,7 +9,9 @@ class Admin::FestivalsController < Admin::BaseController
     )
   end
 
-  def show; end
+  def show
+    @festival_tags = @festival.sorted_tags
+  end
 
   def new
     @festival = Festival.new(timezone: "Asia/Tokyo")
@@ -56,7 +58,7 @@ class Admin::FestivalsController < Admin::BaseController
   private
 
   def set_festival
-    @festival = Festival.find_by_slug!(params[:id])
+    @festival = Festival.includes(:festival_tags).find_by_slug!(params[:id])
   end
 
   def load_festival_tags

--- a/app/controllers/festivals_controller.rb
+++ b/app/controllers/festivals_controller.rb
@@ -24,6 +24,7 @@ class FestivalsController < ApplicationController
 
   def show
     @show_setlists_link = @festival.past? && @festival.setlists_available?
+    @festival_tags = @festival.sorted_tags
   end
 
   private

--- a/app/helpers/festivals_helper.rb
+++ b/app/helpers/festivals_helper.rb
@@ -5,4 +5,68 @@ module FestivalsHelper
       I18n.t("enums.festival.status_filter.#{key}", default: key.humanize)
     end
   end
+
+  def festival_period_label(festival, with_weekday: false, fallback: nil)
+    return fallback if festival.blank?
+
+    formatter = with_weekday ? method(:format_date_with_weekday) : ->(date) { date&.strftime("%Y/%m/%d") }
+    start_label = formatter.call(festival.start_date)
+    end_label = formatter.call(festival.end_date)
+
+    if start_label.present? && end_label.present?
+      festival.end_date == festival.start_date ? start_label : "#{start_label} 〜 #{end_label}"
+    elsif start_label.present?
+      start_label
+    elsif end_label.present?
+      end_label
+    else
+      fallback
+    end
+  end
+
+  def festival_location_label(festival, fallback: nil)
+    return fallback if festival.blank?
+
+    parts = []
+    parts << "＠#{festival.prefecture}" if festival.prefecture.present?
+    parts << festival.city if festival.city.present?
+    parts << festival.venue_name if festival.venue_name.present?
+    parts.any? ? parts.join(" ") : fallback
+  end
+
+  def festival_location_details(festival, fallback: "-")
+    return { venue: fallback, area: nil } if festival.blank?
+
+    venue = festival.venue_name.presence || fallback
+    area_parts = [ festival.prefecture, festival.city ].compact_blank
+    area = area_parts.any? ? area_parts.join(" / ") : nil
+
+    { venue: venue, area: area }
+  end
+
+  def festival_time_zone(festival)
+    ActiveSupport::TimeZone[festival&.timezone] || Time.zone
+  end
+
+  def festival_timetable_status_badge(festival)
+    return "" if festival.blank?
+
+    if festival.timetable_published?
+      tag.span class: "inline-flex items-center gap-2 rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700" do
+        tag.span(class: "inline-block h-2 w-2 rounded-full bg-emerald-500") + "公開中"
+      end
+    else
+      tag.span class: "inline-flex items-center gap-2 rounded-full bg-slate-200 px-3 py-1 text-xs font-semibold text-slate-600" do
+        tag.span(class: "inline-block h-2 w-2 rounded-full bg-slate-400") + "非公開"
+      end
+    end
+  end
+
+  def festival_stage_badge_style(stage)
+    return "" if stage.blank?
+
+    hex = stage.color_hex
+    text_color = stage_text_color(hex)
+    "background-color: #{hex}; color: #{text_color};"
+  end
 end

--- a/app/models/festival.rb
+++ b/app/models/festival.rb
@@ -46,6 +46,10 @@ class Festival < ApplicationRecord
     festival_days.order(:date)
   end
 
+  def sorted_tags
+    festival_tags.order(:name)
+  end
+
   def select_day(date_param, days: festival_days)
     raise ActiveRecord::RecordNotFound if days.blank?
     return days.first if date_param.blank?

--- a/app/views/admin/festivals/index.html.erb
+++ b/app/views/admin/festivals/index.html.erb
@@ -30,26 +30,13 @@
               <div class="mt-1 text-xs font-mono text-slate-500"><%= festival.slug %></div>
             </td>
             <td class="px-4 py-3">
-              <% period_label =
-                if festival.start_date && festival.end_date
-                  start_str = festival.start_date.strftime("%Y/%m/%d")
-                  end_str   = festival.end_date.strftime("%Y/%m/%d")
-                  festival.start_date == festival.end_date ? start_str : "#{start_str} 〜 #{end_str}"
-                elsif festival.start_date
-                  festival.start_date.strftime("%Y/%m/%d")
-                elsif festival.end_date
-                  festival.end_date.strftime("%Y/%m/%d")
-                else
-                  "-"
-                end %>
-              <span><%= period_label %></span>
+              <span><%= festival_period_label(festival, fallback: "-") %></span>
             </td>
             <td class="px-4 py-3">
-              <% location_parts = [festival.prefecture, festival.city].compact_blank %>
-              <% venue_label = festival.venue_name.presence || "-" %>
-              <div><%= venue_label %></div>
-              <% if location_parts.any? %>
-                <div class="mt-1 text-xs text-slate-500"><%= location_parts.join(" / ") %></div>
+              <% location_details = festival_location_details(festival) %>
+              <div><%= location_details[:venue] %></div>
+              <% if location_details[:area].present? %>
+                <div class="mt-1 text-xs text-slate-500"><%= location_details[:area] %></div>
               <% end %>
             </td>
             <td class="px-4 py-3">

--- a/app/views/admin/festivals/show.html.erb
+++ b/app/views/admin/festivals/show.html.erb
@@ -1,7 +1,6 @@
-<% time_zone = ActiveSupport::TimeZone[@festival.timezone] || Time.zone %>
+<% time_zone = festival_time_zone(@festival) %>
 <% festival_days = @festival.festival_days.order(:date) %>
 <% stages = @festival.stages.order(:sort_order, :id) %>
-
 <div class="mx-auto max-w-5xl px-4 py-10 min-h-[calc(100vh-var(--header-offset,4.5rem)-var(--footer-offset,6rem))]">
   <div class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
     <div>
@@ -51,26 +50,16 @@
           <div class="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-3">
             <dt class="font-semibold text-slate-500">開催期間</dt>
             <dd class="sm:col-span-2">
-              <% start_label = @festival.start_date&.strftime("%Y/%m/%d") %>
-              <% end_label   = @festival.end_date&.strftime("%Y/%m/%d") %>
-              <%= if start_label && end_label
-                    @festival.start_date == @festival.end_date ? start_label : "#{start_label} 〜 #{end_label}"
-                  elsif start_label
-                    start_label
-                  elsif end_label
-                    end_label
-                  else
-                    "-"
-                  end %>
+              <%= festival_period_label(@festival, fallback: "-") %>
             </dd>
           </div>
           <div class="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-3">
             <dt class="font-semibold text-slate-500">会場</dt>
             <dd class="sm:col-span-2">
-              <div><%= @festival.venue_name.presence || "-" %></div>
-              <% location = [@festival.prefecture, @festival.city].compact_blank %>
-              <% if location.any? %>
-                <div class="mt-1 text-xs text-slate-500"><%= location.join(" / ") %></div>
+              <% location_details = festival_location_details(@festival) %>
+              <div><%= location_details[:venue] %></div>
+              <% if location_details[:area].present? %>
+                <div class="mt-1 text-xs text-slate-500"><%= location_details[:area] %></div>
               <% end %>
             </dd>
           </div>
@@ -97,29 +86,14 @@
           <div class="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-3">
             <dt class="font-semibold text-slate-500">タイムテーブル公開状態</dt>
             <dd class="sm:col-span-2">
-              <% if @festival.timetable_published? %>
-                <span class="inline-flex items-center gap-2 rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700">
-                  <span class="inline-block h-2 w-2 rounded-full bg-emerald-500"></span>
-                  公開中
-                </span>
-              <% else %>
-                <span class="inline-flex items-center gap-2 rounded-full bg-slate-200 px-3 py-1 text-xs font-semibold text-slate-600">
-                  <span class="inline-block h-2 w-2 rounded-full bg-slate-400"></span>
-                  非公開
-                </span>
-              <% end %>
+              <%= festival_timetable_status_badge(@festival) %>
             </dd>
           </div>
           <div class="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-3">
             <dt class="font-semibold text-slate-500">タグ</dt>
             <dd class="sm:col-span-2 flex flex-wrap gap-2">
-              <% if @festival.festival_tags.any? %>
-                <% @festival.festival_tags.order(:name).each do |tag| %>
-                  <span class="inline-flex items-center rounded-full bg-indigo-50 px-3 py-1 text-xs font-semibold text-indigo-700">
-                    <%= tag.name %>
-                  </span>
-                <% end %>
-              <% else %>
+              <%= render "shared/festival_tags", tags: @festival_tags %>
+              <% if @festival_tags.blank? %>
                 <span class="text-slate-500">未設定</span>
               <% end %>
             </dd>
@@ -144,7 +118,7 @@
             <div class="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
               <div class="flex flex-wrap items-center justify-between gap-2">
                 <div class="text-base font-semibold text-slate-800">
-                  <%= day.date.strftime("%Y/%m/%d (%a)") %>
+                  <%= format_date_with_weekday(day.date) %>
                 </div>
                 <% if day.note.present? %>
                   <div class="text-xs text-slate-500"><%= day.note %></div>
@@ -179,12 +153,11 @@
       <% if stages.any? %>
         <div class="mt-4 grid gap-4 md:grid-cols-2">
           <% stages.each do |stage| %>
-            <% hex = stage.color_hex %>
-            <% text_color = stage_text_color(hex) %>
             <div class="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
               <div class="flex items-center justify-between gap-2">
                 <h3 class="text-base font-semibold text-slate-800"><%= stage.name %></h3>
-                <span class="inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold" style="background-color: <%= hex %>; color: <%= text_color %>;">
+                <span class="inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold"
+                      style="<%= festival_stage_badge_style(stage) %>">
                   <span><%= stage.color_key.presence || "slate" %></span>
                 </span>
               </div>

--- a/app/views/festivals/show.html.erb
+++ b/app/views/festivals/show.html.erb
@@ -1,18 +1,9 @@
 <div class="min-h-screen px-4 pb-24 pt-6">
   <div class="mx-auto max-w-3xl space-y-6">
     <article class="rounded-3xl border border-slate-200 bg-white p-6 shadow-lg shadow-slate-200/60">
-      <% tags = @festival.festival_tags.sort_by(&:name) %>
       <header class="flex flex-col gap-2">
         <h1 class="text-2xl font-bold text-slate-900"><%= @festival.name %></h1>
-        <% if tags.any? %>
-          <div class="flex flex-wrap gap-2">
-            <% tags.each do |tag| %>
-              <span class="inline-flex items-center rounded-full bg-indigo-50 px-3 py-1 text-xs font-semibold text-indigo-700">
-                <%= tag.name %>
-              </span>
-            <% end %>
-          </div>
-      <% end %>
+        <%= render "shared/festival_tags", tags: @festival_tags %>
       </header>
 
       <p class="mt-4 text-sm text-slate-600">
@@ -38,33 +29,16 @@
         <div class="flex flex-col gap-1">
           <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">開催期間</dt>
           <dd class="font-semibold text-slate-800">
-            <% if @festival.start_date.present? %>
-              <% start_label = format_date_with_weekday(@festival.start_date) %>
-              <% end_label = format_date_with_weekday(@festival.end_date) %>
-              <% if end_label.present? && @festival.end_date != @festival.start_date %>
-                <%= start_label %> 〜 <%= end_label %>
-              <% else %>
-                <%= start_label %>
-              <% end %>
-            <% else %>
-              <span class="text-slate-400">未定</span>
-            <% end %>
+            <% period_label = festival_period_label(@festival, with_weekday: true) %>
+            <%= period_label.present? ? period_label : content_tag(:span, "未定", class: "text-slate-400") %>
           </dd>
         </div>
 
         <div class="flex flex-col gap-1">
           <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">会場</dt>
           <dd class="flex flex-wrap items-center gap-2 text-slate-800">
-            <% location_parts = [] %>
-            <% location_parts << "＠#{@festival.prefecture}" if @festival.prefecture.present? %>
-            <% location_parts << @festival.city if @festival.city.present? %>
-            <% location_parts << @festival.venue_name if @festival.venue_name.present? %>
-
-            <% if location_parts.any? %>
-              <span><%= location_parts.join(" ") %></span>
-            <% else %>
-              <span class="text-slate-400">未定</span>
-            <% end %>
+            <% location_label = festival_location_label(@festival) %>
+            <%= location_label.present? ? location_label : content_tag(:span, "未定", class: "text-slate-400") %>
           </dd>
         </div>
       </dl>

--- a/app/views/shared/_festival_tags.html.erb
+++ b/app/views/shared/_festival_tags.html.erb
@@ -1,0 +1,9 @@
+<% if tags.any? %>
+  <div class="flex flex-wrap gap-2">
+    <% tags.each do |tag| %>
+      <span class="inline-flex items-center rounded-full bg-indigo-50 px-3 py-1 text-xs font-semibold text-indigo-700">
+        <%= tag.name %>
+      </span>
+    <% end %>
+  </div>
+<% end %>


### PR DESCRIPTION
## 概要
- フェス詳細（公開/管理）の表示ロジックを整理し、表示用ヘルパーとパーシャルで共通化してビューを簡潔化。
## 実施内容
- フェス表示系のヘルパー追加（開催期間/会場/タイムゾーン/公開バッジ/ステージバッジ）を festivals_helper.rb に集約
- タグ取得をモデルに移し、取得はコントローラで実行するよう整理（festival.rb, festivals_controller.rb, festivals_controller.rb）
- タグ表示ブロックをパーシャル化し、show.html.erb と show.html.erb で共通利用
- 管理画面のフェス一覧の開催期間/会場表示をヘルパー経由に変更（index.html.erb）
## 対応Issue
なし
## 関連Issue
なし
## 特記事項