### PR TITLE
[refactor]マイタイムテーブルの重複検知ロジックの改善

### DIFF
--- a/app/services/my_timetables/conflict_detector.rb
+++ b/app/services/my_timetables/conflict_detector.rb
@@ -1,11 +1,20 @@
 module MyTimetables
   class ConflictDetector
     def self.call(list)
+      new(list).call
+    end
+
+    def initialize(list)
+      @list = list
+    end
+
+    def call
       conflicts = Set.new
       last_end = nil
       last_id  = nil
-      list.each do |sp|
-        if last_end && sp.starts_at && sp.ends_at && sp.starts_at < last_end
+      sorted_list.each do |sp|
+        has_times = last_end && sp.starts_at && sp.ends_at
+        if has_times && sp.starts_at < last_end
           conflicts << last_id
           conflicts << sp.id
         end
@@ -13,6 +22,18 @@ module MyTimetables
         last_id  = sp.id
       end
       conflicts
+    end
+
+    private
+
+    attr_reader :list
+
+    def sorted_list
+      list.sort_by { |sp| [ time_key(sp.starts_at), time_key(sp.ends_at), sp.id ] }
+    end
+
+    def time_key(time)
+      time || Time.at(0)
     end
   end
 end

--- a/spec/services/my_timetables/conflict_detector_spec.rb
+++ b/spec/services/my_timetables/conflict_detector_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe MyTimetables::ConflictDetector do
+  describe ".call" do
+    let(:festival_day) { create(:festival_day) }
+
+    it "並び順がバラバラでも重複を検知できる" do
+      first = create(
+        :stage_performance,
+        :scheduled,
+        festival_day: festival_day,
+        starts_at: festival_day.date.to_time.change(hour: 12),
+        ends_at: festival_day.date.to_time.change(hour: 13)
+      )
+      second = create(
+        :stage_performance,
+        :scheduled,
+        festival_day: festival_day,
+        starts_at: festival_day.date.to_time.change(hour: 12, min: 30),
+        ends_at: festival_day.date.to_time.change(hour: 13, min: 30)
+      )
+      third = create(
+        :stage_performance,
+        :scheduled,
+        festival_day: festival_day,
+        starts_at: festival_day.date.to_time.change(hour: 14),
+        ends_at: festival_day.date.to_time.change(hour: 15)
+      )
+
+      result = described_class.call([ third, second, first ])
+
+      expect(result.to_a).to match_array([ first.id, second.id ])
+    end
+
+    it "重複がない場合は空の集合を返す" do
+      first = create(
+        :stage_performance,
+        :scheduled,
+        festival_day: festival_day,
+        starts_at: festival_day.date.to_time.change(hour: 10),
+        ends_at: festival_day.date.to_time.change(hour: 11)
+      )
+      second = create(
+        :stage_performance,
+        :scheduled,
+        festival_day: festival_day,
+        starts_at: festival_day.date.to_time.change(hour: 11),
+        ends_at: festival_day.date.to_time.change(hour: 12)
+      )
+
+      result = described_class.call([ second, first ])
+
+      expect(result).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## 概要
- マイタイムテーブルの重複検知を「入力順に依存しない」安全な挙動に改善。
- ConflictDetector の仕様を担保するspecを追加
## 実施内容
- conflict_detector.rb で内部ソートを導入し、重複判定を可読性重視に整理。
- conflict_detector_spec.rb を追加し、順序非依存の重複検知をテスト。
## 対応Issue
なし
## 関連Issue
なし
## 特記事項
- サービス単体で使われるケースや、別の呼び出し元で Array を渡すケースでも正しく動作するよう、内部でソートと判定の責務を持たせた。