### PR TITLE
[update]セットリスト一覧の表示条件を「開始日が今日以降」に変更

### DIFF
--- a/app/controllers/festivals_controller.rb
+++ b/app/controllers/festivals_controller.rb
@@ -23,7 +23,7 @@ class FestivalsController < ApplicationController
   end
 
   def show
-    @show_setlists_link = @festival.past? && @festival.setlists_available?
+    @show_setlists_link = @festival.setlists_visible?
     @festival_tags = @festival.sorted_tags
   end
 

--- a/app/controllers/setlists_controller.rb
+++ b/app/controllers/setlists_controller.rb
@@ -4,7 +4,7 @@ class SetlistsController < ApplicationController
   before_action :set_header_back_path, only: :show
 
   def index
-    raise ActiveRecord::RecordNotFound unless @festival.past?
+    raise ActiveRecord::RecordNotFound unless @festival.setlists_visible?
 
     @festival_days = @festival.timetable_days
     @selected_day = @festival.select_day(params[:date], days: @festival_days)

--- a/app/models/festival.rb
+++ b/app/models/festival.rb
@@ -78,16 +78,15 @@ class Festival < ApplicationRecord
     )
   end
 
-  # 開催済みフェスかを判定（本日より終了日が過去か）
-  def past?(today = Date.current)
-    end_date < today
-  end
-
   # セットリスト一覧への導線を出せるか判定
   def setlists_available?
     Setlist.joins(stage_performance: :festival_day)
            .where(festival_days: { festival_id: id })
            .exists?
+  end
+
+  def setlists_visible?(today = Date.current)
+    start_date.present? && start_date >= today && setlists_available?
   end
 
   private

--- a/spec/requests/setlists_spec.rb
+++ b/spec/requests/setlists_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe "セットリスト一覧", type: :request do
   let(:festival) do
     create(
       :festival,
-      start_date: 10.days.ago.to_date,
-      end_date: 9.days.ago.to_date,
+      start_date: Date.current,
+      end_date: 1.day.from_now.to_date,
       timezone: "Asia/Tokyo"
     )
   end
@@ -13,7 +13,7 @@ RSpec.describe "セットリスト一覧", type: :request do
   let(:festival_day) { create(:festival_day, festival: festival, date: festival.start_date) }
 
   describe "GET /festivals/:festival_id/setlists" do
-    it "過去フェスの一覧を表示できる" do
+    it "開始日が今日以降のフェスの一覧を表示できる" do
       stage = create(:stage, festival: festival)
       performance = create(:stage_performance, :scheduled, festival_day: festival_day, stage: stage)
       create(:setlist, stage_performance: performance)
@@ -25,11 +25,10 @@ RSpec.describe "セットリスト一覧", type: :request do
       expect(response.body).to include(performance.artist.name)
     end
 
-    it "出演枠がない場合は空メッセージを表示する" do
+    it "セットリストがない場合は404になる" do
       get festival_setlists_path(festival, date: festival_day.date.to_s)
 
-      expect(response).to have_http_status(:ok)
-      expect(response.body).to include("表示できる出演枠がありません。")
+      expect(response).to have_http_status(:not_found)
     end
   end
 end


### PR DESCRIPTION
## 概要
- セットリスト一覧の表示条件を「開始日が今日以降」に変更。
- フェス詳細の導線判定とテストを新仕様に合わせた。
- 関連する重複条件はモデルに集約。
## 実施内容
- setlists_controller.rb の一覧表示条件を start_date >= 今日 に変更。
- festivals_controller.rb の「セットリストへ」表示条件を同基準に変更。
- festival.rb に setlists_visible? を追加し、重複条件を集約（未使用の past? は削除）。
- setlists_spec.rb を新条件に合わせ、セットリスト無しは 404 になるテストに更新。
## 対応Issue
なし
## 関連Issue
なし
## 特記事項
セットリストを随時更新し、シェアするために仕様変更。