### PR TITLE
[refactor]アーティスト一覧の表示準備ロジックに移動

### DIFF
--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -15,6 +15,7 @@ class ArtistsController < ApplicationController
 
     @pagy, @artists = pagy(result, params: request.query_parameters)
     @back_to = request.fullpath
+    prepare_index_view_context
   end
 
   def show; end
@@ -23,5 +24,17 @@ class ArtistsController < ApplicationController
 
   def set_artist
     @artist = Artist.find_published!(params[:id])
+  end
+
+  def prepare_index_view_context
+    # TODO: 画面ロジックが増えたらViewContext/Presenterに移す
+    @show_day_tabs = @festival.present? && @festival_days.any?
+    @preserved_query = request.query_parameters.except(:page, :festival_day_id)
+    @tab_items = @festival_days.map { |festival_day| [ festival_day.id, festival_day.date.strftime("%-m/%-d") ] }.to_h
+    @tab_url_builder = ->(festival_day_id) { festival_artists_path(@festival, @preserved_query.merge(festival_day_id: festival_day_id)) }
+    @search_url = artists_path
+    @search_hidden_fields = {}
+    @selected_day_label = nil
+    @show_selected_day_label = false
   end
 end

--- a/app/controllers/festivals/artists_controller.rb
+++ b/app/controllers/festivals/artists_controller.rb
@@ -13,6 +13,7 @@ class Festivals::ArtistsController < ApplicationController
     result = @q.result(distinct: true)
 
     @pagy, @artists = pagy(result, params: request.query_parameters)
+    prepare_index_view_context
 
     render "artists/index"
   end
@@ -36,5 +37,17 @@ class Festivals::ArtistsController < ApplicationController
   def set_back_to_param
     # 現在の一覧URLを保存し、詳細遷移時の戻り先として渡す
     @back_to = request.fullpath
+  end
+
+  def prepare_index_view_context
+    # TODO: 画面ロジックが増えたらViewContext/Presenterに移す
+    @show_day_tabs = @festival.present? && @festival_days.any?
+    @preserved_query = request.query_parameters.except(:page, :festival_day_id)
+    @tab_items = @festival_days.map { |festival_day| [ festival_day.id, festival_day.date.strftime("%-m/%-d") ] }.to_h
+    @tab_url_builder = ->(festival_day_id) { festival_artists_path(@festival, @preserved_query.merge(festival_day_id: festival_day_id)) }
+    @search_url = festival_artists_path(@festival, festival_day_id: @selected_festival_day&.id)
+    @search_hidden_fields = @selected_festival_day ? { festival_day_id: @selected_festival_day.id } : {}
+    @selected_day_label = @selected_festival_day&.date&.strftime("%-m/%-d")
+    @show_selected_day_label = @selected_festival_day.present?
   end
 end

--- a/app/views/artists/index.html.erb
+++ b/app/views/artists/index.html.erb
@@ -6,7 +6,7 @@
       </h1>
       <p class="text-sm text-slate-600">
         FES READYに登録されているアーティスト一覧です。
-        <% if @festival.present? && @festival_days.any? %><br>出演日を切り替えると、その日のアーティストだけに絞り込めます。<% end %>
+        <% if @show_day_tabs %><br>出演日を切り替えると、その日のアーティストだけに絞り込めます。<% end %>
       </p>
       <% unless user_signed_in? %>
         <%= render "shared/login_callout",
@@ -15,36 +15,26 @@
                    cta_label: "ログイン" %>
       <% end %>
 
-      <% if @festival.present? && @festival_days.any? %>
-        <% preserved_query = request.query_parameters.except(:page, :festival_day_id) %>
-        <% tab_items = @festival_days.map { |festival_day| [ festival_day.id, festival_day.date.strftime("%-m/%-d") ] }.to_h %>
+      <% if @show_day_tabs %>
         <div class="flex justify-center">
           <%= render "shared/segmented_tabs",
-                tabs: tab_items,
+                tabs: @tab_items,
                 active_tab_key: @selected_festival_day&.id,
-                url_builder: ->(festival_day_id) {
-                  festival_artists_path(@festival, preserved_query.merge(festival_day_id: festival_day_id))
-                } %>
+                url_builder: @tab_url_builder %>
         </div>
       <% end %>
 
-      <% if @festival.present? && @selected_festival_day %>
+      <% if @show_selected_day_label %>
         <p class="text-sm font-semibold text-slate-600">
-          <%= @selected_festival_day.date.strftime("%-m/%-d") %> の出演アーティスト
+          <%= @selected_day_label %> の出演アーティスト
         </p>
       <% end %>
     </header>
 
-    <% search_url = if @festival.present?
-      festival_artists_path(@festival, festival_day_id: @selected_festival_day&.id)
-    else
-      artists_path
-    end %>
-
     <%= render Shared::SearchFormComponent.new(
                query: @q,
-               url: search_url,
-               hidden_fields: (@selected_festival_day ? { festival_day_id: @selected_festival_day.id } : {}),
+               url: @search_url,
+               hidden_fields: @search_hidden_fields,
                placeholder: "アーティスト名を入力"
              ) %>
 


### PR DESCRIPTION
## 概要
- アーティスト一覧の表示準備ロジックをビューからコントローラに移し、ビューを描画専用に整理。
## 実施内容
- artists_controller.rb に表示準備用の prepare_index_view_context を追加。
- artists_controller.rb に同様の表示準備を追加。
- index.html.erb から preserved_query / tab_items / search_url などの定義を削除し、コントローラで用意した変数を利用。
- 将来的にViewContext/Presenterへ移す可能性を示すTODOコメントを追加。
## 対応Issue
なし
## 関連Issue
なし
## 特記事項
責務の分離の観点ではhelper or Presenterに移行すべきだが、処理フローの可読性の観点からコントローラで許容できると判断した。