### PR TITLE
[fix]Fly Machine が自動停止できるように設定変更

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -12,6 +12,9 @@ app = "fes-ready"
   internal_port = 3000
   protocol = "tcp"
   processes = ["app"]
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
 
   [[services.ports]]
     port = 80


### PR DESCRIPTION
## 概要
Fly.io の `fly.toml` を見直し、アイドル時に Machine を自動停止できるよう設定を追加した。
これにより、未アクセス時にアプリケーションの Machine が起動しっぱなしになるのを防ぎ、Neon 側の DB compute 使用量の増加を抑えることを目的としています。

## 実施内容
- `fly.toml` の `[[services]]` に以下を追加
  - `auto_stop_machines = "stop"`
  - `auto_start_machines = true`
  - `min_machines_running = 0`
- 既存の `http_checks` 設定はそのまま維持

## 対応Issue
- なし

## 関連Issue
- なし

## 特記事項
- アプリコードの変更はなく、Fly.io のデプロイ設定のみ変更
- これまで Machine が常時起動に近い状態だった可能性があり、Neon の compute usage 増加要因になっていた可能性あり
- デプロイ後は Neon の usage / Monitoring を数日〜1週間ほど確認し、compute 使用量の増加ペースが改善するかを確認する
- 初回アクセス時は、Machine の自動起動によりレスポンスが少し遅くなる可能性あり