### PR TITLE
[refactor]adminフェス設定の apply を撤廃して update に統一

### DIFF
--- a/app/controllers/admin/festivals_controller.rb
+++ b/app/controllers/admin/festivals_controller.rb
@@ -1,10 +1,10 @@
 class Admin::FestivalsController < Admin::BaseController
-  before_action :set_festival, only: %i[show edit update destroy setup apply]
-  before_action :load_festival_tags, only: %i[new edit setup create update apply]
+  before_action :set_festival, only: %i[show edit update destroy setup]
+  before_action :load_festival_tags, only: %i[new edit setup create update]
 
   def index
     @pagy, @festivals = pagy(
-      Festival.includes(:festival_days, :stages).order(start_date: :desc),
+      Festival.order(start_date: :desc),
       limit: 10
     )
   end
@@ -18,7 +18,7 @@ class Admin::FestivalsController < Admin::BaseController
   end
 
   def create
-    @festival = Festival.new(festival_params_basic)
+    @festival = Festival.new(festival_params)
     if @festival.save
       redirect_to setup_admin_festival_path(@festival), notice: "フェスを作成しました。日程・ステージを設定してください。"
     else
@@ -29,10 +29,11 @@ class Admin::FestivalsController < Admin::BaseController
   def edit; end
 
   def update
-    if @festival.update(festival_params_basic)
-      redirect_to admin_festival_path(@festival), notice: "更新しました。"
+    if @festival.update(festival_params)
+      notice = nested_update_request? ? "日程・ステージを更新しました。" : "更新しました。"
+      redirect_to admin_festival_path(@festival), notice: notice
     else
-      render :edit, status: :unprocessable_entity
+      render_update_failure
     end
   end
 
@@ -47,42 +48,41 @@ class Admin::FestivalsController < Admin::BaseController
     @festival.stages.build        if @festival.stages.blank?
   end
 
-  def apply
-    if @festival.update(festival_params_nested)
-      redirect_to admin_festival_path(@festival), notice: "日程・ステージを更新しました。"
-    else
-      render :setup, status: :unprocessable_entity
-    end
-  end
-
   private
 
   def set_festival
-    @festival = Festival.includes(:festival_tags).find_by_slug!(params[:id])
+    @festival = Festival.find_by_slug!(params[:id])
   end
 
   def load_festival_tags
     @festival_tags = FestivalTag.order(:name)
   end
 
-  # 1ページ目（基本情報のみ）
-  def festival_params_basic
+  # 基本情報＋ネストをまとめて許可する。
+  def festival_params
     params.require(:festival).permit(
       :name, :slug, :venue_name, :city, :prefecture,
       :start_date, :end_date, :timezone,
       :official_url, :timetable_published,
       :latitude, :longitude,
-      festival_tag_ids: []
-    )
-  end
-
-  # setupページ（ネスト＋必要なら基本も一緒に）
-  def festival_params_nested
-    params.require(:festival).permit(
-      :name, :venue_name, :city, :prefecture, :timezone, :start_date, :end_date, :official_url, :timetable_published,
-      :latitude, :longitude, festival_tag_ids: [],
+      festival_tag_ids: [],
       festival_days_attributes: [ :id, :date, :doors_at, :start_at, :end_at, :note, :_destroy ],
       stages_attributes:        [ :id, :name, :sort_order, :note, :color_key, :_destroy ]
     )
+  end
+
+  def nested_update_request?
+    # setupフォーム（ネスト更新）か通常編集かを判別する
+    attrs = params[:festival] || {}
+    attrs.key?(:festival_days_attributes) || attrs.key?(:stages_attributes)
+  end
+
+  def render_update_failure
+    # setupフォームの場合はsetupに戻す
+    if nested_update_request?
+      render :setup, status: :unprocessable_entity
+    else
+      render :edit, status: :unprocessable_entity
+    end
   end
 end

--- a/app/controllers/festivals_controller.rb
+++ b/app/controllers/festivals_controller.rb
@@ -36,6 +36,6 @@ class FestivalsController < ApplicationController
   private
 
   def set_festival
-    @festival = Festival.includes(:festival_tags).find_by_slug!(params[:id])
+    @festival = Festival.find_by_slug!(params[:id])
   end
 end

--- a/app/views/admin/festivals/setup.html.erb
+++ b/app/views/admin/festivals/setup.html.erb
@@ -1,7 +1,7 @@
 <h1 class="text-xl font-bold mb-4">日程・ステージの設定</h1>
 
 <%= form_with model: [:admin, @festival],
-              url: apply_admin_festival_path(@festival),
+              url: admin_festival_path(@festival),
               method: :patch,
               class: "space-y-6" do |f| %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,7 +61,6 @@ Rails.application.routes.draw do
     resources :festivals do
       member do
         get  :setup
-        patch :apply
       end
     end
     resources :items, only: [ :index, :new, :create, :edit, :update, :destroy ]

--- a/spec/requests/admin_spec.rb
+++ b/spec/requests/admin_spec.rb
@@ -137,4 +137,40 @@ RSpec.describe "管理画面のリクエスト", type: :request do
       expect(response).to have_http_status(:unprocessable_entity)
     end
   end
+
+  describe "PATCH /admin/festivals/:id" do
+    let(:admin) { create(:user, role: :admin) }
+    let(:festival) { create(:festival) }
+
+    before do
+      sign_in admin, scope: :user
+    end
+
+    it "基本情報を更新できる" do
+      patch admin_festival_path(festival), params: { festival: { name: "更新後フェス" } }
+
+      expect(response).to redirect_to(admin_festival_path(festival))
+      expect(festival.reload.name).to eq("更新後フェス")
+    end
+
+    it "日程・ステージをネスト更新できる" do
+      params = {
+        festival: {
+          festival_days_attributes: {
+            "0" => { date: festival.start_date }
+          },
+          stages_attributes: {
+            "0" => { name: "Main Stage" }
+          }
+        }
+      }
+
+      expect {
+        patch admin_festival_path(festival), params: params
+      }.to change(FestivalDay, :count).by(1)
+        .and change(Stage, :count).by(1)
+
+      expect(response).to redirect_to(admin_festival_path(festival))
+    end
+  end
 end


### PR DESCRIPTION
## 概要
- adminフェス設定の apply （フェスの日程・ステージ分のupdate）を撤廃して update に統一し、ルーティングをREST寄りに整理。
- Bulletの「不要なeager loading」警告を解消（フェス一覧/詳細の includes を削除）。
- admin/festivals#update周りのspecを追加。
## 実施内容
- ルーティング整理: routes.rb
- setupフォーム送信先を update に変更: setup.html.erb
- Admin::FestivalsController の更新処理を統一 + params一本化 + failure時の描画分岐: festivals_controller.rb
- public側の includes(:festival_tags) 削除: festivals_controller.rb
- admin側の includes(:festival_tags)/一覧の includes(:festival_days, :stages) 削除: festivals_controller.rb
- spec追加（update基本/ネスト更新）: admin_spec.rb
## 対応Issue
なし
## 関連Issue
なし
## 特記事項
- ルーティングを apply から update に寄せ、RESTfulに統一（保守性・可読性の向上を意図）