### PR TITLE
[refactor]Spotify埋め込み表示の責務をヘルパーに移行

### DIFF
--- a/app/helpers/artists_helper.rb
+++ b/app/helpers/artists_helper.rb
@@ -18,6 +18,7 @@ module ArtistsHelper
     festival.name
   end
 
+  # セットリスト一覧で表示する日付サブテキスト用
   def setlist_subtext(setlist)
     setlist.stage_performance.festival_day.date.to_fs(:db)
   end
@@ -38,6 +39,15 @@ module ArtistsHelper
     )
   end
 
+  # prep/festivals の詳細で埋め込み or 代替メッセージを表示する
+  def spotify_embed_block(song, empty_message: "Spotify未登録の曲です", height: 152, css_class: nil)
+    embed = spotify_embed_for(song, height: height, css_class: css_class)
+    return embed if embed.present?
+
+    content_tag(:p, empty_message, class: "text-xs text-slate-500")
+  end
+
+  # prep/artist 詳細のランキング表示に渡すlocalsをまとめる
   def ranking_entry_locals(entry, index, artist)
     song  = entry[:song]
     embed = spotify_embed_for(song)

--- a/app/views/prep/festivals/show.html.erb
+++ b/app/views/prep/festivals/show.html.erb
@@ -30,14 +30,9 @@
               <p class="text-sm font-semibold text-slate-900">
                 <%= entry[:song].name %> / <%= entry[:artist].name %>
               </p>
-              <% embed = spotify_embed_for(entry[:song]) %>
-              <% if embed.present? %>
-                <div class="overflow-hidden rounded-xl border border-slate-200 shadow-sm">
-                  <%= embed %>
-                </div>
-              <% else %>
-                <p class="text-xs text-slate-500">Spotify未登録の曲です</p>
-              <% end %>
+              <div class="overflow-hidden rounded-xl border border-slate-200 shadow-sm">
+                <%= spotify_embed_block(entry[:song]) %>
+              </div>
             </div>
           <% end %>
         </div>


### PR DESCRIPTION
## 概要
- 埋め込み表示の責務をヘルパーに移し、prepフェス詳細のビュー分岐を削減。
- ArtistsHelper に用途が分かるコメントを追加。
## 実施内容
- artists_helper.rb に spotify_embed_block を追加し、埋め込み/代替表示を集約。
- prep/festivals/show.html.erb の spotify_embed_for 直接呼び出しと分岐を spotify_embed_block に置き換え。
- artists_helper.rb に spotify_embed_block / setlist_subtext / ranking_entry_locals の用途コメントを追加。
## 対応Issue
なし
## 関連Issue
なし
## 特記事項