### PR TITLE
[refactor]OAuth由来のニックネーム整形メソッドの切り離し

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,11 +27,6 @@ class User < ApplicationRecord
     Users::FromOmniauth.call(auth)
   end
 
-  def self.sanitized_nickname(auth)
-    nickname = auth.info.name.presence || auth.info.first_name.presence || auth.info.email.split("@").first
-    nickname.to_s[0, 10]
-  end
-
   def self.create_unique_string
     SecureRandom.uuid
   end

--- a/app/services/users/from_omniauth.rb
+++ b/app/services/users/from_omniauth.rb
@@ -12,7 +12,7 @@ module Users
       user = User.find_by(provider: @auth.provider, uid: @auth.uid)
       user ||= User.find_by(email: @auth.info.email)
 
-      nickname = user&.nickname.presence || User.sanitized_nickname(@auth)
+      nickname = user&.nickname.presence || sanitized_nickname(@auth)
 
       user ||= User.new(
         email: @auth.info.email,
@@ -23,6 +23,13 @@ module Users
       user.assign_attributes(provider: @auth.provider, uid: @auth.uid, nickname: nickname)
       user.save!
       user
+    end
+
+    private
+
+    def sanitized_nickname(auth)
+      nickname = auth.info.name.presence || auth.info.first_name.presence || auth.info.email.split("@").first
+      nickname.to_s[0, 10]
     end
   end
 end


### PR DESCRIPTION
## 概要
- OAuth由来のニックネーム整形を User から切り離し、Users::FromOmniauth に集約して責務を明確化。
## 実施内容
- from_omniauth.rb に sanitized_nickname を移動し、内部呼び出しを変更。
- user.rb から sanitized_nickname を削除。
## 対応Issue
なし
## 関連Issue
なし
## 特記事項