### PR TITLE
[fix]セットリスト一覧の公開条件を「開始日が今日以前」に変更

### DIFF
--- a/app/models/festival.rb
+++ b/app/models/festival.rb
@@ -86,7 +86,7 @@ class Festival < ApplicationRecord
   end
 
   def setlists_visible?(today = Date.current)
-    start_date.present? && start_date >= today && setlists_available?
+    start_date.present? && start_date <= today && setlists_available?
   end
 
   private


### PR DESCRIPTION
## 概要
- セットリスト一覧の公開条件を「開始日が今日以前」に変更し、過去フェスの一覧が表示されるように修正。
- 将来日付フェスは引き続き404になることをテストで担保。
## 実施内容
- festival.rb の setlists_visible? 判定を start_date <= today に変更。
- setlists_spec.rb の説明文を「今日以前」に更新。
- setlists_spec.rb に将来日付フェスが404となるテストを追加。
## 対応Issue
なし
## 関連Issue
なし
## 特記事項
ミスにより本番環境で404となっていたため、修正。