### PR TITLE
[refactor]フェス一覧の共通化

### DIFF
--- a/app/views/artists/show.html.erb
+++ b/app/views/artists/show.html.erb
@@ -36,11 +36,11 @@
         </div>
       </div>
 
-      <p class="mt-6 text-sm text-slate-600">
+      <hr class="my-8 border-slate-200" />
+
+      <p class="mt-2 mb-5 text-sm text-slate-600">
         出演フェスや予習ページをチェックできます。
       </p>
-
-      <hr class="my-8 border-slate-200" />
 
       <div class="space-y-3">
         <%= link_to artist_festivals_path(@artist),

--- a/app/views/festivals/index.html.erb
+++ b/app/views/festivals/index.html.erb
@@ -52,29 +52,14 @@
                selected_tag_ids: @selected_tag_ids,
                reset_url: reset_url %>
 
-    <section class="grid gap-3 md:grid-cols-2 md:gap-4">
-      <% if @festivals.any? %>
-        <% @festivals.each do |festival| %>
-          <div class="w-full">
-            <%= render Shared::NavStackButtonComponent.new(
-                       label: festival.name,
-                       subtext: festival_date_and_location(festival),
-                       url: festival_path(festival, back_to: @back_to),
-                       trailing: favorite_button_for(
-                         favorited: festival_favorited?(festival),
-                         toggle_url: festival_favorite_path(festival)
-                       )
-                     ) %>
-          </div>
-        <% end %>
-      <% else %>
-        <p class="rounded-xl bg-white px-4 py-12 text-center text-sm text-slate-500 shadow md:col-span-2 space-y-1">
-          <span class="block">表示できるフェスがありません。</span>
-          <span class="block">条件に合う開催予定が見つかりませんでした。</span>
-          <span class="block">日程・エリア・タグを変えて再検索してください。</span>
-        </p>
-      <% end %>
-    </section>
+    <%= render "shared/festival_list",
+               festivals: @festivals,
+               empty_messages: [
+                 "表示できるフェスがありません。",
+                 "条件に合う開催予定が見つかりませんでした。",
+                 "日程・エリア・タグを変えて再検索してください。"
+               ],
+               link_url_proc: ->(festival) { festival_path(festival, back_to: @back_to) } %>
   </div>
   <%= render "shared/pagination", pagy: @pagy %>
 </div>

--- a/app/views/prep/festivals/index.html.erb
+++ b/app/views/prep/festivals/index.html.erb
@@ -21,7 +21,6 @@
       </div>
     </header>
 
-    <% search_url = prep_festivals_path %>
     <% search_query = params.dig(:q, :name_i_cont) %>
     <% hidden_filter_fields = {
          start_date_from: @filter_params[:start_date_from],
@@ -31,7 +30,7 @@
        } %>
     <%= render Shared::SearchFormComponent.new(
                query: @q,
-               url: search_url,
+               url: prep_festivals_path,
                placeholder: "フェス名を入力",
                status: @status,
                hidden_fields: hidden_filter_fields
@@ -42,7 +41,7 @@
     <% reset_url = prep_festivals_path(reset_params) %>
 
     <%= render "shared/festival_filters",
-               form_url: search_url,
+               form_url: prep_festivals_path,
                status: @status,
                search_query: search_query,
                filter_params: @filter_params,
@@ -50,29 +49,14 @@
                selected_tag_ids: @selected_tag_ids,
                reset_url: reset_url %>
 
-    <section class="grid gap-3 md:grid-cols-2 md:gap-4">
-      <% if @festivals.any? %>
-        <% @festivals.each do |festival| %>
-          <div class="w-full">
-            <%= render Shared::NavStackButtonComponent.new(
-                       label: festival.name,
-                       subtext: festival_date_and_location(festival),
-                       url: prep_festival_path(festival),
-                       trailing: favorite_button_for(
-                         favorited: festival_favorited?(festival),
-                         toggle_url: festival_favorite_path(festival)
-                       )
-                     ) %>
-          </div>
-        <% end %>
-      <% else %>
-        <p class="rounded-xl bg-white px-4 py-12 text-center text-sm text-slate-500 shadow md:col-span-2 space-y-1">
-          <span class="block">表示できるフェスがありません。</span>
-          <span class="block">予習対象のフェスが見つかりませんでした。</span>
-          <span class="block">開催時期やタグを変えて再検索してください。</span>
-        </p>
-      <% end %>
-    </section>
+    <%= render "shared/festival_list",
+               festivals: @festivals,
+               empty_messages: [
+                 "表示できるフェスがありません。",
+                 "予習対象のフェスが見つかりませんでした。",
+                 "開催時期やタグを変えて再検索してください。"
+               ],
+               link_url_proc: ->(festival) { prep_festival_path(festival) } %>
     <%= render "shared/pagination", pagy: @pagy %>
   </div>
 </div>

--- a/app/views/shared/_festival_list.html.erb
+++ b/app/views/shared/_festival_list.html.erb
@@ -1,0 +1,23 @@
+<section class="grid gap-3 md:grid-cols-2 md:gap-4">
+  <% if festivals.any? %>
+    <% festivals.each do |festival| %>
+      <div class="w-full">
+        <%= render Shared::NavStackButtonComponent.new(
+                   label: festival.name,
+                   subtext: festival_date_and_location(festival),
+                   url: link_url_proc.call(festival),
+                   trailing: favorite_button_for(
+                     favorited: festival_favorited?(festival),
+                     toggle_url: festival_favorite_path(festival)
+                   )
+                 ) %>
+      </div>
+    <% end %>
+  <% else %>
+    <p class="rounded-xl bg-white px-4 py-12 text-center text-sm text-slate-500 shadow md:col-span-2 space-y-1">
+      <% empty_messages.each do |message| %>
+        <span class="block"><%= message %></span>
+      <% end %>
+    </p>
+  <% end %>
+</section>


### PR DESCRIPTION
## 概要
- フェス一覧のフェス表示部分の共通化。
- アーティスト詳細の説明文レイアウト調整。
## 実施内容
- _festival_list.html.erb を追加し、フェス一覧のレイアウトと空状態メッセージを共通化
- index.html.erb / index.html.erb で共通パーシャルを利用し、link_url_proc を渡す形に整理
- show.html.erb の説明文を <hr> の下へ移動し、余白を調整して見た目のバランスを改善
## 対応Issue
なし
## 関連Issue
なし
## 特記事項