### PR TITLE
[refactor]マイタイムテーブルの更新処理をフォームオブジェクトに集約

### DIFF
--- a/app/controllers/my_timetables_controller.rb
+++ b/app/controllers/my_timetables_controller.rb
@@ -19,11 +19,11 @@ class MyTimetablesController < ApplicationController
   end
 
   def update
-    MyTimetables::Updater.call(
+    MyTimetables::Form.new(
       user: current_user,
       festival_day: @selected_day,
       stage_performance_ids: params[:stage_performance_ids]
-    )
+    ).save
     redirect_to festival_my_timetable_path(@festival, date: @selected_day.date.to_s, user_id: current_user.uuid),
                 notice: "マイタイムテーブルを保存しました。"
   end
@@ -41,7 +41,7 @@ class MyTimetablesController < ApplicationController
   def show
     @performances = @timetable_owner
                       .my_stage_performances
-                      .includes(:artist, :stage, :festival_day)
+                      .includes(:artist, :stage)
                       .where(stage_performances: { festival_day_id: @selected_day.id })
                       .order(:starts_at, :ends_at, :id)
     @conflicts = MyTimetables::ConflictDetector.call(@performances)

--- a/app/forms/my_timetables/form.rb
+++ b/app/forms/my_timetables/form.rb
@@ -1,8 +1,6 @@
 module MyTimetables
-  class Updater
-    def self.call(...)
-      new(...).call
-    end
+  class Form
+    include ActiveModel::Model
 
     def initialize(user:, festival_day:, stage_performance_ids:)
       @user = user
@@ -10,13 +8,15 @@ module MyTimetables
       @stage_performance_ids = Array(stage_performance_ids).map(&:to_i)
     end
 
-    def call
+    def save
       ActiveRecord::Base.transaction do
         delete_existing_entries
         filtered_ids.each do |stage_performance_id|
           user.user_timetable_entries.create!(stage_performance_id: stage_performance_id)
         end
       end
+
+      true
     end
 
     private
@@ -24,6 +24,7 @@ module MyTimetables
     attr_reader :user, :festival_day, :stage_performance_ids
 
     def delete_existing_entries
+      # 対象日の既存の選択を一度削除してから入れ替える
       user.user_timetable_entries
           .joins(:stage_performance)
           .where(stage_performances: { festival_day_id: festival_day.id })

--- a/spec/forms/my_timetables/form_spec.rb
+++ b/spec/forms/my_timetables/form_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
-RSpec.describe MyTimetables::Updater do
-  describe ".call" do
+RSpec.describe MyTimetables::Form do
+  describe "#save" do
     let(:user) { create(:user) }
     let(:festival_day) { create(:festival_day) }
     let(:other_day) { create(:festival_day, festival: festival_day.festival, date: festival_day.date + 1.day) }
@@ -14,11 +14,13 @@ RSpec.describe MyTimetables::Updater do
     let!(:target_performance) { create(:stage_performance, :scheduled, festival_day: festival_day) }
 
     it "対象日の選択だけを置き換え、他の日の選択は残す" do
-      described_class.call(
+      form = described_class.new(
         user: user,
         festival_day: festival_day,
         stage_performance_ids: [ target_performance.id ]
       )
+
+      form.save
 
       same_day_ids = user.user_timetable_entries.joins(:stage_performance).where(stage_performances: { festival_day_id: festival_day.id }).pluck(:stage_performance_id)
       other_day_ids = user.user_timetable_entries.joins(:stage_performance).where(stage_performances: { festival_day_id: other_day.id }).pluck(:stage_performance_id)
@@ -30,11 +32,13 @@ RSpec.describe MyTimetables::Updater do
     it "重複IDや他の日のIDは無視してユニークに登録する" do
       another_day_perf = create(:stage_performance, :scheduled)
 
-      described_class.call(
+      form = described_class.new(
         user: user,
         festival_day: festival_day,
         stage_performance_ids: [ target_performance.id, target_performance.id, another_day_perf.id, 999 ]
       )
+
+      form.save
 
       same_day_ids = user.user_timetable_entries.joins(:stage_performance).where(stage_performances: { festival_day_id: festival_day.id }).pluck(:stage_performance_id)
       expect(same_day_ids).to match_array([ target_performance.id ])
@@ -43,15 +47,14 @@ RSpec.describe MyTimetables::Updater do
     it "作成時に例外が起きたらトランザクションでロールバックされる" do
       allow_any_instance_of(UserTimetableEntry).to receive(:save!).and_raise(StandardError.new("boom"))
 
-      expect {
-        described_class.call(
-          user: user,
-          festival_day: festival_day,
-          stage_performance_ids: [ target_performance.id ]
-        )
-      }.to raise_error(StandardError)
+      form = described_class.new(
+        user: user,
+        festival_day: festival_day,
+        stage_performance_ids: [ target_performance.id ]
+      )
 
-      # 例外前に削除された既存の当日分も、ロールバックで復元される
+      expect { form.save }.to raise_error(StandardError)
+
       same_day_ids = user.user_timetable_entries.joins(:stage_performance).where(stage_performances: { festival_day_id: festival_day.id }).pluck(:stage_performance_id)
       expect(same_day_ids).to include(existing_same_day_entry.stage_performance_id)
     end


### PR DESCRIPTION
## 概要
- MyTimetables の更新処理をフォームオブジェクトに集約し、保存フローを統一。
- マイタイムテーブル詳細の不要な eager load を削除し、Bullet 警告を解消。
## 実施内容
- フォーム追加: form.rb
- コントローラ置換: my_timetables_controller.rb
- 旧サービス削除: updater.rb
- spec移行: form_spec.rb（旧 updater spec を置き換え）
- includes(:festival_day) の削除
my_timetables_controller.rb
## 対応Issue
なし
## 関連Issue
なし
## 特記事項
- 更新処理（入力の正規化＋保存）を1つのフォームに集約し、他のフォームオブジェクトと方針を統一するため。
- コントローラを「保存の入口」に限定し、責務を明確化するため。
- 将来、入力ルールが増えてもフォーム側に閉じて拡張できるようにするため。