### PR TITLE
[refactor]マイタイムテーブルの選択取得をクエリとして共通化

### DIFF
--- a/app/controllers/my_timetables_controller.rb
+++ b/app/controllers/my_timetables_controller.rb
@@ -27,11 +27,7 @@ class MyTimetablesController < ApplicationController
   end
 
   def destroy
-    current_user
-      .user_timetable_entries
-      .joins(:stage_performance)
-      .where(stage_performances: { festival_day_id: @selected_day.id })
-      .delete_all
+    MyTimetables::EntriesForDayQuery.call(user: current_user, festival_day: @selected_day).delete_all
 
     redirect_to my_timetables_path, notice: "マイタイムテーブルを削除しました。"
   end

--- a/app/forms/my_timetables/form.rb
+++ b/app/forms/my_timetables/form.rb
@@ -25,10 +25,7 @@ module MyTimetables
 
     def delete_existing_entries
       # 対象日の既存の選択を一度削除してから入れ替える
-      user.user_timetable_entries
-          .joins(:stage_performance)
-          .where(stage_performances: { festival_day_id: festival_day.id })
-          .delete_all
+      MyTimetables::EntriesForDayQuery.call(user: user, festival_day: festival_day).delete_all
     end
 
     def filtered_ids

--- a/app/queries/my_timetables/entries_for_day_query.rb
+++ b/app/queries/my_timetables/entries_for_day_query.rb
@@ -1,0 +1,22 @@
+module MyTimetables
+  class EntriesForDayQuery
+    def self.call(user:, festival_day:)
+      new(user: user, festival_day: festival_day).call
+    end
+
+    def initialize(user:, festival_day:)
+      @user = user
+      @festival_day = festival_day
+    end
+
+    def call
+      user.user_timetable_entries
+          .joins(:stage_performance)
+          .where(stage_performances: { festival_day_id: festival_day.id })
+    end
+
+    private
+
+    attr_reader :user, :festival_day
+  end
+end

--- a/spec/forms/my_timetables/form_spec.rb
+++ b/spec/forms/my_timetables/form_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe MyTimetables::Form do
 
       form.save
 
-      same_day_ids = user.user_timetable_entries.joins(:stage_performance).where(stage_performances: { festival_day_id: festival_day.id }).pluck(:stage_performance_id)
-      other_day_ids = user.user_timetable_entries.joins(:stage_performance).where(stage_performances: { festival_day_id: other_day.id }).pluck(:stage_performance_id)
+      same_day_ids = MyTimetables::EntriesForDayQuery.call(user: user, festival_day: festival_day).pluck(:stage_performance_id)
+      other_day_ids = MyTimetables::EntriesForDayQuery.call(user: user, festival_day: other_day).pluck(:stage_performance_id)
 
       expect(same_day_ids).to match_array([ target_performance.id ])
       expect(other_day_ids).to match_array([ existing_other_day_entry.stage_performance_id ])
@@ -40,7 +40,7 @@ RSpec.describe MyTimetables::Form do
 
       form.save
 
-      same_day_ids = user.user_timetable_entries.joins(:stage_performance).where(stage_performances: { festival_day_id: festival_day.id }).pluck(:stage_performance_id)
+      same_day_ids = MyTimetables::EntriesForDayQuery.call(user: user, festival_day: festival_day).pluck(:stage_performance_id)
       expect(same_day_ids).to match_array([ target_performance.id ])
     end
 
@@ -55,7 +55,7 @@ RSpec.describe MyTimetables::Form do
 
       expect { form.save }.to raise_error(StandardError)
 
-      same_day_ids = user.user_timetable_entries.joins(:stage_performance).where(stage_performances: { festival_day_id: festival_day.id }).pluck(:stage_performance_id)
+      same_day_ids = MyTimetables::EntriesForDayQuery.call(user: user, festival_day: festival_day).pluck(:stage_performance_id)
       expect(same_day_ids).to include(existing_same_day_entry.stage_performance_id)
     end
   end


### PR DESCRIPTION
## 概要
- マイタイムテーブルの当日分エントリ取得条件をクエリとして共通化。
## 実施内容
- クエリ追加: entries_for_day_query.rb
- 更新/削除処理で共通クエリを利用
form.rb
my_timetables_controller.rb
- spec内の重複条件も置換
form_spec.rb
## 対応Issue
なし
## 関連Issue
なし
## 特記事項
- 「当日分のマイタイムテーブルの選択抽出」という同一条件が更新と削除で重複していたため、クエリを1か所に集約して変更点を局所化する狙いがある。
- delete_all は呼び出し側に残し、クエリは「対象のRelationを返す」責務に限定して再利用性を確保している。