### PR TITLE
[add]フェス一覧からタイムテーブル閲覧までのUIフローをsystem specで追加

### DIFF
--- a/spec/system/festival_timetable_flow_spec.rb
+++ b/spec/system/festival_timetable_flow_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe "フェスのタイムテーブル閲覧", type: :system do
+  before { driven_by :rack_test }
+
+  it "フェス一覧から詳細を開きタイムテーブルを閲覧できる" do
+    festival = create(:festival, timetable_published: true)
+    festival_day = create(:festival_day, festival: festival, date: festival.start_date)
+    stage = create(:stage, festival: festival)
+    artist = create(:artist, name: "テストアーティスト")
+    create(
+      :stage_performance,
+      :scheduled,
+      festival_day: festival_day,
+      stage: stage,
+      artist: artist,
+      starts_at: festival_day.date.to_time.change(hour: 12),
+      ends_at: festival_day.date.to_time.change(hour: 13)
+    )
+
+    visit festivals_path
+    click_link festival.name
+
+    expect(page).to have_content(festival.name)
+    click_link "タイムテーブルへ"
+
+    expect(page).to have_content("タイムテーブル")
+    expect(page).to have_content(artist.name)
+  end
+end


### PR DESCRIPTION
## 概要
- フェス一覧からタイムテーブル閲覧までのUIフローをsystem specで追加し、公開済みフェスの基本導線をE2Eで確認。
## 実施内容
- festival_timetable_flow_spec.rb を新規追加。
- rack_test を利用してブラウザ不要で動作するE2Eに設定。
## 対応Issue
なし
## 関連Issue
なし
## 特記事項