### PR TITLE
[fix]N＋1、eager_loadの対応

### DIFF
--- a/app/controllers/admin/setlists_controller.rb
+++ b/app/controllers/admin/setlists_controller.rb
@@ -5,8 +5,8 @@ class Admin::SetlistsController < Admin::BaseController
 
   def index
     scope = Setlist.includes(
-      stage_performance: [ :artist, :stage, { festival_day: :festival } ],
-      setlist_songs: []
+      :setlist_songs,
+      stage_performance: [ :artist, :stage, { festival_day: :festival } ]
     ).order(created_at: :desc)
     scope = scope.joins(:stage_performance).where(stage_performances: { artist_id: params[:artist_id] }) if params[:artist_id].present?
     @pagy, @setlists = pagy(scope, limit: 20)

--- a/app/controllers/admin/stage_performances_controller.rb
+++ b/app/controllers/admin/stage_performances_controller.rb
@@ -6,7 +6,7 @@ class Admin::StagePerformancesController < Admin::BaseController
     @festival_days = FestivalDay.includes(:festival).order(:date)
     @artists = Artist.order(:name)
 
-    scope = StagePerformance.includes(:festival_day, :stage, :artist)
+    scope = StagePerformance.includes(:stage, :artist, festival_day: :festival)
                             .order(:starts_at)
                             .for_day(params[:festival_day_id])
                             .for_artist(params[:artist_id])

--- a/app/controllers/my_timetables_controller.rb
+++ b/app/controllers/my_timetables_controller.rb
@@ -78,7 +78,6 @@ class MyTimetablesController < ApplicationController
       @festival
         .stage_performances_on(@selected_day)
         .scheduled
-        .includes(:stage, :artist)
     # ステージ単位にまとめる
     @performances_by_stage = @performances.group_by(&:stage)
 

--- a/app/controllers/mypage/favorite_festivals_controller.rb
+++ b/app/controllers/mypage/favorite_festivals_controller.rb
@@ -5,7 +5,6 @@ module Mypage
     def index
       favorites_scope = current_user
                           .favorite_festivals
-                          .includes(:festival_days, :stages)
                           .order(start_date: :asc, name: :asc)
       @pagy, @festivals = pagy(favorites_scope, limit: 20)
     end

--- a/app/controllers/setlists_controller.rb
+++ b/app/controllers/setlists_controller.rb
@@ -14,7 +14,7 @@ class SetlistsController < ApplicationController
     @performances = @festival
                       .stage_performances_on(@selected_day)
                       .scheduled
-                      .includes(:artist, :stage, :setlist)
+                      .includes(:setlist)
                       .order(:starts_at, :ends_at, :id)
     @stages = @festival.stages.order(:sort_order, :id)
 


### PR DESCRIPTION
## 概要
- 管理画面のN+1を解消し、不要な eager loading を削除してクエリを最適化。
## 実施内容
- N+1対応
  - stage_performances_controller.rb
    - sp.festival_day.festival 参照に備え、includes(festival_day: :festival) を追加
- 不要 eager loading の整理
  - favorite_festivals_controller.rb
    - includes(:festival_days, :stages) を削除
  - setlists_controller.rb
    - 重複していた includes(:artist, :stage) を削除し includes(:setlist) のみに
  - my_timetables_controller.rb
    - stage_performances_on と重複する includes(:stage, :artist) を削除
## 対応Issue
なし
## 関連Issue
なし
## 特記事項