### PR TITLE
[add]ヘルプ・ガイドページの追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,17 @@ class ApplicationController < ActionController::Base
 
   include Pagy::Backend
 
+  helper_method :show_help_fab?
+
   private
+
+  def show_help_fab?
+    return false if devise_controller?
+    return false if controller_path.start_with?("admin/")
+    return false if controller_name == "home" && action_name == "guide"
+
+    true
+  end
 
   def configure_permitted_parameters
     added = [ :nickname ]

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -10,4 +10,7 @@ class HomeController < ApplicationController
 
   def operator
   end
+
+  def guide
+  end
 end

--- a/app/views/home/guide.html.erb
+++ b/app/views/home/guide.html.erb
@@ -1,0 +1,39 @@
+<main class="min-h-screen px-4 py-6">
+  <div class="mx-auto w-full max-w-3xl space-y-6">
+    <header class="space-y-3">
+      <h1 class="text-2xl font-bold text-slate-900">はじめてガイド</h1>
+      <p class="text-sm text-slate-600">
+        フェス未経験でも迷わないように、最初にやることをまとめました。
+      </p>
+    </header>
+
+    <section class="space-y-4 rounded-2xl border border-slate-200 bg-white/80 p-5 shadow-[0_20px_45px_rgba(15,23,42,0.08)]">
+      <h2 class="text-base font-semibold text-slate-900">まずはこの4つ</h2>
+      <ol class="space-y-3 text-sm leading-relaxed text-slate-700">
+        <li class="rounded-xl border border-slate-100 bg-slate-50/70 p-3">
+          1. 参加予定のフェスを探す
+        </li>
+        <li class="rounded-xl border border-slate-100 bg-slate-50/70 p-3">
+          2. 参加するフェスのマイタイムテーブルを作成
+        </li>
+        <li class="rounded-xl border border-slate-100 bg-slate-50/70 p-3">
+          3. 参加するフェスの予習リストにある楽曲を予習
+        </li>
+        <li class="rounded-xl border border-slate-100 bg-slate-50/70 p-3">
+          4. 持ち物リストを作って当日の準備に備える
+        </li>
+      </ol>
+    </section>
+
+    <section class="grid gap-3 sm:grid-cols-2">
+      <%= link_to "フェス一覧を見る", festivals_path,
+                  class: "inline-flex items-center justify-center rounded-full border border-slate-200 bg-white/90 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md" %>
+      <%= link_to "タイムテーブル一覧を見る", timetables_path,
+                  class: "inline-flex items-center justify-center rounded-full border border-slate-200 bg-white/90 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md" %>
+      <%= link_to "フェス予習リストを見る", prep_festivals_path,
+                  class: "inline-flex items-center justify-center rounded-full border border-slate-200 bg-white/90 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md" %>
+      <%= link_to "持ち物リストを作る", packing_lists_path,
+                  class: "inline-flex items-center justify-center rounded-full border border-slate-200 bg-white/90 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md" %>
+    </section>
+  </div>
+</main>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -56,6 +56,7 @@
     <%= render "shared/side_menu" %>
     <%= render "shared/flash" %>
     <%= yield %>
+    <%= render "shared/help_fab" if show_help_fab? %>
     <%= render "shared/footer" %>
   </body>
 </html>

--- a/app/views/prep/show.html.erb
+++ b/app/views/prep/show.html.erb
@@ -1,7 +1,7 @@
 <div class="min-h-screen px-4 py-6">
   <div class="mx-auto max-w-5xl space-y-6">
     <header class="space-y-3">
-      <h1 class="text-2xl font-bold text-slate-900">予習</h1>
+      <h1 class="text-2xl font-bold text-slate-900">楽曲予習</h1>
       <p class="text-sm text-slate-600">
         フェス全体で聴き込むか、気になるアーティストから絞って予習するかを選んでください。
       </p>

--- a/app/views/shared/_help_fab.html.erb
+++ b/app/views/shared/_help_fab.html.erb
@@ -1,0 +1,8 @@
+<div class="fixed bottom-32 right-4 z-30 md:right-12">
+  <%= link_to guide_path,
+              class: "group inline-flex h-12 w-12 items-center justify-center rounded-full bg-white/90 text-slate-900 shadow-[0_12px_30px_rgba(15,23,42,0.2)] ring-1 ring-slate-200/80 interactive-lift focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#F95858]",
+              data: { controller: "tap-feedback" } do %>
+    <span class="text-lg font-bold">？</span>
+    <span class="sr-only">ガイドを見る</span>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   get "/terms", to: "home#terms", as: :terms
   get "/privacy", to: "home#privacy", as: :privacy
   get "/operator", to: "home#operator", as: :operator
+  get "/guide", to: "home#guide", as: :guide
   resource :prep, only: [ :show ], controller: "prep"
   namespace :prep, path: "prep" do
     resources :festivals, only: [ :index, :show ]

--- a/spec/requests/public_pages_spec.rb
+++ b/spec/requests/public_pages_spec.rb
@@ -21,6 +21,16 @@ RSpec.describe "公開ページのリクエスト", type: :request do
       get operator_path
       expect(response).to have_http_status(:ok)
     end
+
+    it "ガイドページが200を返す" do
+      get guide_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "ガイドページではガイドボタンを表示しない" do
+      get guide_path
+      expect(response.body).not_to include("ガイドを見る")
+    end
   end
 
   describe "フェス・アーティストの一覧/詳細" do


### PR DESCRIPTION
## 概要
- 全ページからアクセスできるガイド導線（右下「？」ボタン）と、簡易ガイドページを追加。
- サイドメニュー/ガイド表示時のボタン表示制御を整備。
- ガイド導線のリンク拡充とアクセスspecを追加。
## 実施内容
- routes.rb：GET /guide を追加。
- home_controller.rb：guide アクションを追加。
- guide.html.erb：簡易ガイドページを実装、導線を追加（フェス/タイムテーブル/予習/持ち物）
- _help_fab.html.erb：右下「？」ボタン追加、z-index調整、tap-feedback適用。
- application.html.erb：全ページへのボタン表示を追加。
- application_controller.rb：ボタン表示制御（admin/devise/guide）
- public_pages_spec.rb：ガイドページのアクセスとボタン非表示のspec追加。
## 対応Issue
- close #439 
## 関連Issue
なし
## 特記事項
- 今後も詳細なガイド内容を追加・更新予定。