### PR TITLE
[add]外部APIクライアントにタイムアウト設定を追加

### DIFF
--- a/app/services/spotify/client.rb
+++ b/app/services/spotify/client.rb
@@ -7,6 +7,8 @@ module Spotify
   class Client
     TOKEN_URL  = "https://accounts.spotify.com/api/token"
     SEARCH_URL = "https://api.spotify.com/v1/search"
+    OPEN_TIMEOUT = 5
+    READ_TIMEOUT = 10
 
     def initialize
       @client_id     = ENV["SPOTIFY_CLIENT_ID"]     || Rails.application.credentials.dig(:spotify, :client_id)
@@ -63,7 +65,15 @@ module Spotify
 
     private
 
-    def http(uri) = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https")
+    def http(uri)
+      Net::HTTP.start(
+        uri.host,
+        uri.port,
+        use_ssl: uri.scheme == "https",
+        open_timeout: OPEN_TIMEOUT,
+        read_timeout: READ_TIMEOUT
+      )
+    end
 
     def access_token
       Rails.cache.fetch("spotify_access_token", expires_in: 50.minutes) { fetch_access_token }

--- a/app/services/weather/open_meteo/client.rb
+++ b/app/services/weather/open_meteo/client.rb
@@ -6,19 +6,20 @@ module Weather
   module OpenMeteo
     class Client
       FORECAST_URL = "https://api.open-meteo.com/v1/forecast"
+      OPEN_TIMEOUT = 5
+      READ_TIMEOUT = 10
 
       def hourly_forecast(latitude:, longitude:, date:, timezone: "Asia/Tokyo")
-        # Open-Meteo は start_date/end_date で日付範囲を指定できる。
-        # 今回は「フェス当日」だけ欲しいので同一日付をセットする。
+        # Open-Meteo は start_date/end_date で日付範囲を指定できる
+        # 今回は「フェス当日」だけ欲しいので同一日付をセットする
         uri = URI(FORECAST_URL)
         uri.query = URI.encode_www_form(
           latitude: latitude,
           longitude: longitude,
-          # hourly は「1時間ごとの配列」で返るので、必要な項目だけ指定する。
+          # hourly は「1時間ごとの配列」で返るので、必要な項目だけ指定する
           hourly: "temperature_2m,weather_code",
           start_date: date.iso8601,
           end_date: date.iso8601,
-          # timezone を指定すると time がそのタイムゾーン基準で返る（今回は日本時間固定）。
           timezone: timezone
         )
 
@@ -31,7 +32,15 @@ module Weather
 
       private
 
-      def http(uri) = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https")
+      def http(uri)
+        Net::HTTP.start(
+          uri.host,
+          uri.port,
+          use_ssl: uri.scheme == "https",
+          open_timeout: OPEN_TIMEOUT,
+          read_timeout: READ_TIMEOUT
+        )
+      end
     end
   end
 end

--- a/spec/services/weather/open_meteo/client_spec.rb
+++ b/spec/services/weather/open_meteo/client_spec.rb
@@ -59,6 +59,25 @@ RSpec.describe Weather::OpenMeteo::Client do
     expect(params["timezone"]).to eq([ "Asia/Tokyo" ])
   end
 
+  it "HTTPタイムアウト設定を渡してリクエストする" do
+    ok_response = instance_double(Net::HTTPSuccess, body: "{}", code: "200")
+    allow(ok_response).to receive(:is_a?).with(Net::HTTPSuccess).and_return(true)
+
+    allow(Net::HTTP).to receive(:start).and_return(http)
+    allow(http).to receive(:request).and_return(ok_response)
+
+    client.hourly_forecast(latitude: 35.0, longitude: 139.0, date: date)
+
+    expect(Net::HTTP).to have_received(:start).with(
+      anything,
+      anything,
+      hash_including(
+        open_timeout: described_class::OPEN_TIMEOUT,
+        read_timeout: described_class::READ_TIMEOUT
+      )
+    )
+  end
+
   it "timezoneを上書きできる" do
     ok_response = instance_double(Net::HTTPSuccess, body: "{}", code: "200")
     allow(ok_response).to receive(:is_a?).with(Net::HTTPSuccess).and_return(true)


### PR DESCRIPTION
## 概要
- 外部APIクライアントにタイムアウト設定を追加し、応答遅延時の待ち過ぎを防止。
- タイムアウト設定の適用をspecで担保。
## 実施内容
- 各client.rb に OPEN_TIMEOUT = 5 / READ_TIMEOUT = 10 を追加し http に反映。
- 各client_spec.rb で Net::HTTP.start にタイムアウトが渡されることを検証（2回呼び出し対応）。
## 対応Issue
なし
## 関連Issue
なし
## 特記事項
- タイムアウト追加により、遅延時のレスポンス待ちを制御して画面/処理のパフォーマンス劣化を抑制。