### PR TITLE
[fix]フェスごとのアーティスト一覧表示に公開フィルタを追加

### DIFF
--- a/app/models/festival.rb
+++ b/app/models/festival.rb
@@ -80,7 +80,8 @@ class Festival < ApplicationRecord
     return Artist.none if festival_day.blank?
     raise ArgumentError, "festival_day must belong to festival" if festival_day.festival_id != id
 
-    Artist.joins(stage_performances: :festival_day)
+    Artist.published
+          .joins(stage_performances: :festival_day)
           .where(stage_performances: { festival_day_id: festival_day.id })
           .distinct
           .order(:name)

--- a/spec/models/festival_spec.rb
+++ b/spec/models/festival_spec.rb
@@ -44,4 +44,21 @@ RSpec.describe Festival, type: :model do
       expect(festival.to_param).to eq("awesome-fes")
     end
   end
+
+  describe "#artists_for_day" do
+    it "非公開アーティストを含めない" do
+      festival = create(:festival)
+      festival_day = create(:festival_day, festival: festival)
+      published_artist = create(:artist, published: true)
+      unpublished_artist = create(:artist, published: false)
+
+      create(:stage_performance, festival_day: festival_day, artist: published_artist)
+      create(:stage_performance, festival_day: festival_day, artist: unpublished_artist)
+
+      result = festival.artists_for_day(festival_day)
+
+      expect(result).to include(published_artist)
+      expect(result).not_to include(unpublished_artist)
+    end
+  end
 end


### PR DESCRIPTION
## 概要
- フェス出演アーティスト一覧で非公開アーティストが表示されないように、Festival#artists_for_dayに公開フィルタを追加。
- 上記の挙動をモデルスペックで担保。
## 実施内容
- 公開アーティストのみを返すように Artist.published を追加 festival.rb
- Festival#artists_for_day のフィルタ動作を検証するテストを追加 festival_spec.rb
## 対応Issue
なし
## 関連Issue
なし
## 特記事項
- 非公開設定のアーティストは基本的に自身の曲を持たず、歌唱以外でタイムテーブルに組み込まれているアーティスト（DJ等）。
- タイムテーブルのみに表示し、アーティスト詳細には飛べないようにしている。