### PR TITLE
[update]アーティスト予習詳細の「過去セットリスト」を5件ずつの「もっと見る」で段階表示

### DIFF
--- a/app/controllers/setlists_controller.rb
+++ b/app/controllers/setlists_controller.rb
@@ -37,8 +37,7 @@ class SetlistsController < ApplicationController
 
   def show
     @setlist = Setlist
-                .includes(stage_performance: [ :artist, :stage, { festival_day: :festival } ],
-                          setlist_songs: :song)
+                .includes(stage_performance: [ :artist, :stage, { festival_day: :festival } ])
                 .find_by!(uuid: params[:id])
 
     @stage_performance = @setlist.stage_performance

--- a/app/views/prep/artists/_setlist_item.html.erb
+++ b/app/views/prep/artists/_setlist_item.html.erb
@@ -1,0 +1,6 @@
+<% festival = setlist.stage_performance.festival_day.festival %>
+<%= render Shared::NavStackButtonComponent.new(
+           label: setlist_label(setlist),
+           subtext: setlist_subtext(setlist),
+           url: festival_setlist_path(festival, setlist, back_to: back_to)
+         ) %>

--- a/app/views/prep/artists/_setlists_more.html.erb
+++ b/app/views/prep/artists/_setlists_more.html.erb
@@ -1,0 +1,9 @@
+<p class="text-xs text-slate-500">表示中 <%= displayed_count %> / <%= setlists_count %> 件</p>
+<% if pagy.next %>
+  <%= link_to "もっと見る",
+              prep_artist_path(artist, request.query_parameters.merge(page: pagy.next)),
+              data: { turbo_stream: true },
+              class: "inline-flex items-center justify-center rounded-full bg-slate-900 px-5 py-2 text-sm font-semibold text-white shadow transition hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900" %>
+<% else %>
+  <span class="text-xs text-slate-500">すべて表示しました</span>
+<% end %>

--- a/app/views/prep/artists/show.html.erb
+++ b/app/views/prep/artists/show.html.erb
@@ -56,15 +56,15 @@
       </div>
 
       <% if @setlists.any? %>
-        <div class="grid gap-3">
-          <% @setlists.each do |setlist| %>
-            <% festival = setlist.stage_performance.festival_day.festival %>
-            <%= render Shared::NavStackButtonComponent.new(
-                       label: setlist_label(setlist),
-                       subtext: setlist_subtext(setlist),
-                       url: festival_setlist_path(festival, setlist, back_to: request.fullpath)
-                     ) %>
-          <% end %>
+        <div id="artist-setlists" class="grid gap-3">
+          <%= render partial: "prep/artists/setlist_item",
+                     collection: @setlists,
+                     as: :setlist,
+                     locals: { back_to: request.fullpath } %>
+        </div>
+        <div id="artist-setlists-more" class="mt-4 flex flex-col items-center gap-2">
+          <%= render partial: "prep/artists/setlists_more",
+                     locals: { pagy: @pagy, displayed_count: @setlists_displayed_count, setlists_count: @setlists_count, artist: @artist } %>
         </div>
       <% else %>
         <div class="rounded-2xl border border-slate-200 bg-white px-4 py-6 text-center text-sm text-slate-600 shadow space-y-1">

--- a/app/views/prep/artists/show.turbo_stream.erb
+++ b/app/views/prep/artists/show.turbo_stream.erb
@@ -1,0 +1,13 @@
+<%= turbo_stream.append "artist-setlists" do %>
+  <%= render partial: "prep/artists/setlist_item",
+             collection: @setlists,
+             as: :setlist,
+             locals: { back_to: request.fullpath } %>
+<% end %>
+
+<%= turbo_stream.replace "artist-setlists-more" do %>
+  <div id="artist-setlists-more" class="mt-4 flex flex-col items-center gap-2">
+    <%= render partial: "prep/artists/setlists_more",
+               locals: { pagy: @pagy, displayed_count: @setlists_displayed_count, setlists_count: @setlists_count, artist: @artist } %>
+  </div>
+<% end %>


### PR DESCRIPTION
## 概要
- アーティスト予習詳細の「過去セットリスト」を5件ずつの「もっと見る」で段階表示。
- Turbo Streamで一覧のみ追記する構成に変更し、ランキングなどは再描画しない。
- 不要な eager load を削除してBullet警告を抑制（予習詳細・セットリスト詳細）。
## 実施内容
- 予習詳細の過去セットリストを pagy で5件ずつ取得
  - artists_controller.rb
- Turbo Streamで「もっと見る」を実装
  - 一覧追記: show.turbo_stream.erb
  - 一覧UI整理: show.html.erb
- 表示パーツの分離
  - 1件表示パーシャル: _setlist_item.html.erb
  - もっと見るUIパーシャル: _setlists_more.html.erb
- 不要な eager load を削除
  - 予習詳細: stage_performance から artist/stage を除外
    - artists_controller.rb
  - セットリスト詳細: setlist_songs の includes を削除（後段で別取得するため）
    - setlists_controller.rb
## 対応Issue
- close #470 
## 関連Issue
なし
## 特記事項