### PR TITLE
[update]dependabot.ymlの設定変更

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,43 @@
 version: 2
 updates:
-- package-ecosystem: bundler
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 3
+
+    groups:
+      security_auth:
+        patterns:
+          - "omniauth*"
+          - "*csrf*"
+          - "devise*"
+      rails_related:
+        patterns:
+          - "rails"
+          - "railties"
+          - "activerecord"
+          - "activesupport"
+          - "actionpack"
+          - "actionmailer"
+          - "rails-i18n"
+      everything_else:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 1
+
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## 概要
- Dependabot による依存関係更新PRが大量に作成される状況を改善するため、更新頻度と同時オープン数を制限し、PRをグルーピングする運用設計に変更。
## 実施内容
- Dependabot の実行頻度を daily から weekly に変更
- open-pull-requests-limit を小さく設定し、同時に作成されるPR数を制限
- Bundler の更新を以下のカテゴリでグルーピング
  - セキュリティ / 認証系
  - Rails関連
  - その他
- GitHub Actions の更新も1つのグループにまとめて管理
## 対応Issue
なし
## 関連Issue
なし
## 特記事項
- 依存更新の自動化は維持しつつ、レビュー・運用コストが過剰に増えないように改善。