### PR TITLE
[refactor]出演枠一括登録の入力ルールとエラー処理をフォームオブジェクトへ集約

### DIFF
--- a/app/controllers/admin/stage_performances_controller.rb
+++ b/app/controllers/admin/stage_performances_controller.rb
@@ -16,17 +16,18 @@ class Admin::StagePerformancesController < Admin::BaseController
   def show; end
 
   def new
-    @bulk_entries = Array.new(10) { StagePerformance.new(status: :draft) }
+    @bulk_form = Admin::StagePerformances::BulkForm.new({})
+    @bulk_entries = Admin::StagePerformances::BulkForm.empty_entries
   end
 
   def create
-    result = Admin::StagePerformances::BulkCreator.call(bulk_params)
+    form = Admin::StagePerformances::BulkForm.new(bulk_params)
 
-    if result.success?
-      redirect_to admin_stage_performances_path, notice: "#{result.created_count}件の出演枠を追加しました。"
+    if form.save
+      redirect_to admin_stage_performances_path, notice: "#{form.created_count}件の出演枠を追加しました。"
     else
-      @bulk_entries = result.bulk_entries
-      flash.now[:alert] = result.error_message
+      @bulk_form = form
+      @bulk_entries = form.bulk_entries
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/views/admin/stage_performances/new.html.erb
+++ b/app/views/admin/stage_performances/new.html.erb
@@ -22,6 +22,17 @@
             "bulk-stage-performance-form-default-time-value": "00:00",
             "bulk-stage-performance-form-minute-step-value": 5
           } do |f| %>
+      <%# create失敗時にnewを再表示するためのエラー表示 %>
+      <% if @bulk_form.errors.any? %>
+        <div class="rounded border border-rose-200 bg-rose-50 px-4 py-3 text-rose-700">
+          <div class="mb-2 font-semibold"><%= pluralize(@bulk_form.errors.count, "error") %> prohibited this bulk import from being saved:</div>
+          <ul class="list-disc pl-5 text-sm">
+            <% @bulk_form.errors.full_messages.each do |msg| %>
+              <li><%= msg %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
       <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
         <div>
           <label class="text-sm font-semibold text-slate-700">フェス日程（全行に適用）</label>

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,10 @@ module Myapp
     config.autoload_paths << components_path
     config.eager_load_paths << components_path
 
+    forms_path = Rails.root.join("app/forms")
+    config.autoload_paths << forms_path
+    config.eager_load_paths << forms_path
+
     config.i18n.available_locales = [ :ja, :en ]
     config.i18n.default_locale = :ja
     config.time_zone = "Asia/Tokyo"

--- a/spec/forms/admin/stage_performances/bulk_form_spec.rb
+++ b/spec/forms/admin/stage_performances/bulk_form_spec.rb
@@ -1,0 +1,80 @@
+require "rails_helper"
+
+RSpec.describe Admin::StagePerformances::BulkForm do
+  describe "#save" do
+    it "開催日・ステージ・入力行がない場合にエラーになる" do
+      form = described_class.new({})
+
+      expect(form.save).to be(false)
+      expect(form.errors.full_messages).to include("開催日を選択してください。", "ステージを選択してください。", "1行以上入力してください。")
+      expect(form.bulk_entries.size).to eq(described_class::ENTRY_LIMIT)
+    end
+
+    it "開催日またはステージがない場合にエラーになる" do
+      artist = create(:artist)
+
+      form = described_class.new(entries: [ { artist_id: artist.id } ])
+
+      expect(form.save).to be(false)
+      expect(form.errors.full_messages).to include("開催日を選択してください。", "ステージを選択してください。")
+    end
+
+    it "入力が有効なら出演枠を作成する" do
+      festival_day = create(:festival_day)
+      stage = create(:stage, festival: festival_day.festival)
+      artist = create(:artist)
+
+      params = {
+        festival_day_id: festival_day.id,
+        stage_id: stage.id,
+        entries: [
+          { artist_id: artist.id, starts_at: nil, ends_at: nil, status: "draft", canceled: "0" }
+        ]
+      }
+
+      form = described_class.new(params)
+
+      expect { form.save }.to change(StagePerformance, :count).by(1)
+      expect(form.created_count).to eq(1)
+    end
+
+    it "空行は無視して入力行だけ作成する" do
+      festival_day = create(:festival_day)
+      stage = create(:stage, festival: festival_day.festival)
+      artist = create(:artist)
+
+      params = {
+        festival_day_id: festival_day.id,
+        stage_id: stage.id,
+        entries: [
+          { artist_id: nil, starts_at: nil, ends_at: nil, status: "draft", canceled: "0" },
+          { artist_id: artist.id, starts_at: nil, ends_at: nil, status: "draft", canceled: "0" }
+        ]
+      }
+
+      form = described_class.new(params)
+
+      expect { form.save }.to change(StagePerformance, :count).by(1)
+      expect(form.created_count).to eq(1)
+    end
+
+    it "canceledがチェックされていればtrueになる" do
+      festival_day = create(:festival_day)
+      stage = create(:stage, festival: festival_day.festival)
+      artist = create(:artist)
+
+      params = {
+        festival_day_id: festival_day.id,
+        stage_id: stage.id,
+        entries: [
+          { artist_id: artist.id, starts_at: nil, ends_at: nil, status: "draft", canceled: "1" }
+        ]
+      }
+
+      form = described_class.new(params)
+
+      expect(form.save).to be(true)
+      expect(StagePerformance.last.canceled).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
## 概要
- 出演枠一括登録の入力ルールとエラー処理をフォームオブジェクトへ集約し、errors ベースの標準的な流れに統一。
- app/forms を autoload/eager load 対象に追加し、フォームの読み込み対応を行った。
- 画面に複数エラー表示を追加し、フォーム単体テストを拡充。
## 実施内容
- フォーム化と入力ルール集約: bulk_form.rb
- コントローラ連携更新: stage_performances_controller.rb
- エラー表示の複数行対応: new.html.erb
- フォームの読み込み設定追加: application.rb
- 仕様を検証するフォームspec追加・拡充: bulk_form_spec.rb
## 対応Issue
なし
## 関連Issue
なし
## 特記事項
- 画面固有の入力ルール（開催日/ステージ必須、1行以上入力、空行補完）をフォームに集約し、モデルの「データルール」と分離するため。
- errors/valid? に統一して Rails 標準のフローに合わせ、理解しやすさと拡張性を優先するため。
- 一括登録の振る舞いをフォーム単体でテストできるようにし、UIに依存しない保証点を作るため。