### PR TITLE
[refactor]BoardComponent にステージごとの描画ロジックを集約

### DIFF
--- a/app/components/timetables/board_component.html.erb
+++ b/app/components/timetables/board_component.html.erb
@@ -17,7 +17,13 @@
       <div class="flex flex-1 gap-2 md:gap-3">
         <% if stages.any? %>
           <% stages.each do |stage| %>
-            <%= stage_renderer.call(stage) %>
+            <%= render stage_component.new(
+                         stage: stage,
+                         performances: performances_by_stage[stage],
+                         time_markers: time_markers,
+                         timeline_layout: timeline_layout,
+                         **stage_component_options
+                       ) %>
           <% end %>
         <% else %>
           <div class="flex h-full min-h-[320px] flex-1 items-center justify-center rounded-2xl border border-dashed border-slate-300 bg-white/70 px-6 py-12 text-center text-sm text-slate-500"><%= empty_message %></div>

--- a/app/components/timetables/board_component.rb
+++ b/app/components/timetables/board_component.rb
@@ -1,17 +1,21 @@
 module Timetables
   class BoardComponent < ViewComponent::Base
-    def initialize(stages:, time_markers:, timeline_layout:, timezone:, empty_message: "ステージ情報がありません", stage_renderer:)
+    def initialize(stages:, time_markers:, timeline_layout:, timezone:, empty_message: "ステージ情報がありません",
+                   stage_component:, performances_by_stage:, stage_component_options: {})
       @stages = Array(stages)
       @time_markers = Array(time_markers)
       @timeline_layout = timeline_layout
       @timezone = timezone
       @empty_message = empty_message
-      @stage_renderer = stage_renderer
+      @stage_component = stage_component
+      @performances_by_stage = performances_by_stage || {}
+      @stage_component_options = stage_component_options || {}
     end
 
     private
 
-    attr_reader :stages, :time_markers, :timeline_layout, :timezone, :empty_message, :stage_renderer
+    attr_reader :stages, :time_markers, :timeline_layout, :timezone, :empty_message, :stage_component,
+                :performances_by_stage, :stage_component_options
 
     def marker_timeline_style
       "height: #{timeline_layout.column_height_px}px;"

--- a/app/views/my_timetables/edit.html.erb
+++ b/app/views/my_timetables/edit.html.erb
@@ -14,23 +14,15 @@
     <%= form_with url: festival_my_timetable_path(@festival, date: @selected_day.date.to_s, user_id: current_user.uuid),
                   method: :patch,
                   class: "flex flex-col gap-6" do %>
-      <% stage_renderer = ->(stage) do
-           render Timetables::Columns::MyTimetablePickerComponent.new(
-             stage: stage,
-             performances: @performances_by_stage[stage],
-             time_markers: @time_markers,
-             timeline_layout: @timeline_layout,
-             picked_ids: @picked_ids
-           )
-         end %>
-
       <%= render Timetables::BoardComponent.new(
                stages: @stages,
                time_markers: @time_markers,
                timeline_layout: @timeline_layout,
                timezone: @timezone,
                empty_message: "登録されたステージがありません",
-               stage_renderer: stage_renderer
+               stage_component: Timetables::Columns::MyTimetablePickerComponent,
+               performances_by_stage: @performances_by_stage,
+               stage_component_options: { picked_ids: @picked_ids }
              ) %>
 
       <div class="flex justify-center">

--- a/app/views/my_timetables/show.html.erb
+++ b/app/views/my_timetables/show.html.erb
@@ -40,27 +40,21 @@
       <% end %>
 
       <% timetable_owner_identifier = params[:user_id].presence || @timetable_owner&.uuid %>
-      <% stage_renderer = ->(stage) do
-           render Timetables::Columns::MyTimetableViewComponent.new(
-             stage: stage,
-             performances: @performances_by_stage[stage],
-             time_markers: @time_markers,
-             timeline_layout: @timeline_layout,
-             festival: @festival,
-             selected_day: @selected_day,
-             selected_ids: @selected_performance_ids,
-             owner_identifier: timetable_owner_identifier,
-             back_to: request.fullpath
-           )
-         end %>
-
       <%= render Timetables::BoardComponent.new(
                stages: @stages,
                time_markers: @time_markers,
                timeline_layout: @timeline_layout,
                timezone: @timezone,
                empty_message: "ステージ情報がありません。",
-               stage_renderer: stage_renderer
+               stage_component: Timetables::Columns::MyTimetableViewComponent,
+               performances_by_stage: @performances_by_stage,
+               stage_component_options: {
+                 festival: @festival,
+                 selected_day: @selected_day,
+                 selected_ids: @selected_performance_ids,
+                 owner_identifier: timetable_owner_identifier,
+                 back_to: request.fullpath
+               }
              ) %>
 
       <% if @timetable_owner == current_user %>

--- a/app/views/timetables/show.html.erb
+++ b/app/views/timetables/show.html.erb
@@ -35,25 +35,19 @@
       <% end %>
     <% end %>
 
-    <% stage_renderer = ->(stage) do
-         render Timetables::Columns::PublicComponent.new(
-           stage: stage,
-           performances: @performances_by_stage[stage],
-           time_markers: @time_markers,
-           timeline_layout: @timeline_layout,
-           festival: @festival,
-           selected_day: @selected_day,
-           back_to: request.fullpath
-         )
-       end %>
-
     <%= render Timetables::BoardComponent.new(
           stages: @stages,
           time_markers: @time_markers,
           timeline_layout: @timeline_layout,
           timezone: @timezone,
           empty_message: "登録されたステージがありません",
-          stage_renderer: stage_renderer
+          stage_component: Timetables::Columns::PublicComponent,
+          performances_by_stage: @performances_by_stage,
+          stage_component_options: {
+            festival: @festival,
+            selected_day: @selected_day,
+            back_to: request.fullpath
+          }
         ) %>
   </div>
 </div>


### PR DESCRIPTION
## 概要
- Timetables::BoardComponent にステージごとの描画ロジックを集約し、各ビューのラムダ定義を削除した。
## 実施内容
- board_component.rb に stage_component / performances_by_stage / stage_component_options を受け取る設計を追加。
- board_component.html.erb にステージごとのカラムコンポーネント生成・描画処理を移動。
- my_timetables/edit.html.erb の stage_renderer を削除し BoardComponent 呼び出しに切替。
- timetables/show.html.erb の stage_renderer を削除し BoardComponent 呼び出しに切替。
- my_timetables/show.html.erb の stage_renderer を削除し BoardComponent 呼び出しに切替。
## 対応Issue
なし
## 関連Issue
なし
## 特記事項
ビューは必要なデータとオプションを渡すだけに整理。