### PR TITLE
[refactor]フェス日程のタブ生成ロジックをヘルパーに集約

### DIFF
--- a/app/helpers/festivals_helper.rb
+++ b/app/helpers/festivals_helper.rb
@@ -69,4 +69,10 @@ module FestivalsHelper
     text_color = stage_text_color(hex)
     "background-color: #{hex}; color: #{text_color};"
   end
+
+  def festival_day_tabs(festival_days)
+    day_lookup = Array(festival_days).index_by(&:id)
+    tab_items = day_lookup.transform_values { |day| day.date.strftime("%-m/%-d") }
+    { lookup: day_lookup, tabs: tab_items }
+  end
 end

--- a/app/views/prep/festivals/show.html.erb
+++ b/app/views/prep/festivals/show.html.erb
@@ -6,14 +6,13 @@
       <p class="text-sm text-slate-600"><%= festival_date_and_location(@festival) %></p>
     </header>
 
-    <% day_lookup = @festival_days.index_by(&:id) %>
-    <% tab_items = day_lookup.transform_values { |day| day.date.strftime("%-m/%-d") } %>
+    <% day_tabs = festival_day_tabs(@festival_days) %>
     <div class="flex justify-center">
       <%= render "shared/segmented_tabs",
-            tabs: tab_items,
+            tabs: day_tabs[:tabs],
             active_tab_key: @selected_day.id,
             url_builder: ->(festival_day_id) do
-              day = day_lookup[festival_day_id]
+              day = day_tabs[:lookup][festival_day_id]
               prep_festival_path(@festival, date: day.date.to_s, back_to: params[:back_to])
             end %>
     </div>

--- a/app/views/timetables/show.html.erb
+++ b/app/views/timetables/show.html.erb
@@ -6,8 +6,7 @@
                  selected_day: @selected_day,
                  timezone: @timezone
                ) do %>
-      <% day_lookup = @festival_days.index_by(&:id) %>
-      <% tab_items = day_lookup.transform_values { |day| day.date.strftime("%-m/%-d") } %>
+      <% day_tabs = festival_day_tabs(@festival_days) %>
       <% unless user_signed_in? %>
         <div class="mt-2">
           <%= render "shared/login_callout",
@@ -18,10 +17,10 @@
       <% end %>
       <div class="mt-6 flex justify-center">
         <%= render "shared/segmented_tabs",
-              tabs: tab_items,
+              tabs: day_tabs[:tabs],
               active_tab_key: @selected_day.id,
               url_builder: ->(festival_day_id) do
-                day = day_lookup[festival_day_id]
+                day = day_tabs[:lookup][festival_day_id]
                 timetable_path(@festival, @timetable_query_params.merge("date" => day.date.to_s))
               end %>
       </div>


### PR DESCRIPTION
## 概要
- フェス日程のタブ生成ロジックをヘルパーに集約し、各ビューでの重複ロジックを削減した。
## 実施内容
- festivals_helper.rb に festival_day_tabs を追加し、日程の lookup と tabs 生成を共通化。
- timetables/show.html.erb, prep/festivals/show.html.erb で day_lookup / tab_items の生成をヘルパー呼び出しに置き換え。
## 対応Issue
なし
## 関連Issue
なし
## 特記事項