### PR TITLE
[fix]通常ユーザー登録時の uid 付与を廃止

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,9 +1,4 @@
 class Users::RegistrationsController < Devise::RegistrationsController
-  def build_resource(hash = {})
-    hash[:uid] = User.create_unique_string
-    super
-  end
-
   def update_resource(resource, params)
     return super if params["password"].present?
 

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -112,6 +112,24 @@ RSpec.describe "認証のリクエスト", type: :request do
   end
 
   describe "POST /users" do
+    it "正常な入力なら作成される" do
+      expect {
+        post user_registration_path, params: {
+          user: {
+            email: "newuser@example.com",
+            password: "password123",
+            password_confirmation: "password123",
+            nickname: "newuser"
+          }
+        }
+      }.to change(User, :count).by(1)
+
+      user = User.find_by(email: "newuser@example.com")
+      expect(user).not_to be_nil
+      expect(user.uid).to be_nil
+      expect(response).to have_http_status(:see_other)
+    end
+
     it "バリデーションエラーなら作成されない" do
       expect {
         post user_registration_path, params: { user: { email: "", password: "short", nickname: "" } }


### PR DESCRIPTION
## 概要
- 通常ユーザー登録時の uid 付与を廃止して、OAuth専用に整理。
- 認証関連のspecを補強・調整。
## 実施内容
- registrations_controller.rb：build_resource を削除（通常登録で uid を付けない）。
- authentication_spec.rb：新規登録の成功パターンを追加（uid が空であることも検証）。
- authentication_spec.rb：OAuthコールバック/新規登録のリダイレクトステータス期待値を実挙動に合わせて修正。
## 対応Issue
なし
## 関連Issue
なし
## 特記事項
- 通常登録ユーザーの uid が 今後は nil になる（OAuthユーザー・OAuth連携ユーザーは従来通り）。