### PR TITLE
[refactor]予習フェス一覧の表示準備ロジックの切り離し

### DIFF
--- a/app/views/prep/festivals/index.html.erb
+++ b/app/views/prep/festivals/index.html.erb
@@ -9,45 +9,30 @@
                    description: "お気に入り登録で、気になるフェスをすぐに見返せます。",
                    cta_label: "ログイン" %>
       <% end %>
-      <% preserved_query = request.query_parameters.except(:page, :status) %>
       <div class="flex justify-center">
         <%= render "shared/segmented_tabs",
               tabs: status_labels,
               active_tab_key: @status,
-              url_builder: ->(key) do
-                path_options = preserved_query.merge(status: key)
-                prep_festivals_path(path_options)
-              end %>
+              url_builder: @tab_url_builder %>
       </div>
     </header>
 
-    <% search_query = params.dig(:q, :name_i_cont) %>
-    <% hidden_filter_fields = {
-         start_date_from: @filter_params[:start_date_from],
-         end_date_to: @filter_params[:end_date_to],
-         area: @filter_params[:area],
-         "tag_ids[]": @selected_tag_ids
-       } %>
     <%= render Shared::SearchFormComponent.new(
                query: @q,
                url: prep_festivals_path,
                placeholder: "フェス名を入力",
                status: @status,
-               hidden_fields: hidden_filter_fields
+               hidden_fields: @hidden_filter_fields
              ) %>
-
-    <% reset_params = { status: @status } %>
-    <% reset_params[:q] = { name_i_cont: search_query } if search_query.present? %>
-    <% reset_url = prep_festivals_path(reset_params) %>
 
     <%= render "shared/festival_filters",
                form_url: prep_festivals_path,
                status: @status,
-               search_query: search_query,
+               search_query: @search_query,
                filter_params: @filter_params,
                festival_tags: @festival_tags,
                selected_tag_ids: @selected_tag_ids,
-               reset_url: reset_url %>
+               reset_url: @reset_url %>
 
     <%= render "shared/festival_list",
                festivals: @festivals,


### PR DESCRIPTION
## 概要
- 予習フェス一覧の表示準備ロジックをビューからコントローラへ移し、ビューを描画専用に整理。
## 実施内容
- festivals_controller.rb に prepare_index_view_context を追加し、preserved_query / tab_url_builder / search_query / hidden_filter_fields / reset_url を用意。
- index.html.erb からローカル変数定義を削除し、コントローラで用意した値を利用。
- 将来的なViewContext/Presenter移行のためのTODOコメントを追加。
## 対応Issue
なし
## 関連Issue
なし
## 特記事項