### PR TITLE
[refactor]セットリスト一覧の表示準備をビューから分離

### DIFF
--- a/app/controllers/setlists_controller.rb
+++ b/app/controllers/setlists_controller.rb
@@ -17,7 +17,22 @@ class SetlistsController < ApplicationController
                       .includes(:artist, :stage, :setlist)
                       .order(:starts_at, :ends_at, :id)
     @stages = @festival.stages.order(:sort_order, :id)
-    @performances_by_stage = @performances.group_by(&:stage)
+
+    # タブ情報とステージ別の表示用データをまとめて構築する
+    context = SetlistsIndexViewContextBuilder.build(
+      festival: @festival,
+      festival_days: @festival_days,
+      selected_day: @selected_day,
+      performances: @performances,
+      stages: @stages,
+      back_to: request.fullpath,
+      time_range_proc: ->(performance) { helpers.performance_time_range(performance, timezone: @timezone) }
+    )
+    @day_lookup = context[:day_lookup]
+    @tab_items = context[:tab_items]
+    @tab_url_builder = context[:tab_url_builder]
+    @staged_performances = context[:staged_performances]
+    @has_performances = context[:has_performances]
   end
 
   def show

--- a/app/services/setlists_index_view_context_builder.rb
+++ b/app/services/setlists_index_view_context_builder.rb
@@ -1,0 +1,61 @@
+class SetlistsIndexViewContextBuilder
+  include Rails.application.routes.url_helpers
+
+  def self.build(festival:, festival_days:, selected_day:, performances:, stages:, back_to:, time_range_proc:)
+    new(
+      festival: festival,
+      festival_days: festival_days,
+      selected_day: selected_day,
+      performances: performances,
+      stages: stages,
+      back_to: back_to,
+      time_range_proc: time_range_proc
+    ).build
+  end
+
+  def initialize(festival:, festival_days:, selected_day:, performances:, stages:, back_to:, time_range_proc:)
+    @festival = festival
+    @festival_days = festival_days
+    @selected_day = selected_day
+    @performances = performances
+    @stages = stages
+    @back_to = back_to
+    @time_range_proc = time_range_proc
+  end
+
+  def build
+    day_lookup = @festival_days.index_by(&:id)
+    tab_items = day_lookup.transform_values { |day| day.date.strftime("%-m/%-d") }
+    # 日付タブから該当日のセットリストURLを組み立てるためのlambda
+    tab_url_builder = ->(festival_day_id) do
+      day = day_lookup[festival_day_id]
+      festival_setlists_path(@festival, date: day.date.to_s)
+    end
+
+    performances_by_stage = @performances.group_by(&:stage)
+    # ステージごとの表示用エントリーを整形して渡す
+    staged_performances = @stages.filter_map do |stage|
+      stage_performances = performances_by_stage[stage]
+      next if stage_performances.blank?
+
+      entries = stage_performances.map do |performance|
+        label = performance.artist&.name || "(未定)"
+        subtext = @time_range_proc.call(performance)
+        disabled = performance.setlist.blank?
+        url = disabled ? nil : festival_setlist_path(@festival, performance.setlist, back_to: @back_to)
+
+        { label: label, subtext: subtext, disabled: disabled, url: url }
+      end
+
+      { stage: stage, entries: entries }
+    end
+
+    {
+      day_lookup: day_lookup,
+      tab_items: tab_items,
+      tab_url_builder: tab_url_builder,
+      staged_performances: staged_performances,
+      has_performances: staged_performances.any?
+    }
+  end
+end

--- a/app/views/setlists/_stage_performances.html.erb
+++ b/app/views/setlists/_stage_performances.html.erb
@@ -1,0 +1,15 @@
+<div class="space-y-3">
+  <h2 class="text-lg font-semibold" style="color: <%= stage.color_hex %>;">
+    <%= stage.name.presence || "(未定)" %>
+  </h2>
+  <div class="space-y-3 md:grid md:grid-cols-2 md:gap-3 md:space-y-0">
+    <% entries.each do |entry| %>
+      <%= render Shared::NavStackButtonComponent.new(
+                 label: entry[:label],
+                 subtext: entry[:subtext],
+                 url: entry[:url],
+                 disabled: entry[:disabled]
+               ) %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/setlists/index.html.erb
+++ b/app/views/setlists/index.html.erb
@@ -19,49 +19,21 @@
       </div>
     </header>
 
-    <% day_lookup = @festival_days.index_by(&:id) %>
-    <% tab_items = day_lookup.transform_values { |day| day.date.strftime("%-m/%-d") } %>
     <div class="flex justify-center">
       <%= render "shared/segmented_tabs",
-            tabs: tab_items,
+            tabs: @tab_items,
             active_tab_key: @selected_day.id,
-            url_builder: ->(festival_day_id) do
-              day = day_lookup[festival_day_id]
-              festival_setlists_path(@festival, date: day.date.to_s)
-            end %>
+            url_builder: @tab_url_builder %>
     </div>
 
     <section class="space-y-6">
-      <% @stages.each do |stage| %>
-        <% performances = @performances_by_stage[stage] || [] %>
-        <% next if performances.blank? %>
-        <div class="space-y-3">
-          <h2 class="text-lg font-semibold" style="color: <%= stage.color_hex %>;">
-            <%= stage.name.presence || "(未定)" %>
-          </h2>
-          <div class="space-y-3 md:grid md:grid-cols-2 md:gap-3 md:space-y-0">
-            <% performances.each do |performance| %>
-              <% label = performance.artist&.name || "(未定)" %>
-              <% subtext = performance_time_range(performance, timezone: @timezone) %>
-              <% if performance.setlist.present? %>
-                <%= render Shared::NavStackButtonComponent.new(
-                           label: label,
-                           subtext: subtext,
-                           url: festival_setlist_path(@festival, performance.setlist, back_to: request.fullpath)
-                         ) %>
-              <% else %>
-                <%= render Shared::NavStackButtonComponent.new(
-                           label: label,
-                           subtext: subtext,
-                           disabled: true
-                         ) %>
-              <% end %>
-            <% end %>
-          </div>
-        </div>
+      <% @staged_performances.each do |group| %>
+        <%= render "stage_performances",
+                   stage: group[:stage],
+                   entries: group[:entries] %>
       <% end %>
 
-      <% if @performances.blank? %>
+      <% unless @has_performances %>
         <div class="rounded-2xl bg-white px-4 py-12 text-center text-sm text-slate-600 shadow">
           表示できる出演枠がありません。
         </div>

--- a/spec/requests/setlists_spec.rb
+++ b/spec/requests/setlists_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe "セットリスト一覧", type: :request do
+  let(:festival) do
+    create(
+      :festival,
+      start_date: 10.days.ago.to_date,
+      end_date: 9.days.ago.to_date,
+      timezone: "Asia/Tokyo"
+    )
+  end
+
+  let(:festival_day) { create(:festival_day, festival: festival, date: festival.start_date) }
+
+  describe "GET /festivals/:festival_id/setlists" do
+    it "過去フェスの一覧を表示できる" do
+      stage = create(:stage, festival: festival)
+      performance = create(:stage_performance, :scheduled, festival_day: festival_day, stage: stage)
+      create(:setlist, stage_performance: performance)
+
+      get festival_setlists_path(festival, date: festival_day.date.to_s)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("#{festival.name} のセットリスト")
+      expect(response.body).to include(performance.artist.name)
+    end
+
+    it "出演枠がない場合は空メッセージを表示する" do
+      get festival_setlists_path(festival, date: festival_day.date.to_s)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("表示できる出演枠がありません。")
+    end
+  end
+end


### PR DESCRIPTION
## 概要
- セットリスト一覧の表示準備をビューから分離し、Builderとパーシャルに集約して責務分離と可読性を向上。
- 表示確認用のリクエストspecを追加。
## 実施内容
- setlists_index_view_context_builder.rb を追加し、タブ情報・ステージ別表示データの整形を集約。
- setlists_controller.rb でBuilderを利用する構成に変更し、整形ロジックを移動。
- _stage_performances.html.erb を新設してステージ別レンダリングを共通化。
- index.html.erb の整形処理を削除し、Builder結果とパーシャルで描画。
- setlists_spec.rb を追加し、一覧表示と空メッセージの表示を確認。
## 対応Issue
なし
## 関連Issue
なし
## 特記事項
意図的に share_text / share_url はビュー側に残して読みやすさを優先