### PR TITLE
[add]admin用アーティスト一覧の検索機能の追加

### DIFF
--- a/app/controllers/admin/artists_controller.rb
+++ b/app/controllers/admin/artists_controller.rb
@@ -2,7 +2,9 @@ class Admin::ArtistsController < Admin::BaseController
   before_action :set_artist, only: [ :edit, :update, :destroy ]
 
   def index
-    @pagy, @artists = pagy(Artist.order(:name), limit: 20)
+    @q = Artist.order(:name).ransack(params[:q])
+    result = @q.result(distinct: true)
+    @pagy, @artists = pagy(result, limit: 20, params: request.query_parameters)
   end
 
   def new

--- a/app/views/admin/artists/index.html.erb
+++ b/app/views/admin/artists/index.html.erb
@@ -7,6 +7,14 @@
     <%= link_to "新規作成", new_admin_artist_path, class: "inline-flex items-center justify-center rounded-lg bg-[#F95858] px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-[#e04f4f]" %>
   </div>
 
+  <div class="mt-6">
+    <%= render Shared::SearchFormComponent.new(
+               query: @q,
+               url: admin_artists_path,
+               placeholder: "アーティスト名で検索"
+             ) %>
+  </div>
+
   <div class="mt-8 overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm">
     <table class="min-w-full divide-y divide-slate-200 text-sm">
       <thead class="bg-slate-50">

--- a/spec/requests/admin_spec.rb
+++ b/spec/requests/admin_spec.rb
@@ -91,6 +91,22 @@ RSpec.describe "管理画面のリクエスト", type: :request do
     end
   end
 
+  describe "GET /admin/artists" do
+    it "管理者は名前検索できる" do
+      admin = create(:user, role: :admin)
+      sign_in admin, scope: :user
+
+      create(:artist, name: "Alpha")
+      create(:artist, name: "Beta")
+
+      get admin_artists_path, params: { q: { name_cont: "Alpha" } }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Alpha")
+      expect(response.body).not_to include("Beta")
+    end
+  end
+
   describe "POST /admin/festivals" do
     let(:valid_params) do
       {


### PR DESCRIPTION
## 概要
- 管理画面のアーティスト一覧にアーティストの名前による検索機能を追加。
- 検索動作をリクエストspecで検証。
## 実施内容
- 管理画面のindexでRansack検索を組み込み、ページングにクエリを維持 artists_controller.rb
- 管理画面一覧に検索フォームを追加 index.html.erb
- GET /admin/artists の検索挙動をテスト追加 admin_spec.rb
## 対応Issue
なし
## 関連Issue
なし
## 特記事項