### PR TITLE
[add]ユーザーの削除（退会）導線の追加

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -9,4 +9,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
     resource.update_without_password(params.except("current_password"))
   end
+
+  def destroy
+    super do
+      return redirect_to root_path, notice: "退会しました。ご利用ありがとうございました。"
+    end
+  end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -59,6 +59,18 @@
               data: { controller: "tap-feedback" } %>
         <p class="text-xs text-slate-400">登録メールアドレス宛にパスワード再設定用URLを送信します。</p>
       </div>
+
+      <div class="space-y-2 border-t border-slate-200 pt-6">
+        <p class="text-sm font-semibold text-slate-900">退会</p>
+        <p class="text-xs text-slate-500">アカウントと関連データは削除され、元に戻せません。</p>
+        <div class="text-center">
+          <%= button_to "退会する",
+                registration_path(resource_name),
+                method: :delete,
+                class: "inline-flex w-full items-center justify-center rounded-2xl bg-rose-500 px-4 py-3 text-sm font-semibold text-white shadow-md interactive-lift hover:bg-rose-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500",
+                data: { controller: "tap-feedback", turbo_confirm: "退会するとアカウントとデータが削除されます。続行しますか？" } %>
+        </div>
+      </div>
     </section>
   </div>
 </div>

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -24,6 +24,24 @@ RSpec.describe "認証のリクエスト", type: :request do
     end
   end
 
+  describe "DELETE /users" do
+    let!(:user) { create(:user) }
+
+    before { sign_in user, scope: :user }
+
+    it "アカウント退会後にログアウトしトップへ戻る" do
+      expect {
+        delete user_registration_path
+      }.to change(User, :count).by(-1)
+
+      expect(response).to redirect_to(root_path)
+      expect(flash[:notice]).to eq("退会しました。ご利用ありがとうございました。")
+
+      get mypage_dashboard_path
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+
   describe "GET /users/auth/google_oauth2/callback" do
     around do |example|
       OmniAuth.config.test_mode = true


### PR DESCRIPTION
## 概要
- ユーザーの退会導線を追加し、退会後の挙動を明確化。
- 上記のリクエストspecを追加。
## 実施内容
- registrations_controller.rb：退会後にトップへリダイレクト＋フラッシュ表示。
- devise/resistrations/edit.html.erb：退会ボタンをページ下部に追加（赤デザイン・確認ダイアログ・中央寄せ）
- authentication_spec.rb：退会のリクエストspecを追加。
## 対応Issue
- close #464 
## 関連Issue
なし
## 特記事項
- 退会導線がなく致命的なため、即座に対応。